### PR TITLE
fix bug for Microsoft IE11, which does not support str.endsWith

### DIFF
--- a/packages/nivo-core/src/props/curve.js
+++ b/packages/nivo-core/src/props/curve.js
@@ -54,7 +54,12 @@ export const curvePropKeys = Object.keys(curvePropMapping)
 
 export const curvePropType = PropTypes.oneOf(curvePropKeys)
 
-export const closedCurvePropKeys = curvePropKeys.filter(c => c.endsWith('Closed'))
+function endsWith(str, suffix) {
+  // Workaround for IE11, which does not support string.endsWith
+  return str.indexOf(suffix, str.length - suffix.length) !== -1
+}
+
+export const closedCurvePropKeys = curvePropKeys.filter(c => endsWith(c, 'Closed'))
 
 export const closedCurvePropType = PropTypes.oneOf(closedCurvePropKeys)
 

--- a/packages/nivo-core/src/props/curve.js
+++ b/packages/nivo-core/src/props/curve.js
@@ -55,8 +55,8 @@ export const curvePropKeys = Object.keys(curvePropMapping)
 export const curvePropType = PropTypes.oneOf(curvePropKeys)
 
 function endsWith(str, suffix) {
-  // Workaround for IE11, which does not support string.endsWith
-  return str.indexOf(suffix, str.length - suffix.length) !== -1
+    // Workaround for IE11, which does not support string.endsWith
+    return str.indexOf(suffix, str.length - suffix.length) !== -1
 }
 
 export const closedCurvePropKeys = curvePropKeys.filter(c => endsWith(c, 'Closed'))


### PR DESCRIPTION
Without the below fix, IE11 throws an error on loading the code.