### PR TITLE
LineDots labelFormat PropType can be string or function

### DIFF
--- a/packages/nivo-line/src/LineDots.js
+++ b/packages/nivo-line/src/LineDots.js
@@ -139,7 +139,7 @@ LineDots.propTypes = {
     // labels
     enableLabel: PropTypes.bool.isRequired,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
-    labelFormat: PropTypes.string,
+    labelFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     labelYOffset: PropTypes.number,
 
     // theming


### PR DESCRIPTION
Supplying a formatting function to `dotLabelFormat` on the Line graph type
results in a prop type validation error, however the label is formatted
correctly.

The `getLabelGenerator` function is responsible for actually formatting
this label, and accepts a string or a function as a formatter.