### PR TITLE
Added option to place markers behind bars

### DIFF
--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -261,7 +261,6 @@ const Bar = ({
                             left={axisLeft}
                             {...motionProps}
                         />
-                        {bars}
                         <CartesianMarkers
                             markers={markers}
                             width={width}
@@ -269,7 +268,8 @@ const Bar = ({
                             xScale={result.xScale}
                             yScale={result.yScale}
                             theme={theme}
-                        />
+                        />                        
+                        {bars}
                         {legends.map((legend, i) => {
                             let legendData
                             if (legend.dataFrom === 'keys') {

--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -167,8 +167,6 @@ const Bar = ({
         fill: bar.data.fill ? bar.data.fill : bar.color,
     }))
 
-    console.log(markersBehindBars)
-
     return (
         <Container isInteractive={isInteractive} theme={theme}>
             {({ showTooltip, hideTooltip }) => {

--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -262,7 +262,7 @@ const Bar = ({
                             left={axisLeft}
                             {...motionProps}
                         />
-                        {(markersBehindBars) ? null : bars}
+                        {markersBehindBars ? null : bars}
                         <CartesianMarkers
                             markers={markers}
                             width={width}
@@ -270,8 +270,8 @@ const Bar = ({
                             xScale={result.xScale}
                             yScale={result.yScale}
                             theme={theme}
-                        />                        
-                        {(markersBehindBars) ? bars : null}
+                        />
+                        {markersBehindBars ? bars : null}
                         {legends.map((legend, i) => {
                             let legendData
                             if (legend.dataFrom === 'keys') {

--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -85,6 +85,7 @@ const Bar = ({
 
     // markers
     markers,
+    markersBehindBars,
 
     // theming
     theme,
@@ -165,6 +166,8 @@ const Bar = ({
         label: bar.data.indexValue,
         fill: bar.data.fill ? bar.data.fill : bar.color,
     }))
+
+    console.log(markersBehindBars)
 
     return (
         <Container isInteractive={isInteractive} theme={theme}>
@@ -261,6 +264,7 @@ const Bar = ({
                             left={axisLeft}
                             {...motionProps}
                         />
+                        {(markersBehindBars) ? null : bars}
                         <CartesianMarkers
                             markers={markers}
                             width={width}
@@ -269,7 +273,7 @@ const Bar = ({
                             yScale={result.yScale}
                             theme={theme}
                         />                        
-                        {bars}
+                        {(markersBehindBars) ? bars : null}
                         {legends.map((legend, i) => {
                             let legendData
                             if (legend.dataFrom === 'keys') {

--- a/packages/nivo-bar/src/props.js
+++ b/packages/nivo-bar/src/props.js
@@ -51,6 +51,9 @@ export const BarPropTypes = {
     labelLinkColor: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
     getLabelLinkColor: PropTypes.func.isRequired, // computed
 
+    // markers
+    markersBehindBars: PropTypes.bool.isRequired,
+
     // styling
     borderRadius: PropTypes.number.isRequired,
     getColor: PropTypes.func.isRequired, // computed
@@ -104,6 +107,9 @@ export const BarDefaultProps = {
     labelSkipHeight: 0,
     labelLinkColor: 'theme',
     labelTextColor: 'theme',
+
+    // markers
+    markersBehindBars: false,
 
     defs: [],
     fill: [],

--- a/packages/nivo-bar/stories/bar.stories.js
+++ b/packages/nivo-bar/stories/bar.stories.js
@@ -24,17 +24,13 @@ const stories = storiesOf('Bar', module)
 
 stories.addDecorator(story => <div className="wrapper">{story()}</div>).addDecorator(withKnobs)
 
-stories.add('stacked', () => (
-    <Bar {...commonProps} />
-))
+stories.add('stacked', () => <Bar {...commonProps} />)
 
 stories.add('stacked horizontal', () => (
     <Bar {...commonProps} layout="horizontal" enableGridY={false} enableGridX={true} />
 ))
 
-stories.add('grouped', () => (
-    <Bar {...commonProps} groupMode="grouped" />
-))
+stories.add('grouped', () => <Bar {...commonProps} groupMode="grouped" />)
 
 stories.add('grouped horizontal', () => (
     <Bar

--- a/packages/nivo-bar/stories/bar.stories.js
+++ b/packages/nivo-bar/stories/bar.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
+import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { generateCountriesData, sets } from '@nivo/generators'
 import range from 'lodash/range'
 import random from 'lodash/random'
@@ -22,53 +23,50 @@ const commonProps = {
 
 const stories = storiesOf('Bar', module)
 
-stories.add('stacked', withInfo()(() => <Bar {...commonProps} />))
+stories.addDecorator(story => <div className="wrapper">{story()}</div>).addDecorator(withKnobs)
 
-stories.add(
-    'stacked horizontal',
-    withInfo()(() => (
-        <Bar {...commonProps} layout="horizontal" enableGridY={false} enableGridX={true} />
-    ))
-)
+stories.add('stacked', () => (
+    <Bar {...commonProps} />
+))
 
-stories.add('grouped', withInfo()(() => <Bar {...commonProps} groupMode="grouped" />))
+stories.add('stacked horizontal', () => (
+    <Bar {...commonProps} layout="horizontal" enableGridY={false} enableGridX={true} />
+))
 
-stories.add(
-    'grouped horizontal',
-    withInfo()(() => (
-        <Bar
-            {...commonProps}
-            groupMode="grouped"
-            layout="horizontal"
-            enableGridY={false}
-            enableGridX={true}
-        />
-    ))
-)
+stories.add('grouped', () => (
+    <Bar {...commonProps} groupMode="grouped" />
+))
 
-stories.add(
-    'with marker',
-    withInfo()(() => (
-        <Bar
-            {...commonProps}
-            padding={0.4}
-            markers={[
-                {
-                    axis: 'y',
-                    value: 300,
-                    lineStyle: { stroke: 'rgba(0, 0, 0, .35)', strokeWidth: 2 },
-                    legend: 'y marker at 300',
-                    legendOrientation: 'vertical',
-                },
-            ]}
-        />
-    ))
-)
+stories.add('grouped horizontal', () => (
+    <Bar
+        {...commonProps}
+        groupMode="grouped"
+        layout="horizontal"
+        enableGridY={false}
+        enableGridX={true}
+    />
+))
 
-stories.add(
-    'using custom colorBy',
-    withInfo()(() => <Bar {...commonProps} colorBy={({ id, data }) => data[`${id}Color`]} />)
-)
+stories.add('with marker', () => (
+    <Bar
+        {...commonProps}
+        padding={0.4}
+        markersBehindBars={boolean('markersBehindBars', false)}
+        markers={[
+            {
+                axis: 'y',
+                value: 300,
+                lineStyle: { stroke: 'rgba(0, 0, 0, .35)', strokeWidth: 2 },
+                legend: 'y marker at 300',
+                legendOrientation: 'vertical',
+            },
+        ]}
+    />
+))
+
+stories.add('using custom colorBy', () => (
+    <Bar {...commonProps} colorBy={({ id, data }) => data[`${id}Color`]} />
+))
 
 const divergingData = range(9).map(i => {
     let gain = random(0, 100)
@@ -136,65 +134,53 @@ const divergingCommonProps = {
     ],
 }
 
-stories.add(
-    'diverging stacked',
-    withInfo()(() => (
-        <Bar
-            {...divergingCommonProps}
-            keys={['gained <= 100$', 'gained > 100$', 'lost <= 100$', 'lost > 100$']}
-            padding={0.4}
-            colors={['#97e3d5', '#61cdbb', '#f47560', '#e25c3b']}
-            labelFormat={v => `${v}%`}
-        />
-    ))
-)
+stories.add('diverging stacked', () => (
+    <Bar
+        {...divergingCommonProps}
+        keys={['gained <= 100$', 'gained > 100$', 'lost <= 100$', 'lost > 100$']}
+        padding={0.4}
+        colors={['#97e3d5', '#61cdbb', '#f47560', '#e25c3b']}
+        labelFormat={v => `${v}%`}
+    />
+))
 
-stories.add(
-    'diverging grouped',
-    withInfo()(() => (
-        <Bar
-            {...divergingCommonProps}
-            keys={['gained > 100$', 'gained <= 100$', 'lost <= 100$', 'lost > 100$']}
-            groupMode="grouped"
-            padding={0.1}
-            colors={['#61cdbb', '#97e3d5', '#f47560', '#e25c3b']}
-            innerPadding={1}
-        />
-    ))
-)
+stories.add('diverging grouped', () => (
+    <Bar
+        {...divergingCommonProps}
+        keys={['gained > 100$', 'gained <= 100$', 'lost <= 100$', 'lost > 100$']}
+        groupMode="grouped"
+        padding={0.1}
+        colors={['#61cdbb', '#97e3d5', '#f47560', '#e25c3b']}
+        innerPadding={1}
+    />
+))
 
 const CustomBarComponent = ({ x, y, width, height, color }) => (
     <circle cx={x + width / 2} cy={y + height / 2} r={Math.min(width, height) / 2} fill={color} />
 )
 
-stories.add(
-    'custom bar item',
-    withInfo()(() => (
-        <Bar
-            {...commonProps}
-            innerPadding={4}
-            barComponent={CustomBarComponent}
-            labelTextColor="inherit:darker(1)"
-        />
-    ))
-)
+stories.add('custom bar item', () => (
+    <Bar
+        {...commonProps}
+        innerPadding={4}
+        barComponent={CustomBarComponent}
+        labelTextColor="inherit:darker(1)"
+    />
+))
 
-stories.add(
-    'with formatted values',
-    withInfo()(() => (
-        <Bar
-            {...commonProps}
-            axisLeft={{
-                format: value =>
-                    Number(value).toLocaleString('ru-RU', {
-                        minimumFractionDigits: 2,
-                    }),
-            }}
-            tooltipFormat={value =>
-                `${Number(value).toLocaleString('ru-RU', {
+stories.add('with formatted values', () => (
+    <Bar
+        {...commonProps}
+        axisLeft={{
+            format: value =>
+                Number(value).toLocaleString('ru-RU', {
                     minimumFractionDigits: 2,
-                })} ₽`
-            }
-        />
-    ))
-)
+                }),
+        }}
+        tooltipFormat={value =>
+            `${Number(value).toLocaleString('ru-RU', {
+                minimumFractionDigits: 2,
+            })} ₽`
+        }
+    />
+))

--- a/packages/nivo-bar/stories/bar.stories.js
+++ b/packages/nivo-bar/stories/bar.stories.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { generateCountriesData, sets } from '@nivo/generators'
 import range from 'lodash/range'


### PR DESCRIPTION
Sometimes it would be useful if the markers could be placed behind the bars instead in front of it.

Like this:

![image](https://user-images.githubusercontent.com/1242960/38581462-44d6c2f2-3d0d-11e8-9fed-2a8747a98c5c.png)

I tried to make use of an inline logical operator (`bars && markersBehindBars`), but this won't render the bars at all, so I had to stick with `{(markersBehindBars) ? null : bars}`. Hope this is ok or do you have another idea?

Last but not least: thank you so much for this great charting library! By far the nicest in the React world.