### PR TITLE
fix(bar): getLabel is defined twice

### DIFF
--- a/src/components/charts/bar/enhance.js
+++ b/src/components/charts/bar/enhance.js
@@ -25,9 +25,6 @@ export default Component =>
         withPropsOnChange(['indexBy'], ({ indexBy }) => ({
             getIndex: getAccessorFor(indexBy),
         })),
-        withPropsOnChange(['label', 'labelFormat'], ({ label, labelFormat }) => ({
-            getLabel: getLabelGenerator(label, labelFormat),
-        })),
         withPropsOnChange(['labelTextColor'], ({ labelTextColor }) => ({
             getLabelTextColor: getInheritedColorGenerator(labelTextColor, 'axis.textColor'),
         })),


### PR DESCRIPTION
That was probably copy/pasted at some point. Not a bug, just something that doesn't need to happen twice.