### PR TITLE
feat(tooltips): add support for custom tooltips for bubble charts and treemaps

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -18,6 +18,7 @@ function loadStories() {
     require('../packages/nivo-bar/stories/barCanvas.stories')
     require('../packages/nivo-chord/stories/chord.stories')
     require('../packages/nivo-circle-packing/stories/bubble.stories')
+    require('../packages/nivo-circle-packing/stories/bubbleHtml.stories')
     require('../packages/nivo-heatmap/stories/heatmap.stories')
     require('../packages/nivo-line/stories/line.stories')
     require('../packages/nivo-pie/stories/pie.stories')
@@ -26,6 +27,8 @@ function loadStories() {
     require('../packages/nivo-scatterplot/stories/scatterplot.stories')
     require('../packages/nivo-stream/stories/stream.stories')
     require('../packages/nivo-sunburst/stories/sunburst.stories')
+    require('../packages/nivo-treemap/stories/treemap.stories')
+    require('../packages/nivo-treemap/stories/treemapHtml.stories')
 }
 
 configure(loadStories, module)

--- a/packages/nivo-circle-packing/src/Bubble.js
+++ b/packages/nivo-circle-packing/src/Bubble.js
@@ -43,6 +43,7 @@ const Bubble = ({
     isInteractive,
     onClick,
     tooltipFormat,
+    tooltip,
     isZoomable,
     zoomToNode,
 }) => {
@@ -61,6 +62,7 @@ const Bubble = ({
             zoomToNode,
             theme,
             tooltipFormat,
+            tooltip,
         })
 
     return (

--- a/packages/nivo-circle-packing/src/BubbleHtml.js
+++ b/packages/nivo-circle-packing/src/BubbleHtml.js
@@ -43,6 +43,8 @@ const BubbleHtml = ({
     onClick,
     isZoomable,
     zoomToNode,
+    tooltipFormat,
+    tooltip,
 }) => {
     const springConfig = {
         stiffness: motionStiffness,
@@ -58,6 +60,8 @@ const BubbleHtml = ({
             isZoomable,
             zoomToNode,
             theme,
+            tooltipFormat,
+            tooltip,
         })
 
     return (

--- a/packages/nivo-circle-packing/src/BubbleHtmlNode.js
+++ b/packages/nivo-circle-packing/src/BubbleHtmlNode.js
@@ -14,6 +14,14 @@ const BubbleHtmlNode = ({ node, style, handlers }) => {
 
     return (
         <div
+            id={
+                (
+                    (node.data && node.data.id) ?
+                        node.data.id :
+                        // replace special characters with "-"
+                        node.id).replace(/[^\w]/gi, "-"
+                )
+            }
             style={{
                 position: 'absolute',
                 display: 'flex',

--- a/packages/nivo-circle-packing/src/BubbleHtmlNode.js
+++ b/packages/nivo-circle-packing/src/BubbleHtmlNode.js
@@ -14,14 +14,11 @@ const BubbleHtmlNode = ({ node, style, handlers }) => {
 
     return (
         <div
-            id={
-                (
-                    (node.data && node.data.id) ?
-                        node.data.id :
-                        // replace special characters with "-"
-                        node.id).replace(/[^\w]/gi, "-"
-                )
-            }
+            id={(node.data && node.data.id
+                ? node.data.id
+                : // replace special characters with "-"
+                  node.id
+            ).replace(/[^\w]/gi, '-')}
             style={{
                 position: 'absolute',
                 display: 'flex',

--- a/packages/nivo-circle-packing/src/interactivity.js
+++ b/packages/nivo-circle-packing/src/interactivity.js
@@ -20,6 +20,7 @@ export const getNodeHandlers = (
         zoomToNode,
         theme,
         tooltipFormat,
+        tooltip
     }
 ) => {
     if (!isInteractive) return {}
@@ -33,6 +34,9 @@ export const getNodeHandlers = (
                 color={node.color}
                 theme={theme}
                 format={tooltipFormat}
+                renderContent={
+                    typeof tooltip === 'function' ? tooltip.bind(null, { node, ...node }) : null
+                }
             />,
             e
         )

--- a/packages/nivo-circle-packing/src/interactivity.js
+++ b/packages/nivo-circle-packing/src/interactivity.js
@@ -20,7 +20,7 @@ export const getNodeHandlers = (
         zoomToNode,
         theme,
         tooltipFormat,
-        tooltip
+        tooltip,
     }
 ) => {
     if (!isInteractive) return {}

--- a/packages/nivo-circle-packing/src/props.js
+++ b/packages/nivo-circle-packing/src/props.js
@@ -48,6 +48,7 @@ const commonPropTypes = {
     onClick: PropTypes.func.isRequired,
     isZoomable: PropTypes.bool.isRequired,
     tooltipFormat: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+    tooltip: PropTypes.func,
 }
 
 export const BubblePropTypes = {

--- a/packages/nivo-circle-packing/stories/bubble.stories.js
+++ b/packages/nivo-circle-packing/stories/bubble.stories.js
@@ -41,7 +41,7 @@ storiesOf('Bubble', module)
                 theme={{
                     tooltip: {
                         container: {
-                            background: '#333'
+                            background: '#333',
                         },
                     },
                 }}

--- a/packages/nivo-circle-packing/stories/bubbleHtml.stories.js
+++ b/packages/nivo-circle-packing/stories/bubbleHtml.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { generateLibTree } from '@nivo/generators'
-import { Bubble } from '../index'
+import { BubbleHtml } from '../index'
 import { withInfo } from '@storybook/addon-info'
 
 const commonProperties = {
@@ -14,12 +14,12 @@ const commonProperties = {
     labelSkipRadius: 16,
 }
 
-storiesOf('Bubble', module)
+storiesOf('BubbleHtml', module)
     .addDecorator(story => <div className="wrapper">{story()}</div>)
-    .add('default', () => <Bubble {...commonProperties} />)
-    .add('rendering leaves only', () => <Bubble {...commonProperties} leavesOnly={true} />)
+    .add('default', () => <BubbleHtml {...commonProperties} />)
+    .add('rendering leaves only', () => <BubbleHtml {...commonProperties} leavesOnly={true} />)
     .add('with formatted values', () => (
-        <Bubble
+        <BubbleHtml
             {...commonProperties}
             tooltipFormat={value =>
                 `${Number(value).toLocaleString('ru-RU', {
@@ -31,7 +31,7 @@ storiesOf('Bubble', module)
     .add(
         'custom tooltip',
         withInfo()(() => (
-            <Bubble
+            <BubbleHtml
                 {...commonProperties}
                 tooltip={({ id, value, color }) => (
                     <strong style={{ color }}>

--- a/packages/nivo-circle-packing/stories/bubbleHtml.stories.js
+++ b/packages/nivo-circle-packing/stories/bubbleHtml.stories.js
@@ -41,7 +41,7 @@ storiesOf('BubbleHtml', module)
                 theme={{
                     tooltip: {
                         container: {
-                            background: '#333'
+                            background: '#333',
                         },
                     },
                 }}

--- a/packages/nivo-treemap/src/TreeMap.js
+++ b/packages/nivo-treemap/src/TreeMap.js
@@ -41,6 +41,8 @@ const TreeMap = ({
     // interactivity
     isInteractive,
     onClick,
+    tooltipFormat,
+    tooltip,
 }) => {
     const springConfig = {
         stiffness: motionStiffness,
@@ -54,6 +56,8 @@ const TreeMap = ({
             showTooltip,
             hideTooltip,
             theme,
+            tooltipFormat,
+            tooltip,
         })
 
     return (

--- a/packages/nivo-treemap/src/TreeMapHtml.js
+++ b/packages/nivo-treemap/src/TreeMapHtml.js
@@ -40,6 +40,8 @@ const TreeMapHtml = ({
     // interactivity
     isInteractive,
     onClick,
+    tooltipFormat,
+    tooltip,
 }) => {
     const springConfig = {
         stiffness: motionStiffness,
@@ -53,6 +55,8 @@ const TreeMapHtml = ({
             showTooltip,
             hideTooltip,
             theme,
+            tooltipFormat,
+            tooltip,
         })
 
     return (

--- a/packages/nivo-treemap/src/TreeMapHtmlNode.js
+++ b/packages/nivo-treemap/src/TreeMapHtmlNode.js
@@ -16,14 +16,11 @@ const TreeMapHtmlNode = ({ node, style, handlers }) => {
 
     return (
         <div
-            id={
-                (
-                    (node.data && node.data.id) ?
-                        node.data.id :
-                        // replace special characters with "-"
-                        node.id).replace(/[^\w]/gi, "-"
-                )
-            }
+            id={(node.data && node.data.id
+                ? node.data.id
+                : // replace special characters with "-"
+                  node.id
+            ).replace(/[^\w]/gi, '-')}
             style={{
                 boxSizing: 'border-box',
                 position: 'absolute',

--- a/packages/nivo-treemap/src/TreeMapHtmlNode.js
+++ b/packages/nivo-treemap/src/TreeMapHtmlNode.js
@@ -16,6 +16,14 @@ const TreeMapHtmlNode = ({ node, style, handlers }) => {
 
     return (
         <div
+            id={
+                (
+                    (node.data && node.data.id) ?
+                        node.data.id :
+                        // replace special characters with "-"
+                        node.id).replace(/[^\w]/gi, "-"
+                )
+            }
             style={{
                 boxSizing: 'border-box',
                 position: 'absolute',

--- a/packages/nivo-treemap/src/TreeMapNodeTooltip.js
+++ b/packages/nivo-treemap/src/TreeMapNodeTooltip.js
@@ -10,13 +10,16 @@ import React from 'react'
 import pure from 'recompose/pure'
 import { BasicTooltip } from '@nivo/core'
 
-const TreeMapNodeTooltip = ({ node, theme }) => (
+const TreeMapNodeTooltip = ({ node, theme, tooltip }) => (
     <BasicTooltip
         id={node.id}
         value={node.value}
         enableChip={true}
         color={node.color}
         theme={theme}
+        renderContent={
+            typeof tooltip === 'function' ? tooltip.bind(null, { node, ...node }) : null
+        }
     />
 )
 

--- a/packages/nivo-treemap/src/TreeMapNodeTooltip.js
+++ b/packages/nivo-treemap/src/TreeMapNodeTooltip.js
@@ -17,9 +17,7 @@ const TreeMapNodeTooltip = ({ node, theme, tooltip }) => (
         enableChip={true}
         color={node.color}
         theme={theme}
-        renderContent={
-            typeof tooltip === 'function' ? tooltip.bind(null, { node, ...node }) : null
-        }
+        renderContent={typeof tooltip === 'function' ? tooltip.bind(null, { node, ...node }) : null}
     />
 )
 

--- a/packages/nivo-treemap/src/interactivity.js
+++ b/packages/nivo-treemap/src/interactivity.js
@@ -11,12 +11,19 @@ import TreeMapNodeTooltip from './TreeMapNodeTooltip'
 
 export const getNodeHandlers = (
     node,
-    { isInteractive, onClick, showTooltip, hideTooltip, theme }
+    {
+        isInteractive,
+        onClick,
+        showTooltip,
+        hideTooltip,
+        theme,
+        tooltip
+    }
 ) => {
     if (!isInteractive) return {}
 
     const handleTooltip = e => {
-        showTooltip(<TreeMapNodeTooltip node={node} theme={theme} />, e)
+        showTooltip(<TreeMapNodeTooltip node={node} theme={theme} tooltip={tooltip} />, e)
     }
 
     return {

--- a/packages/nivo-treemap/src/interactivity.js
+++ b/packages/nivo-treemap/src/interactivity.js
@@ -11,14 +11,7 @@ import TreeMapNodeTooltip from './TreeMapNodeTooltip'
 
 export const getNodeHandlers = (
     node,
-    {
-        isInteractive,
-        onClick,
-        showTooltip,
-        hideTooltip,
-        theme,
-        tooltip
-    }
+    { isInteractive, onClick, showTooltip, hideTooltip, theme, tooltip }
 ) => {
     if (!isInteractive) return {}
 

--- a/packages/nivo-treemap/src/props.js
+++ b/packages/nivo-treemap/src/props.js
@@ -48,6 +48,7 @@ const commonPropTypes = {
     // interactivity
     isInteractive: PropTypes.bool.isRequired,
     onClick: PropTypes.func.isRequired,
+    tooltip: PropTypes.func,
 }
 
 export const TreeMapPropTypes = {

--- a/packages/nivo-treemap/stories/treemap.stories.js
+++ b/packages/nivo-treemap/stories/treemap.stories.js
@@ -29,7 +29,7 @@ storiesOf('TreeMap', module)
                 theme={{
                     tooltip: {
                         container: {
-                            background: '#333'
+                            background: '#333',
                         },
                     },
                 }}

--- a/packages/nivo-treemap/stories/treemap.stories.js
+++ b/packages/nivo-treemap/stories/treemap.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { generateLibTree } from '@nivo/generators'
-import { Bubble } from '../index'
+import { TreeMap } from '../index'
 import { withInfo } from '@storybook/addon-info'
 
 const commonProperties = {
@@ -14,24 +14,12 @@ const commonProperties = {
     labelSkipRadius: 16,
 }
 
-storiesOf('Bubble', module)
+storiesOf('TreeMap', module)
     .addDecorator(story => <div className="wrapper">{story()}</div>)
-    .add('default', () => <Bubble {...commonProperties} />)
-    .add('rendering leaves only', () => <Bubble {...commonProperties} leavesOnly={true} />)
-    .add('with formatted values', () => (
-        <Bubble
-            {...commonProperties}
-            tooltipFormat={value =>
-                `${Number(value).toLocaleString('ru-RU', {
-                    minimumFractionDigits: 2,
-                })} ₽`
-            }
-        />
-    ))
     .add(
         'custom tooltip',
         withInfo()(() => (
-            <Bubble
+            <TreeMap
                 {...commonProperties}
                 tooltip={({ id, value, color }) => (
                     <strong style={{ color }}>

--- a/packages/nivo-treemap/stories/treemapHtml.stories.js
+++ b/packages/nivo-treemap/stories/treemapHtml.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { generateLibTree } from '@nivo/generators'
-import { Bubble } from '../index'
+import { TreeMapHtml } from '../index'
 import { withInfo } from '@storybook/addon-info'
 
 const commonProperties = {
@@ -14,24 +14,12 @@ const commonProperties = {
     labelSkipRadius: 16,
 }
 
-storiesOf('Bubble', module)
+storiesOf('TreeMapHtml', module)
     .addDecorator(story => <div className="wrapper">{story()}</div>)
-    .add('default', () => <Bubble {...commonProperties} />)
-    .add('rendering leaves only', () => <Bubble {...commonProperties} leavesOnly={true} />)
-    .add('with formatted values', () => (
-        <Bubble
-            {...commonProperties}
-            tooltipFormat={value =>
-                `${Number(value).toLocaleString('ru-RU', {
-                    minimumFractionDigits: 2,
-                })} ₽`
-            }
-        />
-    ))
     .add(
         'custom tooltip',
         withInfo()(() => (
-            <Bubble
+            <TreeMapHtml
                 {...commonProperties}
                 tooltip={({ id, value, color }) => (
                     <strong style={{ color }}>

--- a/packages/nivo-treemap/stories/treemapHtml.stories.js
+++ b/packages/nivo-treemap/stories/treemapHtml.stories.js
@@ -29,7 +29,7 @@ storiesOf('TreeMapHtml', module)
                 theme={{
                     tooltip: {
                         container: {
-                            background: '#333'
+                            background: '#333',
                         },
                     },
                 }}


### PR DESCRIPTION
This allows custom tooltips for bubble charts and treemaps.