### PR TITLE
Fix missing legend in Bar chart 

### DIFF
--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 import React, { Fragment } from 'react'
-import uniqBy from "lodash/uniqBy"
+import uniqBy from 'lodash/uniqBy'
 import { TransitionMotion, spring } from 'react-motion'
 import { bindDefs, Container, SvgWrapper, Grid, CartesianMarkers } from '@nivo/core'
 import { Axes } from '@nivo/axes'
@@ -153,23 +153,27 @@ const Bar = props => {
         targetKey: 'data.fill',
     })
 
-    const legendDataForKeys = uniqBy(result.bars
-        .map(bar => ({
-            id: bar.data.id,
-            label: bar.data.id,
-            color: bar.color,
-            fill: bar.data.fill,
-        }))
-        .reverse(), (({id}) => id))
+    const legendDataForKeys = uniqBy(
+        result.bars
+            .map(bar => ({
+                id: bar.data.id,
+                label: bar.data.id,
+                color: bar.color,
+                fill: bar.data.fill,
+            }))
+            .reverse(),
+        ({ id }) => id
+    )
 
-    const legendDataForIndexes = uniqBy(result.bars
-        .map(bar => ({
+    const legendDataForIndexes = uniqBy(
+        result.bars.map(bar => ({
             id: bar.data.indexValue,
             label: bar.data.indexValue,
             color: bar.color,
             fill: bar.data.fill,
-        })
-    ), (({id}) => id))
+        })),
+        ({ id }) => id
+    )
 
     return (
         <Container isInteractive={isInteractive} theme={theme}>

--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 import React, { Fragment } from 'react'
+import uniqBy from "lodash/uniqBy"
 import { TransitionMotion, spring } from 'react-motion'
 import { bindDefs, Container, SvgWrapper, Grid, CartesianMarkers } from '@nivo/core'
 import { Axes } from '@nivo/axes'
@@ -152,22 +153,23 @@ const Bar = props => {
         targetKey: 'data.fill',
     })
 
-    const legendDataForKeys = result.bars
-        .filter(bar => bar.data.index === 0)
+    const legendDataForKeys = uniqBy(result.bars
         .map(bar => ({
             id: bar.data.id,
             label: bar.data.id,
             color: bar.color,
             fill: bar.data.fill,
         }))
-        .reverse()
+        .reverse(), (({id}) => id))
 
-    const legendDataForIndexes = result.bars.filter(bar => bar.data.id === keys[0]).map(bar => ({
-        id: bar.data.indexValue,
-        label: bar.data.indexValue,
-        color: bar.color,
-        fill: bar.data.fill,
-    }))
+    const legendDataForIndexes = uniqBy(result.bars
+        .map(bar => ({
+            id: bar.data.indexValue,
+            label: bar.data.indexValue,
+            color: bar.color,
+            fill: bar.data.fill,
+        })
+    ), (({id}) => id))
 
     return (
         <Container isInteractive={isInteractive} theme={theme}>

--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 import React, { Component } from 'react'
+import uniqBy from "lodash/uniqBy"
 import setDisplayName from 'recompose/setDisplayName'
 import {
     renderAxesToCanvas,
@@ -132,23 +133,22 @@ class BarCanvas extends Component {
             })
 
         this.ctx.strokeStyle = '#dddddd'
-        const legendDataForKeys = result.bars
-            .filter(bar => bar.data.index === 0)
+
+        const legendDataForKeys = uniqBy(result.bars
             .map(bar => ({
                 id: bar.data.id,
                 label: bar.data.id,
                 color: bar.color,
                 fill: bar.data.fill,
             }))
-            .reverse()
-        const legendDataForIndexes = result.bars
-            .filter(bar => bar.data.id === keys[0])
+            .reverse(), (({id}) => id))
+        const legendDataForIndexes = uniqBy(result.bars
             .map(bar => ({
                 id: bar.data.indexValue,
                 label: bar.data.indexValue,
                 color: bar.color,
                 fill: bar.data.fill,
-            }))
+            })), (({id}) => id))
 
         legends.forEach(legend => {
             let legendData

--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 import React, { Component } from 'react'
-import uniqBy from "lodash/uniqBy"
+import uniqBy from 'lodash/uniqBy'
 import setDisplayName from 'recompose/setDisplayName'
 import {
     renderAxesToCanvas,
@@ -134,21 +134,26 @@ class BarCanvas extends Component {
 
         this.ctx.strokeStyle = '#dddddd'
 
-        const legendDataForKeys = uniqBy(result.bars
-            .map(bar => ({
-                id: bar.data.id,
-                label: bar.data.id,
-                color: bar.color,
-                fill: bar.data.fill,
-            }))
-            .reverse(), (({id}) => id))
-        const legendDataForIndexes = uniqBy(result.bars
-            .map(bar => ({
+        const legendDataForKeys = uniqBy(
+            result.bars
+                .map(bar => ({
+                    id: bar.data.id,
+                    label: bar.data.id,
+                    color: bar.color,
+                    fill: bar.data.fill,
+                }))
+                .reverse(),
+            ({ id }) => id
+        )
+        const legendDataForIndexes = uniqBy(
+            result.bars.map(bar => ({
                 id: bar.data.indexValue,
                 label: bar.data.indexValue,
                 color: bar.color,
                 fill: bar.data.fill,
-            })), (({id}) => id))
+            })),
+            ({ id }) => id
+        )
 
         legends.forEach(legend => {
             let legendData


### PR DESCRIPTION
Another trial to fix #111 or #218 

So the problem that I aim to fix here is, if some keys have `0` as value in first column, it doesn't generate legend at all even if other columns have non-zero value. 

Related conversation is also in #128 which is a first trial to fix this issue. I saw #219 as well and I understand there might be more cases we can improve. 
But I think many ppl including me, this missing legend with zero value in 1st column issue is more urgent I think. 

tl; dr 

#### Before 
<img width="1092" alt="screen shot 2018-11-30 at 2 17 13 pm" src="https://user-images.githubusercontent.com/10060731/49270004-17c26180-f4ab-11e8-95c7-83f64fe328af.png">

#### After 
<img width="1257" alt="screen shot 2018-11-30 at 2 17 04 pm" src="https://user-images.githubusercontent.com/10060731/49270003-142eda80-f4ab-11e8-89a5-aed243b7094e.png">

Also applied in Canvas 
![screen shot 2018-11-30 at 2 12 51 pm](https://user-images.githubusercontent.com/10060731/49270036-3163a900-f4ab-11e8-9203-d245c100c629.png)
