### PR TITLE
Feature: Add orderability to Sankey Nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
   "workspaces": [
     "packages/*",
     "api"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,5 @@
   "workspaces": [
     "packages/*",
     "api"
-  ],
-  "dependencies": {}
+  ]
 }

--- a/packages/sankey/index.d.ts
+++ b/packages/sankey/index.d.ts
@@ -76,6 +76,8 @@ declare module '@nivo/sankey' {
         theme: Theme
 
         legends: LegendProps[]
+
+        sort?: (nodeA: SankeyDataNode, nodeB: SankeyDataNode) => number
     }>
 
     interface Dimensions {

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@nivo/core": "0.53.0",
     "@nivo/legends": "0.53.0",
-    "d3-sankey": "^0.7.1",
+    "d3-sankey": "0.12.1",
     "lodash": "^4.17.4",
     "react-motion": "^0.5.2",
     "recompose": "^0.30.0"

--- a/packages/sankey/src/Sankey.js
+++ b/packages/sankey/src/Sankey.js
@@ -74,8 +74,11 @@ const Sankey = ({
     tooltipFormat,
 
     legends,
+
+    sort,
 }) => {
     const sankey = d3Sankey()
+        .nodeSort(sort)
         .nodeAlign(sankeyAlignmentFromProp(align))
         .nodeWidth(nodeWidth)
         .nodePadding(nodePaddingY)

--- a/packages/sankey/stories/sankey.stories.js
+++ b/packages/sankey/stories/sankey.stories.js
@@ -83,6 +83,24 @@ const randColorProperties = {
     colors: commonProperties.colors,
 }
 
-stories.add('with custom node & link coloring', () => (
-    <Sankey {...randColorProperties} enableLinkGradient={true} colorBy={node => node.nodeColor} />
-))
+stories.add(
+    'with custom node & link coloring',
+    withInfo()(() => (
+        <Sankey
+            {...randColorProperties}
+            enableLinkGradient={true}
+            colorBy={node => node.nodeColor}
+        />
+    ))
+)
+
+const minNodeValueOnTop = (nodeA, nodeB) => {
+    if (nodeA.value < nodeB.value) return -1
+    if (nodeA.value > nodeB.value) return 1
+    return 0
+}
+
+stories.add(
+    'with reverse sort ordering (min node value on top)',
+    withInfo()(() => <Sankey {...commonProperties} sort={minNodeValueOnTop} />)
+)

--- a/packages/sankey/stories/sankey.stories.js
+++ b/packages/sankey/stories/sankey.stories.js
@@ -85,13 +85,13 @@ const randColorProperties = {
 
 stories.add(
     'with custom node & link coloring',
-    withInfo()(() => (
+    () => (
         <Sankey
             {...randColorProperties}
             enableLinkGradient={true}
             colorBy={node => node.nodeColor}
         />
-    ))
+    )
 )
 
 const minNodeValueOnTop = (nodeA, nodeB) => {
@@ -102,5 +102,5 @@ const minNodeValueOnTop = (nodeA, nodeB) => {
 
 stories.add(
     'with reverse sort ordering (min node value on top)',
-    withInfo()(() => <Sankey {...commonProperties} sort={minNodeValueOnTop} />)
+    () => <Sankey {...commonProperties} sort={minNodeValueOnTop} />
 )

--- a/packages/sankey/stories/sankey.stories.js
+++ b/packages/sankey/stories/sankey.stories.js
@@ -83,16 +83,9 @@ const randColorProperties = {
     colors: commonProperties.colors,
 }
 
-stories.add(
-    'with custom node & link coloring',
-    () => (
-        <Sankey
-            {...randColorProperties}
-            enableLinkGradient={true}
-            colorBy={node => node.nodeColor}
-        />
-    )
-)
+stories.add('with custom node & link coloring', () => (
+    <Sankey {...randColorProperties} enableLinkGradient={true} colorBy={node => node.nodeColor} />
+))
 
 const minNodeValueOnTop = (nodeA, nodeB) => {
     if (nodeA.value < nodeB.value) return -1
@@ -100,7 +93,6 @@ const minNodeValueOnTop = (nodeA, nodeB) => {
     return 0
 }
 
-stories.add(
-    'with reverse sort ordering (min node value on top)',
-    () => <Sankey {...commonProperties} sort={minNodeValueOnTop} />
-)
+stories.add('with reverse sort ordering (min node value on top)', () => (
+    <Sankey {...commonProperties} sort={minNodeValueOnTop} />
+))

--- a/yarn.lock
+++ b/yarn.lock
@@ -4946,7 +4946,7 @@ d3-path@1:
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.7.tgz#8de7cd693a75ac0b5480d3abaccd94793e58aae8"
   integrity sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA==
 
-d3-sankey@^0.7.1:
+"d3-sankey@github:neilrackett/d3-sankey#f2a8cee64cebc0c6690f01474232f44da6dc0ec0":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.7.1.tgz#d229832268fc69a7fec84803e96c2256a614c521"
   integrity sha1-0imDImj8aaf+yEgD6WwiVqYUxSE=

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,6 +4899,11 @@ d3-array@1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
+"d3-array@>=1 <=2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.0.3.tgz#9c0531eda701e416f28a030e3d4e6179ba74f19f"
+  integrity sha512-C7g4aCOoJa+/K5hPVqZLG8wjYHsTUROTk7Z1Ep9F4P5l+WVrvV0+6nAZ1wKTRLMhFWpGbozxUpyjIPZYAaLi+g==
+
 d3-chord@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
@@ -4946,13 +4951,12 @@ d3-path@1:
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.7.tgz#8de7cd693a75ac0b5480d3abaccd94793e58aae8"
   integrity sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA==
 
-"d3-sankey@github:neilrackett/d3-sankey#f2a8cee64cebc0c6690f01474232f44da6dc0ec0":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.7.1.tgz#d229832268fc69a7fec84803e96c2256a614c521"
-  integrity sha1-0imDImj8aaf+yEgD6WwiVqYUxSE=
+d3-sankey@0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.12.1.tgz#f4a655227ee90211befcd32074aeb275e73f92ba"
+  integrity sha512-2DF8aj52Zkghfl06yCsCJUW/p8ChQND0+p1Xx3DiQIvABp4XazvyMAppgGRjJGwK2tkVYtpI1IgFIlMppBZMhg==
   dependencies:
-    d3-array "1"
-    d3-collection "1"
+    d3-array ">=1 <=2"
     d3-shape "^1.2.0"
 
 d3-scale-chromatic@^1.3.3:


### PR DESCRIPTION
Update @nivo-sankey to point to neilrackett's d3-sankey fork, exposing his addition of the nodeSort method by adding the sort parameter to Sankey. (Note that the head fork d3/d3-sankey has been inactive for over a year).

This allows the developer to render the nodes in the order submitted, or in a custom sorted order based on any metric they attach to the nodes. Note that in my PR I am purposely allowing the sort method to be optional.

Default
<img width="1178" alt="screen shot 2018-12-22 at 13 09 30" src="https://user-images.githubusercontent.com/17368530/50378608-00c6e900-05eb-11e9-85ef-a3053a86f93b.png">

With reverse sort order function property
<img width="1175" alt="screen shot 2018-12-22 at 13 09 41" src="https://user-images.githubusercontent.com/17368530/50378612-12a88c00-05eb-11e9-8920-000951096705.png">

Function that was attached for the sankey_stories.js file
```javascript
let minNodeValueOnTop = (nodeA, nodeB) => { 
    if (nodeA.value < nodeB.value) return -1 
    if (nodeA.value > nodeB.value) return 1 
    return 0 
}
```

