### PR TITLE
[WIP] added option to define `gridValues`

### DIFF
--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -72,6 +72,8 @@ const Bar = ({
     axisLeft,
     enableGridX,
     enableGridY,
+    gridXValues,
+    gridYValues,
 
     // customization
     barComponent,
@@ -247,6 +249,8 @@ const Bar = ({
                             height={height}
                             xScale={enableGridX ? result.xScale : null}
                             yScale={enableGridY ? result.yScale : null}
+                            xValues={gridXValues}
+                            yValues={gridYValues}
                             {...motionProps}
                         />
                         <Axes

--- a/packages/nivo-bar/src/props.js
+++ b/packages/nivo-bar/src/props.js
@@ -35,6 +35,8 @@ export const BarPropTypes = {
     axisLeft: PropTypes.object,
     enableGridX: PropTypes.bool.isRequired,
     enableGridY: PropTypes.bool.isRequired,
+    gridXValues: PropTypes.arrayOf(PropTypes.number),
+    gridYValues: PropTypes.arrayOf(PropTypes.number),
 
     // customization
     barComponent: PropTypes.func.isRequired,

--- a/packages/nivo-core/src/components/axes/Grid.js
+++ b/packages/nivo-core/src/components/axes/Grid.js
@@ -19,6 +19,8 @@ const Grid = ({
     height,
     xScale,
     yScale,
+    xValues,
+    yValues,
     theme,
     animate,
     motionStiffness,
@@ -30,6 +32,7 @@ const Grid = ({
               height,
               scale: xScale,
               axis: 'x',
+              values: xValues,
           })
         : false
 
@@ -39,6 +42,7 @@ const Grid = ({
               height,
               scale: yScale,
               axis: 'y',
+              values: yValues,
           })
         : false
 
@@ -74,6 +78,8 @@ Grid.propTypes = {
 
     xScale: PropTypes.func,
     yScale: PropTypes.func,
+    xValues: PropTypes.arrayOf(PropTypes.number),
+    yValues: PropTypes.arrayOf(PropTypes.number),
 
     theme: PropTypes.object.isRequired,
 

--- a/packages/nivo-core/src/lib/cartesian/axes.js
+++ b/packages/nivo-core/src/lib/cartesian/axes.js
@@ -162,7 +162,13 @@ export const computeAxisTicks = ({
  *
  * @return {Array.<Object>}
  */
-export const computeGridLines = ({ width, height, scale, axis, values = getScaleValues(scale) }) => {
+export const computeGridLines = ({
+    width,
+    height,
+    scale,
+    axis,
+    values = getScaleValues(scale),
+}) => {
     const position = scale.bandwidth ? centerScale(scale) : scale
 
     let lines

--- a/packages/nivo-core/src/lib/cartesian/axes.js
+++ b/packages/nivo-core/src/lib/cartesian/axes.js
@@ -162,9 +162,7 @@ export const computeAxisTicks = ({
  *
  * @return {Array.<Object>}
  */
-export const computeGridLines = ({ width, height, scale, axis }) => {
-    const values = getScaleValues(scale)
-
+export const computeGridLines = ({ width, height, scale, axis, values = getScaleValues(scale) }) => {
     const position = scale.bandwidth ? centerScale(scale) : scale
 
     let lines


### PR DESCRIPTION
As I think that this feature was often requested in the past, I've added another option that was inspired by `tickValues`: `xGridValues` and `yGridValues`.

At first I thought that we could use the `tickValues` value from the `axis` prop, but since there could be two axis for one dimension, we need an extra option.

So this component `<Bar {...commonProps} axisLeft={{ tickValues: [0,50,100] }} gridYValues={[0,50,100]} />` would produce this chart:

<img width="1117" alt="bildschirmfoto 2018-04-10 um 23 19 05" src="https://user-images.githubusercontent.com/1242960/38584356-56401634-3d16-11e8-8952-c7b5397c7805.png">

If you're fine with this idea/my approach, I would like to add the props to all other components (I've just added it to the `Bar` component in the moment) and add tests :-)