### PR TITLE
fix(heatmap): better handling of NaN values

### DIFF
--- a/packages/nivo-core/src/components/tooltip/BasicTooltip.js
+++ b/packages/nivo-core/src/components/tooltip/BasicTooltip.js
@@ -33,7 +33,7 @@ const BasicTooltip = props => {
                 {enableChip && <Chip color={color} style={chipStyle} />}
                 {value !== undefined ? (
                     <span>
-                        {id}: <strong>{value}</strong>
+                        {id}: <strong>{isNaN(value) ? String(value) : value}</strong>
                     </span>
                 ) : (
                     id

--- a/packages/nivo-heatmap/src/computeNodes.js
+++ b/packages/nivo-heatmap/src/computeNodes.js
@@ -25,6 +25,7 @@ export default ({
     cellWidth,
     cellHeight,
     colorScale,
+    nanColor,
     getLabelTextColor,
 
     currentNode,
@@ -50,7 +51,7 @@ export default ({
                 width,
                 height,
                 value: d[key],
-                color: colorScale(d[key]),
+                color: isNaN(d[key]) ? nanColor : colorScale(d[key]),
             }
 
             let opacity = cellOpacity

--- a/packages/nivo-heatmap/src/props.js
+++ b/packages/nivo-heatmap/src/props.js
@@ -47,6 +47,7 @@ export const HeatMapPropTypes = {
     // theming
     colors: quantizeColorScalePropType.isRequired,
     colorScale: PropTypes.func.isRequired, // computed
+    nanColor: PropTypes.string,
 
     // interactivity
     isInteractive: PropTypes.bool,
@@ -89,6 +90,7 @@ export const HeatMapDefaultProps = {
 
     // theming
     colors: 'nivo',
+    nanColor: '#000000',
 
     // interactivity
     isInteractive: true,


### PR DESCRIPTION
When a NaN value is included in heatmap data, no errors appear but two warnings are raised:
* The prop `node.color` is marked as required in `HeatMapCellTooltip`, but its value is `undefined`.
* Received NaN for the `children` attribute. If this is expected, cast the value to a string.

This commit addresses both of these, and adds a `nanColor` prop to `HeatMap` to allow specifying the color used for a cell that is NaN (defaults to #000000).