### PR TITLE
feat(bar) Add enableGridX / enableGridY / legends props to BarCanvas component

### DIFF
--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -164,7 +164,7 @@ class BarCanvas extends Component {
                 data: legendData,
                 containerWidth: width,
                 containerHeight: height,
-                itemTextColor: "#999",
+                itemTextColor: '#999',
                 symbolSize: 16,
             })
         })


### PR DESCRIPTION
### Description 

I just added `enableGridX` / `enableGridY` / `legends` options to `BarCanvas` component as SVG `Bar` component does. 

Here is how it looks (tested with storybook 😅) 
 - Before 
<img width="900" alt="screen shot 2018-11-24 at 8 23 09 pm" src="https://user-images.githubusercontent.com/10060731/48967637-e539e400-f026-11e8-9b2a-3dda3c5ed2d6.png">

 - After
<img width="974" alt="screen shot 2018-11-24 at 8 23 18 pm" src="https://user-images.githubusercontent.com/10060731/48967638-e79c3e00-f026-11e8-9236-7c3a3040fba0.png">

