### PR TITLE
Missing legend keys on bar charts with zero data values

### DIFF
--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -167,7 +167,8 @@ const Bar = ({
         fill: bar.data.fill ? bar.data.fill : bar.color,
     }))
 
-    result.bars = result.bars.filter(bar => bar.height === 0)
+    result.bars = result.bars
+        .filter(bar => (layout === 'vertical') ? (bar.height !== 0) : (bar.width !== 0)) 
 
     return (
         <Container isInteractive={isInteractive} theme={theme}>

--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -167,8 +167,9 @@ const Bar = ({
         fill: bar.data.fill ? bar.data.fill : bar.color,
     }))
 
-    result.bars = result.bars
-        .filter(bar => (layout === 'vertical') ? (bar.height !== 0) : (bar.width !== 0)) 
+    result.bars = result.bars.filter(
+        bar => (layout === 'vertical' ? bar.height !== 0 : bar.width !== 0)
+    )
 
     return (
         <Container isInteractive={isInteractive} theme={theme}>

--- a/packages/nivo-bar/src/Bar.js
+++ b/packages/nivo-bar/src/Bar.js
@@ -167,6 +167,8 @@ const Bar = ({
         fill: bar.data.fill ? bar.data.fill : bar.color,
     }))
 
+    result.bars = result.bars.filter(bar => bar.height === 0)
+
     return (
         <Container isInteractive={isInteractive} theme={theme}>
             {({ showTooltip, hideTooltip }) => {

--- a/packages/nivo-bar/src/BarCanvas.js
+++ b/packages/nivo-bar/src/BarCanvas.js
@@ -120,7 +120,7 @@ class BarCanvas extends Component {
         })
 
         result.bars
-            .filter(bar => (layout === 'vertical') ? (bar.height !== 0) : (bar.width !== 0))
+            .filter(bar => (layout === 'vertical' ? bar.height !== 0 : bar.width !== 0))
             .forEach(({ x, y, color, width, height }) => {
                 this.ctx.fillStyle = color
                 this.ctx.fillRect(x, y, width, height)

--- a/packages/nivo-bar/src/BarCanvas.js
+++ b/packages/nivo-bar/src/BarCanvas.js
@@ -119,6 +119,8 @@ class BarCanvas extends Component {
             left: axisLeft,
         })
 
+        result.bars = result.bars.filter(bar => bar.height === 0)
+
         result.bars.forEach(({ x, y, color, width, height }) => {
             this.ctx.fillStyle = color
             this.ctx.fillRect(x, y, width, height)

--- a/packages/nivo-bar/src/BarCanvas.js
+++ b/packages/nivo-bar/src/BarCanvas.js
@@ -119,12 +119,12 @@ class BarCanvas extends Component {
             left: axisLeft,
         })
 
-        result.bars = result.bars.filter(bar => bar.height === 0)
-
-        result.bars.forEach(({ x, y, color, width, height }) => {
-            this.ctx.fillStyle = color
-            this.ctx.fillRect(x, y, width, height)
-        })
+        result.bars
+            .filter(bar => (layout === 'vertical') ? (bar.height !== 0) : (bar.width !== 0))
+            .forEach(({ x, y, color, width, height }) => {
+                this.ctx.fillStyle = color
+                this.ctx.fillRect(x, y, width, height)
+            })
     }
 
     handleMouseHover = (showTooltip, hideTooltip) => event => {

--- a/packages/nivo-bar/src/compute/grouped.js
+++ b/packages/nivo-bar/src/compute/grouped.js
@@ -90,9 +90,8 @@ export const generateVerticalGroupedBars = ({
             range(xScale.domain().length).forEach(index => {
                 const x = xScale(getIndex(data[index])) + barWidth * i + innerPadding * i
                 const y = getY(data[index][key])
-                const barHeight = getHeight(data[index][key], y)
 
-                if (barWidth > 0 && barHeight > 0) {
+                if (barWidth > 0) {
                     const barData = {
                         id: key,
                         value: data[index][key],
@@ -107,7 +106,7 @@ export const generateVerticalGroupedBars = ({
                         x,
                         y,
                         width: barWidth,
-                        height: barHeight,
+                        height: getHeight(data[index][key], y),
                         color: getColor(barData),
                     })
                 }
@@ -169,25 +168,23 @@ export const generateHorizontalGroupedBars = ({
                 const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
                 const barWidth = getWidth(data[index][key], x)
 
-                if (barWidth > 0) {
-                    const barData = {
-                        id: key,
-                        value: data[index][key],
-                        index,
-                        indexValue: getIndex(data[index]),
-                        data: data[index],
-                    }
-
-                    bars.push({
-                        key: `${key}.${barData.indexValue}`,
-                        data: barData,
-                        x,
-                        y,
-                        width: barWidth,
-                        height: barHeight,
-                        color: getColor(barData),
-                    })
+                const barData = {
+                    id: key,
+                    value: data[index][key],
+                    index,
+                    indexValue: getIndex(data[index]),
+                    data: data[index],
                 }
+
+                bars.push({
+                    key: `${key}.${barData.indexValue}`,
+                    data: barData,
+                    x,
+                    y,
+                    width: barWidth,
+                    height: barHeight,
+                    color: getColor(barData),
+                })
             })
         })
     }


### PR DESCRIPTION
Fix for https://github.com/plouc/nivo/issues/111 and https://github.com/plouc/nivo/issues/218 (duplicate).

See https://github.com/plouc/nivo/issues/218 for a detailed explanation of the issue and approach but the summary is that by filtering out zero-height bars before generating the legend, if a bar doesn't show in the first group of bars (because it has a value at or close to zero) it doesn't appear in the legend. To fix, remove this filter and add filtering just before the graphs are rendered.

I think this approach is better than https://github.com/plouc/nivo/pull/128 because with that method it appears that if a key has value 0 across the whole range covered by the graph, it will not appear in the legend. In our use case this is quite common as you can set the date range of the graph and some of the keys may have no data in them for certain periods of time. The key should still appear in the legend so it is clear that the value is zero, rather than just not included in the graph.