### PR TITLE
Set pointer as 'normal' not crosshair in ScatterPlot canvas chart

### DIFF
--- a/packages/scatterplot/src/ScatterPlotCanvas.js
+++ b/packages/scatterplot/src/ScatterPlotCanvas.js
@@ -243,7 +243,7 @@ class ScatterPlotCanvas extends Component {
                         style={{
                             width: outerWidth,
                             height: outerHeight,
-                            cursor: isInteractive ? 'crosshair' : 'normal',
+                            cursor: 'normal',
                         }}
                         onMouseEnter={this.handleMouseHover(showTooltip, hideTooltip)}
                         onMouseMove={this.handleMouseHover(showTooltip, hideTooltip)}

--- a/packages/scatterplot/src/ScatterPlotCanvas.js
+++ b/packages/scatterplot/src/ScatterPlotCanvas.js
@@ -243,7 +243,6 @@ class ScatterPlotCanvas extends Component {
                         style={{
                             width: outerWidth,
                             height: outerHeight,
-                            cursor: 'normal',
                         }}
                         onMouseEnter={this.handleMouseHover(showTooltip, hideTooltip)}
                         onMouseMove={this.handleMouseHover(showTooltip, hideTooltip)}


### PR DESCRIPTION
Fixes https://github.com/plouc/nivo/issues/370 

#### Before
![record_before](https://user-images.githubusercontent.com/10060731/50372755-ac862e00-0617-11e9-97cb-504e19cd4130.gif)

#### After
![record_after](https://user-images.githubusercontent.com/10060731/50372756-b0b24b80-0617-11e9-9340-f23147552d73.gif)
