### PR TITLE
Add number support to gridXValues and gridYValues on Line

### DIFF
--- a/packages/core/src/components/axes/Grid.js
+++ b/packages/core/src/components/axes/Grid.js
@@ -80,11 +80,15 @@ Grid.propTypes = {
     yScale: PropTypes.func,
     xValues: PropTypes.oneOfType([
         PropTypes.number,
-        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+        PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)])
+        ),
     ]),
     yValues: PropTypes.oneOfType([
         PropTypes.number,
-        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+        PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)])
+        ),
     ]),
 
     theme: PropTypes.object.isRequired,

--- a/packages/core/src/components/axes/Grid.js
+++ b/packages/core/src/components/axes/Grid.js
@@ -78,8 +78,14 @@ Grid.propTypes = {
 
     xScale: PropTypes.func,
     yScale: PropTypes.func,
-    xValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
-    yValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    xValues: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    ]),
+    yValues: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    ]),
 
     theme: PropTypes.object.isRequired,
 

--- a/packages/core/src/lib/cartesian/axes.js
+++ b/packages/core/src/lib/cartesian/axes.js
@@ -163,13 +163,12 @@ export const computeAxisTicks = ({
  *
  * @return {Array.<Object>}
  */
-export const computeGridLines = ({
-    width,
-    height,
-    scale,
-    axis,
-    values = getScaleValues(scale),
-}) => {
+export const computeGridLines = ({ width, height, scale, axis, values: _values }) => {
+    const gridValues = isArray(_values) ? _values : undefined
+    const gridCount = isNumber(_values) ? _values : undefined
+
+    const values = gridValues || getScaleValues(scale, gridCount)
+
     const position = scale.bandwidth ? centerScale(scale) : scale
 
     let lines

--- a/packages/line/src/props.js
+++ b/packages/line/src/props.js
@@ -66,11 +66,15 @@ export const LinePropTypes = {
     enableGridY: PropTypes.bool.isRequired,
     gridXValues: PropTypes.oneOfType([
         PropTypes.number,
-        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+        PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)])
+        ),
     ]),
     gridYValues: PropTypes.oneOfType([
         PropTypes.number,
-        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+        PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)])
+        ),
     ]),
 
     enableDots: PropTypes.bool.isRequired,

--- a/packages/line/src/props.js
+++ b/packages/line/src/props.js
@@ -64,8 +64,14 @@ export const LinePropTypes = {
 
     enableGridX: PropTypes.bool.isRequired,
     enableGridY: PropTypes.bool.isRequired,
-    gridXValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
-    gridYValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    gridXValues: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    ]),
+    gridYValues: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    ]),
 
     enableDots: PropTypes.bool.isRequired,
     dotSymbol: PropTypes.func,


### PR DESCRIPTION
This commit adds gridCount/integer support to `gridXValues` and `gridYValues` for line charts. This allows for grid lines and axes ticks to be calculated the same when using a number that is passed. For example:

```javascript
<ResponsiveLine
  axisRight={{
    tickValues: 6,
  }}
  gridYValues={6}
  ...
/>
```

I tried to follow all of the contributing guidelines, happy to contribute to a great library!