### PR TITLE
Feature: Decouple Sankey Node coloring and Link coloring

### DIFF
--- a/packages/sankey/src/SankeyLinksItem.js
+++ b/packages/sankey/src/SankeyLinksItem.js
@@ -59,6 +59,12 @@ const SankeyLinksItem = ({
     path,
     width,
     color,
+
+    //Decouples link colors from node color
+    defaultColor, //If no linear gradient
+    startColor, //Use startColor & endColor if linear gradient
+    endColor,
+
     opacity,
     contract,
     blendMode,
@@ -80,8 +86,8 @@ const SankeyLinksItem = ({
                 x1={link.source.x}
                 x2={link.target.x}
             >
-                <stop offset="0%" stopColor={link.source.color} />
-                <stop offset="100%" stopColor={link.target.color} />
+                <stop offset="0%" stopColor={link.startColor || link.source.color} />
+                <stop offset="100%" stopColor={link.endColor || link.target.color} />
             </linearGradient>
         )}
         <path
@@ -118,6 +124,8 @@ SankeyLinksItem.propTypes = {
     path: PropTypes.string.isRequired,
     width: PropTypes.number.isRequired,
     color: PropTypes.string.isRequired,
+    startColor: PropTypes.string,
+    endColor: PropTypes.string,
     opacity: PropTypes.number.isRequired,
     contract: PropTypes.number.isRequired,
     blendMode: blendModePropType.isRequired,

--- a/packages/sankey/src/SankeyLinksItem.js
+++ b/packages/sankey/src/SankeyLinksItem.js
@@ -59,12 +59,6 @@ const SankeyLinksItem = ({
     path,
     width,
     color,
-
-    //Decouples link colors from node color
-    defaultColor, //If no linear gradient
-    startColor, //Use startColor & endColor if linear gradient
-    endColor,
-
     opacity,
     contract,
     blendMode,
@@ -86,6 +80,7 @@ const SankeyLinksItem = ({
                 x1={link.source.x}
                 x2={link.target.x}
             >
+                {/*Use startColor & endColor if want to customize link color gradient*/}
                 <stop offset="0%" stopColor={link.startColor || link.source.color} />
                 <stop offset="100%" stopColor={link.endColor || link.target.color} />
             </linearGradient>
@@ -124,8 +119,6 @@ SankeyLinksItem.propTypes = {
     path: PropTypes.string.isRequired,
     width: PropTypes.number.isRequired,
     color: PropTypes.string.isRequired,
-    startColor: PropTypes.string,
-    endColor: PropTypes.string,
     opacity: PropTypes.number.isRequired,
     contract: PropTypes.number.isRequired,
     blendMode: blendModePropType.isRequired,

--- a/packages/sankey/stories/sankey.stories.js
+++ b/packages/sankey/stories/sankey.stories.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
-import { generateSankeyData } from '@nivo/generators'
+import { generateSankeyData, randColor } from '@nivo/generators'
 import { Sankey } from '../index'
 
+const sankeyData = generateSankeyData({ nodeCount: 11, maxIterations: 2 })
 const commonProperties = {
     width: 900,
     height: 400,
     margin: { top: 0, right: 80, bottom: 0, left: 80 },
-    data: generateSankeyData({ nodeCount: 11, maxIterations: 2 }),
+    data: sankeyData,
     colors: 'category10',
 }
 
@@ -82,6 +83,39 @@ stories.add(
                     minimumFractionDigits: 2,
                 })} ₽`
             }
+        />
+    ))
+)
+
+const dataWithRandLinkColors = data => {
+    return {
+        nodes: data.nodes.map(node => ({
+            ...node,
+            nodeColor: 'blue',
+        })),
+        links: data.links.map(link => ({
+            ...link,
+            startColor: randColor(),
+            endColor: randColor(),
+        })),
+    }
+}
+
+const randColorProperties = {
+    width: commonProperties.width,
+    height: commonProperties.height,
+    margin: commonProperties.margin,
+    data: dataWithRandLinkColors(sankeyData),
+    colors: commonProperties.colors,
+}
+
+stories.add(
+    'with custom node & link coloring',
+    withInfo()(() => (
+        <Sankey
+            {...randColorProperties}
+            enableLinkGradient={true}
+            colorBy={node => node.nodeColor}
         />
     ))
 )


### PR DESCRIPTION
This PR aims to make it much easier to customize node and link colorings for the sankey plot, to be able to create a plot like this

<img width="1234" alt="screen shot 2018-12-23 at 14 02 54" src="https://user-images.githubusercontent.com/17368530/50387864-8d40dc80-06bb-11e9-9206-93c9d87c52e1.png">

Now one can customize link gradients from the node color when using enable gradient by adding the startColor and endColor properties to each link's data. Otherwise, this will default to the color of each node.