### PR TITLE
fix(bar): Allow BarItem label property to accept React.Element

### DIFF
--- a/packages/bar/src/BarItem.js
+++ b/packages/bar/src/BarItem.js
@@ -98,7 +98,7 @@ BarItem.propTypes = {
     borderWidth: PropTypes.number.isRequired,
     borderColor: PropTypes.string.isRequired,
 
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    label: PropTypes.node.isRequired,
     shouldRenderLabel: PropTypes.bool.isRequired,
     labelColor: PropTypes.string.isRequired,
 


### PR DESCRIPTION
Bar chart allow to use a function that returns a `<tspan>` tag, but BarItem's ProptTypes expect to receive a string only, showing a warning in the browser development console.

System:
- SO: Windows 10 Enterprise
- Browser: Chrome Version 70.0.3538.110 (Official Build) (64-bit)
- Nivo/Bar:  0.51.5

How to reproduce:
- Use the bar package
- Create a `Bar` or `ResponsiveBar` element
- Set the `labelFormat` property to `d => <tspan>custom {d}</tspan>}`
- Run the app and check the browser development console for message `Warning: Failed prop type: invalid prop 'label' supplied to 'baritem'`.