### PR TITLE
Pass `tickIndex` to Axis’ renderTick method

### DIFF
--- a/packages/axes/src/components/Axis.js
+++ b/packages/axes/src/components/Axis.js
@@ -210,8 +210,9 @@ class Axis extends Component {
                         >
                             {interpolatedStyles => (
                                 <Fragment>
-                                    {interpolatedStyles.map(({ style, data: tick }) =>
+                                    {interpolatedStyles.map(({ style, data: tick }, tickIndex) =>
                                         renderTick({
+                                            tickIndex,
                                             format: tickValueFormat,
                                             textBaseline,
                                             textAnchor: textAlign,


### PR DESCRIPTION
Decide whether or not to render a tick based on the index. 
For example dependent on viewport width you could modulo the `tickIndex` to only render *n* ticks.