### PR TITLE
Fix wrong legend item color in ScatterPlotCanvas

### DIFF
--- a/packages/scatterplot/src/ScatterPlotCanvas.js
+++ b/packages/scatterplot/src/ScatterPlotCanvas.js
@@ -216,13 +216,14 @@ class ScatterPlotCanvas extends Component {
         const legendData = data.map(serie => ({
             id: serie.id,
             label: serie.id,
-            color: getColor(serie),
+            color: getColor({ serie }),
         }))
 
         legends.forEach(legend => {
             renderLegendToCanvas(this.ctx, {
                 ...legend,
                 data: legendData,
+                itemTextColor: '#999',
                 containerWidth: width,
                 containerHeight: height,
             })

--- a/packages/scatterplot/src/ScatterPlotCanvas.js
+++ b/packages/scatterplot/src/ScatterPlotCanvas.js
@@ -223,7 +223,6 @@ class ScatterPlotCanvas extends Component {
             renderLegendToCanvas(this.ctx, {
                 ...legend,
                 data: legendData,
-                itemTextColor: '#999',
                 containerWidth: width,
                 containerHeight: height,
             })

--- a/website/src/components/charts/scatterplot/ScatterPlotCanvas.js
+++ b/website/src/components/charts/scatterplot/ScatterPlotCanvas.js
@@ -47,7 +47,7 @@ export default class ScatterPlotCanvas extends Component {
             pixelRatio: window && window.devicePixelRatio ? window.devicePixelRatio : 1,
 
             colors: 'nivo',
-            colorBy: 'id',
+            colorBy: 'serie.id',
 
             symbolSize: 4,
             symbolShape: 'circle',


### PR DESCRIPTION
Aiming to fix #371 

### Before 
<img width="1210" alt="screen shot 2018-12-07 at 6 50 15 pm" src="https://user-images.githubusercontent.com/10060731/49640755-b58cd200-fa51-11e8-8b4e-4cf82a403375.png">

### After
<img width="1160" alt="screen shot 2018-12-07 at 6 54 51 pm" src="https://user-images.githubusercontent.com/10060731/49640766-ba518600-fa51-11e8-9280-4f659a638ca2.png">

