### PR TITLE
Implemented the option to add a tag in nodes properties objects

### DIFF
--- a/packages/nivo-sankey/src/Sankey.js
+++ b/packages/nivo-sankey/src/Sankey.js
@@ -93,7 +93,7 @@ const Sankey = ({
 
     data.nodes.forEach(node => {
         node.color = getColor(node)
-        node.label = getLabel(node)
+        node.label = node.tag === undefined ? getLabel(node) : node.tag
         node.x = node.x0 + nodePaddingX
         node.y = node.y0
         node.width = Math.max(node.x1 - node.x0 - nodePaddingX * 2, 0)


### PR DESCRIPTION
Hi! this is my first contribution ever and I think this would be helpful for Sankey Graph.
What I done is add a custom label for each nodes, that also help if you want to represent cycling dependencies (A -> B -> A), for instance a person who has changed between telecommunication companies.

![sankey](https://user-images.githubusercontent.com/30220550/38692215-53de58ee-3e40-11e8-88af-bae173a4e06f.png)

What I you have to do is add a tag property in nodes object 

```
"nodes": [
        {"id": "Movistar"},
        {"id": "Claro", "tag": "Claro"},
        {"id": "Cootel", "tag": "Cootel"},
        {"id": "Otro", "tag": "Movistar"}
],
```

**Note**: The tag is not required and sorry if I make a grammatical mistake
 
