### PR TITLE
feat(pie): Add ability to handle clicks on pie chart slices in javasc…

### DIFF
--- a/packages/pie/src/PieSlice.js
+++ b/packages/pie/src/PieSlice.js
@@ -57,17 +57,19 @@ const PieSlice = ({
     }
 
     return (
-        <path
-            key={data.id}
-            d={path}
-            fill={fill}
-            strokeWidth={borderWidth}
-            stroke={borderColor}
-            onMouseEnter={handleMouseEnter}
-            onMouseMove={handleTooltip}
-            onMouseLeave={handleMouseLeave}
-            onClick={onClick}
-        />
+        <a href={data.id}>
+            <path
+                key={data.id}
+                d={path}
+                fill={fill}
+                strokeWidth={borderWidth}
+                stroke={borderColor}
+                onMouseEnter={handleMouseEnter}
+                onMouseMove={handleTooltip}
+                onMouseLeave={handleMouseLeave}
+                onClick={onClick}
+            />
+        </a>
     )
 }
 
@@ -98,7 +100,10 @@ PieSlice.propTypes = {
 
 const enhance = compose(
     withPropsOnChange(['data', 'onClick'], ({ data, onClick }) => ({
-        onClick: event => onClick(data, event),
+        onClick: event => {
+            event.preventDefault();
+            return onClick(data, event);
+        },
     })),
     pure
 )


### PR DESCRIPTION
* This PR is in connection with the issue raised earlier: https://github.com/plouc/nivo/issues/392

* Wrapped the pie chart slices in anchor tags and added event.preventDefault() method in the individual pie chart slices.

* One important thing to note here is that event.preventDefault() method will only work when javascript is enabled. So, there will be no change in the url on clicking a pie chart slice when javascript is enabled and it will work same as it worked before.

* The purpose of wrapping the pie chart slices in anchor tags is that when javascript is disabled, we want a way to handle the onClick events through our server(React Server Side Rendering in my case) which was otherwise not possible.

* In case of javascript disabled, on clicking on any of the pie chart slices, I've added an href tag with id value of that pie chart slice(data.id), so that we get a request for <existing_url>/<slice_id_value> and then, we can handle this request to handle the onClick events through our server.

* Hence, this change would only affect the library if it is being used in javascript disabled mode, otherwise, there wouldn't be any change in javascript enabled mode. (Just that you would see a pointer cursor on hovering over the pie chart slices due to the anchor tag. This can be easily removed if not required. Although, I would prefer it by default for the nivo pie chart library.