### PR TITLE
Make scatter plot item size have always positive value by wrapping it with Math.abs()

### DIFF
--- a/packages/scatterplot/src/ScatterPlotCanvas.js
+++ b/packages/scatterplot/src/ScatterPlotCanvas.js
@@ -200,7 +200,7 @@ class ScatterPlotCanvas extends Component {
 
         points.forEach(point => {
             this.ctx.beginPath()
-            this.ctx.arc(point.x, point.y, getSymbolSize(point.data) / 2, 0, 2 * Math.PI)
+            this.ctx.arc(point.x, point.y, Math.abs(getSymbolSize(point.data) / 2), 0, 2 * Math.PI)
             this.ctx.fillStyle = getColor(point.data)
             this.ctx.fill()
         })

--- a/packages/scatterplot/src/ScatterPlotItem.js
+++ b/packages/scatterplot/src/ScatterPlotItem.js
@@ -25,7 +25,7 @@ const ScatterPlotItem = ({
     <circle
         cx={x}
         cy={y}
-        r={size / 2}
+        r={Math.abs(size / 2)}
         fill={color}
         onMouseEnter={onMouseEnter}
         onMouseMove={onMouseMove}


### PR DESCRIPTION
Aiming to resolve #374 

### How to replicate 
Put some negative values in sample data in `ScatterPlot.stories.js` & `ScatterPlotCanvas.stories.js` -> Add 
```
yScale: {
  type: 'linear',
  min: 'auto',
  max: 'auto',
},
```
to `commonProps` to see the negative sample data is displayed in the graph  -> Go to "ScatterPlot - Varying Symbol Size" example (same in Canvas storybook example)

#### Before 
In SVG ScatterPlot example 
<img width="1484" alt="screen shot 2018-12-08 at 2 58 47 pm" src="https://user-images.githubusercontent.com/10060731/49682726-cba39c80-fafc-11e8-97a5-a7e6c0c4b3bc.png">

In ScatterPlotCanvas example 
<img width="1380" alt="screen shot 2018-12-08 at 2 58 27 pm" src="https://user-images.githubusercontent.com/10060731/49682730-dc541280-fafc-11e8-9752-ce9c756c3559.png">

Those error should be gone with this patch 
