### PR TITLE
Add tooltip to LineProps

### DIFF
--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -76,6 +76,7 @@ declare module '@nivo/line' {
         enableStackTooltip?: boolean
 
         legends?: LegendProps[]
+        tooltip?(data: LineDatum): React.ReactNode
     }
 
     export interface LineSvgProps extends LineProps, MotionProps {}


### PR DESCRIPTION
Allows the `tooltip` prop to be used on `<Line>` or `<ResponsiveLine>` when you want to have a custom tooltip. I'm not sure if the `(data: LineDatum): React.ReactNode` is the best annotation, but it compiles fine for me, open to someone improving that though.