### PR TITLE
feat(tooltip): ability to use template for heatmap tooltip

### DIFF
--- a/src/components/charts/heatmap/HeatMap.js
+++ b/src/components/charts/heatmap/HeatMap.js
@@ -27,6 +27,13 @@ class HeatMap extends Component {
     handleNodeHover = (showTooltip, node, event) => {
         const { setCurrentNode, theme } = this.props
         setCurrentNode(node)
+
+        node.toolTipFormatter =
+            this.props.toolTipFormatter !== undefined ? this.props.toolTipFormatter : null
+        node.value =
+            node.toolTipFormatter !== null
+                ? new Function('return `' + node.toolTipFormatter + '`;').call(node)
+                : node.value
         showTooltip(<HeatMapCellTooltip node={node} theme={theme} />, event)
     }
 

--- a/stories/charts/heatmap.stories.js
+++ b/stories/charts/heatmap.stories.js
@@ -63,6 +63,7 @@ const commonProperties = {
     data: generateCountriesData(keys, { size: 9, min: 0, max: 100 }),
     indexBy: 'country',
     keys,
+    toolTipFormatter: '${this.value}',
 }
 
 const stories = storiesOf('HeatMap', module).addDecorator(story => (


### PR DESCRIPTION
@plouc Added ability to template the tooltip for heatmap chart type. I would make this universal for all chart types, although I am unclear on how to do so. 