### PR TITLE
[WIP] added option to define `gridValues`

### DIFF
--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -72,6 +72,8 @@ const Bar = ({
     axisLeft,
     enableGridX,
     enableGridY,
+    gridXValues,
+    gridYValues,
 
     // customization
     barComponent,
@@ -248,6 +250,8 @@ const Bar = ({
                             height={height}
                             xScale={enableGridX ? result.xScale : null}
                             yScale={enableGridY ? result.yScale : null}
+                            xValues={gridXValues}
+                            yValues={gridYValues}
                             {...motionProps}
                         />
                         <Axes

--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -261,7 +261,6 @@ const Bar = ({
                             left={axisLeft}
                             {...motionProps}
                         />
-                        {bars}
                         <CartesianMarkers
                             markers={markers}
                             width={width}
@@ -269,7 +268,8 @@ const Bar = ({
                             xScale={result.xScale}
                             yScale={result.yScale}
                             theme={theme}
-                        />
+                        />                        
+                        {bars}
                         {legends.map((legend, i) => {
                             let legendData
                             if (legend.dataFrom === 'keys') {

--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -167,8 +167,6 @@ const Bar = ({
         fill: bar.data.fill ? bar.data.fill : bar.color,
     }))
 
-    console.log(markersBehindBars)
-
     return (
         <Container isInteractive={isInteractive} theme={theme}>
             {({ showTooltip, hideTooltip }) => {

--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -85,6 +85,7 @@ const Bar = ({
 
     // markers
     markers,
+    markersBehindBars,
 
     // theming
     theme,
@@ -165,6 +166,8 @@ const Bar = ({
         label: bar.data.indexValue,
         fill: bar.data.fill ? bar.data.fill : bar.color,
     }))
+
+    console.log(markersBehindBars)
 
     return (
         <Container isInteractive={isInteractive} theme={theme}>
@@ -261,6 +264,7 @@ const Bar = ({
                             left={axisLeft}
                             {...motionProps}
                         />
+                        {(markersBehindBars) ? null : bars}
                         <CartesianMarkers
                             markers={markers}
                             width={width}
@@ -269,7 +273,7 @@ const Bar = ({
                             yScale={result.yScale}
                             theme={theme}
                         />                        
-                        {bars}
+                        {(markersBehindBars) ? bars : null}
                         {legends.map((legend, i) => {
                             let legendData
                             if (legend.dataFrom === 'keys') {

--- a/packages/nivo-bar/src/props.js
+++ b/packages/nivo-bar/src/props.js
@@ -35,6 +35,8 @@ export const BarPropTypes = {
     axisLeft: PropTypes.object,
     enableGridX: PropTypes.bool.isRequired,
     enableGridY: PropTypes.bool.isRequired,
+    gridXValues: PropTypes.arrayOf(PropTypes.number),
+    gridYValues: PropTypes.arrayOf(PropTypes.number),
 
     // customization
     barComponent: PropTypes.func.isRequired,

--- a/packages/nivo-bar/src/props.js
+++ b/packages/nivo-bar/src/props.js
@@ -51,6 +51,9 @@ export const BarPropTypes = {
     labelLinkColor: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
     getLabelLinkColor: PropTypes.func.isRequired, // computed
 
+    // markers
+    markersBehindBars: PropTypes.bool.isRequired,
+
     // styling
     borderRadius: PropTypes.number.isRequired,
     getColor: PropTypes.func.isRequired, // computed
@@ -104,6 +107,9 @@ export const BarDefaultProps = {
     labelSkipHeight: 0,
     labelLinkColor: 'theme',
     labelTextColor: 'theme',
+
+    // markers
+    markersBehindBars: false,
 
     defs: [],
     fill: [],

--- a/packages/nivo-bar/stories/bar.stories.js
+++ b/packages/nivo-bar/stories/bar.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
+import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { generateCountriesData, sets } from '@nivo/generators'
 import range from 'lodash/range'
 import random from 'lodash/random'
@@ -22,53 +23,50 @@ const commonProps = {
 
 const stories = storiesOf('Bar', module)
 
-stories.add('stacked', withInfo()(() => <Bar {...commonProps} />))
+stories.addDecorator(story => <div className="wrapper">{story()}</div>).addDecorator(withKnobs)
 
-stories.add(
-    'stacked horizontal',
-    withInfo()(() => (
-        <Bar {...commonProps} layout="horizontal" enableGridY={false} enableGridX={true} />
-    ))
-)
+stories.add('stacked', () => (
+    <Bar {...commonProps} />
+))
 
-stories.add('grouped', withInfo()(() => <Bar {...commonProps} groupMode="grouped" />))
+stories.add('stacked horizontal', () => (
+    <Bar {...commonProps} layout="horizontal" enableGridY={false} enableGridX={true} />
+))
 
-stories.add(
-    'grouped horizontal',
-    withInfo()(() => (
-        <Bar
-            {...commonProps}
-            groupMode="grouped"
-            layout="horizontal"
-            enableGridY={false}
-            enableGridX={true}
-        />
-    ))
-)
+stories.add('grouped', () => (
+    <Bar {...commonProps} groupMode="grouped" />
+))
 
-stories.add(
-    'with marker',
-    withInfo()(() => (
-        <Bar
-            {...commonProps}
-            padding={0.4}
-            markers={[
-                {
-                    axis: 'y',
-                    value: 300,
-                    lineStyle: { stroke: 'rgba(0, 0, 0, .35)', strokeWidth: 2 },
-                    legend: 'y marker at 300',
-                    legendOrientation: 'vertical',
-                },
-            ]}
-        />
-    ))
-)
+stories.add('grouped horizontal', () => (
+    <Bar
+        {...commonProps}
+        groupMode="grouped"
+        layout="horizontal"
+        enableGridY={false}
+        enableGridX={true}
+    />
+))
 
-stories.add(
-    'using custom colorBy',
-    withInfo()(() => <Bar {...commonProps} colorBy={({ id, data }) => data[`${id}Color`]} />)
-)
+stories.add('with marker', () => (
+    <Bar
+        {...commonProps}
+        padding={0.4}
+        markersBehindBars={boolean('markersBehindBars', false)}
+        markers={[
+            {
+                axis: 'y',
+                value: 300,
+                lineStyle: { stroke: 'rgba(0, 0, 0, .35)', strokeWidth: 2 },
+                legend: 'y marker at 300',
+                legendOrientation: 'vertical',
+            },
+        ]}
+    />
+))
+
+stories.add('using custom colorBy', () => (
+    <Bar {...commonProps} colorBy={({ id, data }) => data[`${id}Color`]} />
+))
 
 const divergingData = range(9).map(i => {
     let gain = random(0, 100)
@@ -136,65 +134,53 @@ const divergingCommonProps = {
     ],
 }
 
-stories.add(
-    'diverging stacked',
-    withInfo()(() => (
-        <Bar
-            {...divergingCommonProps}
-            keys={['gained <= 100$', 'gained > 100$', 'lost <= 100$', 'lost > 100$']}
-            padding={0.4}
-            colors={['#97e3d5', '#61cdbb', '#f47560', '#e25c3b']}
-            labelFormat={v => `${v}%`}
-        />
-    ))
-)
+stories.add('diverging stacked', () => (
+    <Bar
+        {...divergingCommonProps}
+        keys={['gained <= 100$', 'gained > 100$', 'lost <= 100$', 'lost > 100$']}
+        padding={0.4}
+        colors={['#97e3d5', '#61cdbb', '#f47560', '#e25c3b']}
+        labelFormat={v => `${v}%`}
+    />
+))
 
-stories.add(
-    'diverging grouped',
-    withInfo()(() => (
-        <Bar
-            {...divergingCommonProps}
-            keys={['gained > 100$', 'gained <= 100$', 'lost <= 100$', 'lost > 100$']}
-            groupMode="grouped"
-            padding={0.1}
-            colors={['#61cdbb', '#97e3d5', '#f47560', '#e25c3b']}
-            innerPadding={1}
-        />
-    ))
-)
+stories.add('diverging grouped', () => (
+    <Bar
+        {...divergingCommonProps}
+        keys={['gained > 100$', 'gained <= 100$', 'lost <= 100$', 'lost > 100$']}
+        groupMode="grouped"
+        padding={0.1}
+        colors={['#61cdbb', '#97e3d5', '#f47560', '#e25c3b']}
+        innerPadding={1}
+    />
+))
 
 const CustomBarComponent = ({ x, y, width, height, color }) => (
     <circle cx={x + width / 2} cy={y + height / 2} r={Math.min(width, height) / 2} fill={color} />
 )
 
-stories.add(
-    'custom bar item',
-    withInfo()(() => (
-        <Bar
-            {...commonProps}
-            innerPadding={4}
-            barComponent={CustomBarComponent}
-            labelTextColor="inherit:darker(1)"
-        />
-    ))
-)
+stories.add('custom bar item', () => (
+    <Bar
+        {...commonProps}
+        innerPadding={4}
+        barComponent={CustomBarComponent}
+        labelTextColor="inherit:darker(1)"
+    />
+))
 
-stories.add(
-    'with formatted values',
-    withInfo()(() => (
-        <Bar
-            {...commonProps}
-            axisLeft={{
-                format: value =>
-                    Number(value).toLocaleString('ru-RU', {
-                        minimumFractionDigits: 2,
-                    }),
-            }}
-            tooltipFormat={value =>
-                `${Number(value).toLocaleString('ru-RU', {
+stories.add('with formatted values', () => (
+    <Bar
+        {...commonProps}
+        axisLeft={{
+            format: value =>
+                Number(value).toLocaleString('ru-RU', {
                     minimumFractionDigits: 2,
-                })} ₽`
-            }
-        />
-    ))
-)
+                }),
+        }}
+        tooltipFormat={value =>
+            `${Number(value).toLocaleString('ru-RU', {
+                minimumFractionDigits: 2,
+            })} ₽`
+        }
+    />
+))

--- a/packages/nivo-bar/stories/bar.stories.js
+++ b/packages/nivo-bar/stories/bar.stories.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { generateCountriesData, sets } from '@nivo/generators'
 import range from 'lodash/range'

--- a/packages/nivo-core/src/components/axes/Grid.js
+++ b/packages/nivo-core/src/components/axes/Grid.js
@@ -19,6 +19,8 @@ const Grid = ({
     height,
     xScale,
     yScale,
+    xValues,
+    yValues,
     theme,
     animate,
     motionStiffness,
@@ -30,6 +32,7 @@ const Grid = ({
               height,
               scale: xScale,
               axis: 'x',
+              values: xValues,
           })
         : false
 
@@ -39,6 +42,7 @@ const Grid = ({
               height,
               scale: yScale,
               axis: 'y',
+              values: yValues,
           })
         : false
 
@@ -74,6 +78,8 @@ Grid.propTypes = {
 
     xScale: PropTypes.func,
     yScale: PropTypes.func,
+    xValues: PropTypes.arrayOf(PropTypes.number),
+    yValues: PropTypes.arrayOf(PropTypes.number),
 
     theme: PropTypes.object.isRequired,
 

--- a/packages/nivo-core/src/lib/cartesian/axes.js
+++ b/packages/nivo-core/src/lib/cartesian/axes.js
@@ -162,9 +162,7 @@ export const computeAxisTicks = ({
  *
  * @return {Array.<Object>}
  */
-export const computeGridLines = ({ width, height, scale, axis }) => {
-    const values = getScaleValues(scale)
-
+export const computeGridLines = ({ width, height, scale, axis, values = getScaleValues(scale) }) => {
     const position = scale.bandwidth ? centerScale(scale) : scale
 
     let lines


### PR DESCRIPTION
As I think that this feature was often requested in the past, I've added another option that was inspired by `tickValues`: `xGridValues` and `yGridValues`.

At first I thought that we could use the `tickValues` value from the `axis` prop, but since there could be two axis for one dimension, we need an extra option.

So this component `<Bar {...commonProps} axisLeft={{ tickValues: [0,50,100] }} gridYValues={[0,50,100]} />` would produce this chart:

<img width="1117" alt="bildschirmfoto 2018-04-10 um 23 19 05" src="https://user-images.githubusercontent.com/1242960/38584356-56401634-3d16-11e8-8952-c7b5397c7805.png">

If you're fine with this idea/my approach, I would like to add the props to all other components (I've just added it to the `Bar` component in the moment) and add tests :-)

