### PR TITLE
Send node data to onClick handler when isZoomable is false on Bubble Chart

### DIFF
--- a/packages/circle-packing/src/interactivity.js
+++ b/packages/circle-packing/src/interactivity.js
@@ -48,6 +48,10 @@ export const getNodeHandlers = (
             onClick(node, event)
             zoomToNode(node.path)
         }
+    } else {
+        clickHandler = event => {
+            onClick(node, event)
+        }
     }
 
     return {

--- a/packages/circle-packing/tests/Bubble.test.js
+++ b/packages/circle-packing/tests/Bubble.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'enzyme'
+import { render, mount } from 'enzyme'
 import Bubble from '../src/Bubble'
 
 const sampleData = {
@@ -62,4 +62,27 @@ it(`should allow to skip labels using 'labelSkipRadius' if radius is lower than 
     )
 
     expect(wrapper.find('text').length).toBe(6)
+})
+
+it(`should send node data to onClick when 'isZoomable' is false`, () => {
+    const onClickHandler = jest.fn(node => node.data)
+    const wrapper = mount(
+        <Bubble
+            width={600}
+            height={600}
+            root={sampleData}
+            enableLabel={true}
+            labelSkipRadius={24}
+            isZoomable={false}
+            onClick={onClickHandler}
+        />
+    )
+
+    wrapper
+        .find('circle')
+        .at(0) //click the first <circle> (the root)
+        .simulate('click')
+
+    expect(onClickHandler.mock.calls.length).toBe(1)
+    expect(onClickHandler.mock.results[0].value).toEqual(sampleData)
 })


### PR DESCRIPTION
Hey there!

Great lib! I've been using this bubble chart for a project and it's great.

One issue though is you can't get the `node` data with an onClick handler if the 
chart's interactivity/zoom is disabled. I wrote a quick PR here addressing it.

- call the `onClick` function passed in to the chart in either case
- add test to confirm value sent in the click is correct

Thanks!