### PR TITLE
WIP feat(annotations): working example for scatterplot SVG

### DIFF
--- a/packages/annotations/index.js
+++ b/packages/annotations/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./cjs/nivo-annotations')

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@nivo/annotations",
+  "version": "0.49.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "main": "./index.js",
+  "files": [
+    "README.md",
+    "index.js",
+    "index.d.ts",
+    "cjs/",
+    "umd/"
+  ],
+  "dependencies": {
+    "d3-scale": "^2.1.2",
+    "react-annotation": "^1.3.1"
+  },
+  "peerDependencies": {
+    "prop-types": "^15.5.10",
+    "react": ">= 16.2.0 < 17.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/annotations/src/annotations.js
+++ b/packages/annotations/src/annotations.js
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import React from 'react'
+import {
+    AnnotationLabel,
+    AnnotationCallout,
+    AnnotationCalloutCircle,
+    AnnotationCalloutCurve,
+    AnnotationCalloutElbow,
+    AnnotationCalloutRect,
+    AnnotationXYThreshold,
+    AnnotationBadge,
+    AnnotationBracket,
+    AnnotationCalloutCustom,
+} from 'react-annotation'
+import { AnnotationPropTypes } from './props'
+
+const annotationComponents = {
+    label: AnnotationLabel,
+    callout: AnnotationCallout,
+    calloutCircle: AnnotationCalloutCircle,
+    calloutCurve: AnnotationCalloutCurve,
+    calloutElbow: AnnotationCalloutElbow,
+    calloutRect: AnnotationCalloutRect,
+    xyThreshold: AnnotationXYThreshold,
+    badge: AnnotationBadge,
+    bracket: AnnotationBracket,
+    calloutCustom: AnnotationCalloutCustom,
+}
+
+const Annotation = ({
+    type,
+    xScale,
+    yScale,
+
+    // to scale
+    x: _x,
+    y: _y,
+    subject: _subject,
+
+    // pass-through
+    ...rest
+}) => {
+    const AnnotationType = annotationComponents[type]
+
+    /* params we have to scale:
+     *  x
+     *  y
+     *  subject x1, x2, y1, y2, height, width
+     */
+
+    const x = xScale(_x)
+    const y = yScale(_y)
+
+    let subject = {}
+    if (_subject) {
+        subject = Object.assign({}, _subject)
+        if ('x1' in subject) subject.x1 = xScale(subject.x1)
+        if ('x2' in subject) subject.x2 = xScale(subject.x2)
+        if ('y1' in subject) subject.y1 = yScale(subject.y1)
+        if ('y2' in subject) subject.y2 = yScale(subject.y2)
+        if ('width' in subject) subject.width = xScale(subject.width)
+        if ('height' in subject) subject.height = yScale(subject.height)
+    }
+
+    return <AnnotationType {...rest} x={x} y={y} subject={subject} />
+}
+
+Annotation.propTypes = AnnotationPropTypes
+
+export default Annotation

--- a/packages/annotations/src/index.js
+++ b/packages/annotations/src/index.js
@@ -1,0 +1,11 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+export { default as Annotation } from './annotations'
+export * from './props'

--- a/packages/annotations/src/props.js
+++ b/packages/annotations/src/props.js
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import PropTypes from 'prop-types'
+
+export const AnnotationPropTypes = {
+    type: PropTypes.oneOf([
+        'label',
+        'callout',
+        'calloutCircle',
+        'calloutCurve',
+        'calloutElbow',
+        'calloutRect',
+        'xyThreshold',
+        'badge',
+        'bracket',
+        'calloutCustom',
+    ]).isRequired,
+    xScale: PropTypes.func.isRequired, // ought to be a d3 scale fn
+    yScale: PropTypes.func.isRequired, // ought to be a d3 scale fn
+
+    // to scale
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    subject: PropTypes.object,
+
+    // other
+    dx: PropTypes.number,
+    dy: PropTypes.number,
+    color: PropTypes.string,
+    note: PropTypes.shape({
+        label: PropTypes.string.isRequired,
+    }).isRequired,
+}
+
+export const AnnotationPropShape = {
+    type: PropTypes.oneOf([
+        'label',
+        'callout',
+        'calloutCircle',
+        'calloutCurve',
+        'calloutElbow',
+        'calloutRect',
+        'xyThreshold',
+        'badge',
+        'bracket',
+        'calloutCustom',
+    ]).isRequired,
+
+    // to scale
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    subject: PropTypes.object,
+
+    // other
+    dx: PropTypes.number,
+    dy: PropTypes.number,
+    color: PropTypes.string,
+    note: PropTypes.shape({
+        label: PropTypes.string.isRequired,
+    }).isRequired,
+}

--- a/packages/annotations/tests/.eslintrc.yml
+++ b/packages/annotations/tests/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+  jest: true

--- a/packages/annotations/tests/__snapshots__/annotations.test.js.snap
+++ b/packages/annotations/tests/__snapshots__/annotations.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a basic annotation 1`] = `
+<g
+  className="annotation label"
+  transform="translate(20, 64)"
+>
+  <g
+    className="annotation-connector"
+  >
+    <path
+      className="connector"
+      d="M0,0L30,30L30,30"
+      fill="none"
+      stroke="grey"
+    />
+  </g>
+  <g
+    className="annotation-subject"
+  />
+  <g
+    className="annotation-note"
+    transform="translate(30, 30)"
+  >
+    <g
+      className="annotation-note-content"
+      transform="translate(3,
+          0)"
+    >
+      <rect
+        className="annotation-note-bg"
+        fill="white"
+        fillOpacity="0"
+        height={0}
+        stroke="none"
+        width={0}
+        x={-0}
+        y={-0}
+      />
+      <text
+        className="annotation-note-label"
+        fill="grey"
+        y={0}
+      >
+        <tspan
+          dy=".8em"
+          x={0}
+        >
+          This is a noteworthy datapoint
+        </tspan>
+      </text>
+    </g>
+  </g>
+</g>
+`;
+
+exports[`renders a threshold line annotation 1`] = `
+<g
+  className="annotation label"
+  transform="translate(20, 64)"
+>
+  <g
+    className="annotation-connector"
+  >
+    <path
+      className="connector"
+      d="M0,0L30,30L30,30"
+      fill="none"
+      stroke="grey"
+    />
+  </g>
+  <g
+    className="annotation-subject"
+  />
+  <g
+    className="annotation-note"
+    transform="translate(30, 30)"
+  >
+    <g
+      className="annotation-note-content"
+      transform="translate(3,
+          0)"
+    >
+      <rect
+        className="annotation-note-bg"
+        fill="white"
+        fillOpacity="0"
+        height={0}
+        stroke="none"
+        width={0}
+        x={-0}
+        y={-0}
+      />
+      <text
+        className="annotation-note-label"
+        fill="grey"
+        y={0}
+      >
+        <tspan
+          dy=".8em"
+          x={0}
+        >
+          This is a noteworthy datapoint
+        </tspan>
+      </text>
+    </g>
+  </g>
+</g>
+`;

--- a/packages/annotations/tests/annotations.test.js
+++ b/packages/annotations/tests/annotations.test.js
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { linearScale } from '@nivo/scales'
+import Annotation from '../src/annotations'
+
+const xScale = linearScale({ axis: 'x' }, { x: { min: 0, max: 10 } }, 100, 100)
+const yScale = linearScale({ axis: 'y' }, { y: { min: 0, max: 10 } }, 100, 100)
+
+const annotations = [
+    {
+        type: 'label',
+        x: 2,
+        y: 3.6,
+        dx: 30,
+        dy: 30,
+        note: {
+            label: 'This is a noteworthy datapoint',
+            orientation: 'leftRight',
+        },
+        connector: {
+            type: 'elbow',
+        },
+    },
+    {
+        type: 'xyThreshold',
+        x: 6.5,
+        y: 2,
+        dx: 30,
+        dy: 30,
+        note: {
+            label: 'This is a vertical line',
+            orientation: 'leftRight',
+        },
+        subject: {
+            y1: 0,
+            y2: 10,
+        },
+    },
+]
+
+it('renders a basic annotation', () => {
+    const tree = renderer
+        .create(<Annotation {...annotations[0]} xScale={xScale} yScale={yScale} />)
+        .toJSON()
+    expect(tree).toMatchSnapshot()
+})
+
+it('renders a threshold line annotation', () => {
+    const tree = renderer
+        .create(<Annotation {...annotations[0]} xScale={xScale} yScale={yScale} />)
+        .toJSON()
+    expect(tree).toMatchSnapshot()
+})

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@nivo/core": "0.49.0",
     "@nivo/legends": "0.49.0",
+    "@nivo/annotations": "0.49.0",
     "d3-scale": "^2.1.2",
     "d3-shape": "^1.2.2",
     "lodash": "^4.17.4",

--- a/packages/scatterplot/src/ScatterPlot.js
+++ b/packages/scatterplot/src/ScatterPlot.js
@@ -11,6 +11,7 @@ import { TransitionMotion, spring } from 'react-motion'
 import { Container, SvgWrapper } from '@nivo/core'
 import { Grid, Axes } from '@nivo/core'
 import { BoxLegendSvg } from '@nivo/legends'
+import { Annotation } from '@nivo/annotations'
 import setDisplayName from 'recompose/setDisplayName'
 import enhance from './enhance'
 import { ScatterPlotPropTypes } from './props'
@@ -55,6 +56,8 @@ const ScatterPlot = ({
     onClick,
 
     legends,
+
+    annotations,
 }) => {
     const motionProps = {
         animate,
@@ -161,6 +164,9 @@ const ScatterPlot = ({
                             )}
                         </TransitionMotion>
                     )}
+                    {annotations.map((annotation, i) => (
+                        <Annotation key={i} {...annotation} xScale={xScale} yScale={yScale} />
+                    ))}
                     {legends.map((legend, i) => (
                         <BoxLegendSvg
                             key={i}

--- a/packages/scatterplot/src/props.js
+++ b/packages/scatterplot/src/props.js
@@ -8,6 +8,7 @@
  */
 import PropTypes from 'prop-types'
 import { LegendPropShape } from '@nivo/legends'
+import { AnnotationPropShape } from '@nivo/annotations'
 
 export const ScatterPlotPropTypes = {
     data: PropTypes.arrayOf(
@@ -57,6 +58,8 @@ export const ScatterPlotPropTypes = {
 
     legends: PropTypes.arrayOf(PropTypes.shape(LegendPropShape)).isRequired,
 
+    annotations: PropTypes.arrayOf(PropTypes.shape(AnnotationPropShape)),
+
     // canvas specific
     pixelRatio: PropTypes.number.isRequired,
 }
@@ -86,6 +89,8 @@ export const ScatterPlotDefaultProps = {
     enableStackTooltip: true,
 
     legends: [],
+
+    annotations: [],
 
     // canvas specific
     pixelRatio:

--- a/packages/scatterplot/stories/scatterplot.stories.js
+++ b/packages/scatterplot/stories/scatterplot.stories.js
@@ -120,6 +120,52 @@ const sampleData = [
     },
 ]
 
+const annotations = [
+    {
+        type: 'label',
+        x: 2,
+        y: 3.6,
+        dx: 30,
+        dy: 30,
+        note: {
+            label: 'This is one noteworthy datapoint',
+            orientation: 'leftRight',
+        },
+        connector: {
+            type: 'elbow',
+        },
+    },
+    {
+        type: 'label',
+        x: 7,
+        y: 4.8,
+        dx: 30,
+        dy: 30,
+        note: {
+            label: 'Another noteworthy datapoint',
+            orientation: 'leftRight',
+        },
+        connector: {
+            type: 'elbow',
+        },
+    },
+    {
+        type: 'xyThreshold',
+        x: 6.5, // value will be scaled with xScale
+        y: 2, // value will be scaled with yScale
+        dx: 30, // actual screen pxls
+        dy: 30, // actual screen pxls
+        note: {
+            label: 'This is the middle line',
+            orientation: 'leftRight',
+        },
+        subject: {
+            y1: -0.5, // value will be scaled with xScale
+            y2: 6, // value will be scaled with yScale
+        },
+    },
+]
+
 const commonProps = {
     width: 900,
     height: 500,
@@ -197,5 +243,12 @@ stories.add(
                 },
             }}
         />
+    ))
+)
+
+stories.add(
+    'annotations',
+    withInfo(importStatement)(() => (
+        <ScatterPlot {...commonProps} data={[sampleData[1]]} annotations={annotations} />
     ))
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,35 +600,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nivo/babel-preset@^0.32.0-9":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@nivo/babel-preset/-/babel-preset-0.32.0.tgz#60a58eb223f97785d090a94455243ab9d6914ebd"
-  dependencies:
-    babel-cli "^6.26.0"
-    babel-jest "^20.0.3"
-    babel-plugin-check-es2015-constants "^6.22.0"
-    babel-plugin-external-helpers "^6.22.0"
-    babel-plugin-istanbul "^4.1.4"
-    babel-plugin-lodash "^3.2.11"
-    babel-plugin-syntax-jsx "^6.18.0"
-    babel-plugin-transform-class-properties "^6.24.1"
-    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoping "^6.26.0"
-    babel-plugin-transform-es2015-classes "^6.24.1"
-    babel-plugin-transform-es2015-computed-properties "^6.24.1"
-    babel-plugin-transform-es2015-destructuring "^6.23.0"
-    babel-plugin-transform-es2015-function-name "^6.24.1"
-    babel-plugin-transform-es2015-literals "^6.22.0"
-    babel-plugin-transform-es2015-modules-commonjs "^6.26.0"
-    babel-plugin-transform-es2015-object-super "^6.24.1"
-    babel-plugin-transform-es2015-parameters "^6.24.1"
-    babel-plugin-transform-es2015-shorthand-properties "^6.24.1"
-    babel-plugin-transform-es2015-spread "^6.22.0"
-    babel-plugin-transform-es2015-template-literals "^6.22.0"
-    babel-plugin-transform-object-rest-spread "^6.26.0"
-    babel-plugin-transform-react-jsx "^6.24.1"
-
 "@nodelib/fs.stat@^1.0.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.1.tgz#53f349bb986ab273d601175aa1b25a655ab90ee3"
@@ -8338,7 +8309,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.10, prop-types@^15.5.7:
+prop-types@15.6.0, prop-types@^15.5.10, prop-types@^15.5.7:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -8565,6 +8536,13 @@ react-addons-create-fragment@^15.5.3:
     fbjs "^0.8.4"
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
+
+react-annotation@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-annotation/-/react-annotation-1.3.1.tgz#eb04ca3483c034773dcce49e2aa433f77dee42ca"
+  dependencies:
+    prop-types "15.6.0"
+    viz-annotation "0.0.1-3"
 
 react-color@^2.14.0:
   version "2.14.1"
@@ -10567,6 +10545,10 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+viz-annotation@0.0.1-3:
+  version "0.0.1-3"
+  resolved "https://registry.yarnpkg.com/viz-annotation/-/viz-annotation-0.0.1-3.tgz#73d4430f46af0e727a611a027b5d975ec72ddb06"
 
 vlq@^0.2.1:
   version "0.2.3"


### PR DESCRIPTION
So, this is the famouse **annotations** :)

It's basically a wrapper for react-annotation, which you can see here: http://react-annotation.susielu.com/
I found that library flexible, clean and well structured.

The library provides lower level highly customizable components, and a dozen pre-packaged annotation _types_ (which are simply preset combinations of the low level components). You can see these pre-packaged _types_ in the section "Annotation Types" of the link above.

Given Nivo is a high level library, I thought best to wrap the high level _types_, and not give access to the low level components.

I have worked only on the scatterplot at the moment, and you can see an example in the storybook.

The way you add annotations to your chart is by simply passing an object which mirrors react-annotation props, plus a "type" property to define which of the _types_ you want to render (the storybook is a lot clearer than I can explain I think!)