### PR TITLE
Updates slice width to allow for unevenly spaced data.

### DIFF
--- a/packages/line/src/LineSlices.js
+++ b/packages/line/src/LineSlices.js
@@ -11,30 +11,62 @@ import PropTypes from 'prop-types'
 import pure from 'recompose/pure'
 import LineSlicesItem from './LineSlicesItem'
 
-const LineSlices = ({
-    slices,
-    height,
-    showTooltip,
-    hideTooltip,
-    theme,
-    tooltip,
-    tooltipFormat,
-}) => (
-    <g>
-        {slices.map(slice => (
-            <LineSlicesItem
-                key={slice.id}
-                slice={slice}
-                height={height}
-                showTooltip={showTooltip}
-                hideTooltip={hideTooltip}
-                theme={theme}
-                tooltipFormat={tooltipFormat}
-                tooltip={tooltip}
-            />
-        ))}
-    </g>
-)
+class LineSlices extends React.Component {
+    render() {
+        const {
+            slices,
+            height,
+            showTooltip,
+            hideTooltip,
+            theme,
+            tooltip,
+            tooltipFormat,
+        } = this.props;
+        // sliceWidth: half the distance from the previous point + half the distance to the next point
+        let sliceWidth;
+        // xOffset: half the distance from the previous point
+        let xOffset;
+        let lineSlicesItems = [];
+        for (let i = 0; i < slices.length; i++) {
+            const currentXPosition = slices[i].data[0].position.x;
+            const previousXPosition = i > 0 ? slices[i - 1].data[0].position.x : null;
+            const nextXPosition = i < slices.length - 1 ? slices[i + 1].data[0].position.x : null;
+            const widthBetweenCurrentAndNext = (nextXPosition - currentXPosition);
+            const widthBetweenPreviousAndCurrent = (currentXPosition - previousXPosition);
+            // offset: amount to add to the first and last slices' sliceWidths so that the tooltip appears when the
+            // mouse is within the offset amount to the left of the first point and to the right of the last point.
+            const offset = 5;
+            if (i === 0) {
+                // This is the first slice, which does not have a previous x position
+                sliceWidth = widthBetweenCurrentAndNext / 2 + offset;
+                xOffset = -offset;
+            } else if (i === slices.length - 1) {
+                // This is the last slice, which does not have a next x position
+                sliceWidth = widthBetweenPreviousAndCurrent / 2 + offset;
+                xOffset = -widthBetweenPreviousAndCurrent / 2;
+            } else {
+                // This slice is in the middle of the graph
+                sliceWidth = widthBetweenPreviousAndCurrent / 2 + widthBetweenCurrentAndNext / 2;
+                xOffset = -widthBetweenPreviousAndCurrent / 2;
+            }
+            lineSlicesItems.push(
+                <LineSlicesItem
+                    key={slices[i].id}
+                    xOffset={xOffset}
+                    slice={slices[i]}
+                    height={height}
+                    width={sliceWidth}
+                    showTooltip={showTooltip}
+                    hideTooltip={hideTooltip}
+                    theme={theme}
+                    tooltipFormat={tooltipFormat}
+                    tooltip={tooltip}
+                />
+            )
+        }
+        return <g>{lineSlicesItems.map(i => i)}</g>;
+    }
+}
 
 LineSlices.propTypes = {
     slices: PropTypes.arrayOf(

--- a/packages/line/src/LineSlices.js
+++ b/packages/line/src/LineSlices.js
@@ -21,33 +21,33 @@ class LineSlices extends React.Component {
             theme,
             tooltip,
             tooltipFormat,
-        } = this.props;
+        } = this.props
         // sliceWidth: half the distance from the previous point + half the distance to the next point
-        let sliceWidth;
+        let sliceWidth
         // xOffset: half the distance from the previous point
-        let xOffset;
-        let lineSlicesItems = [];
+        let xOffset
+        let lineSlicesItems = []
         for (let i = 0; i < slices.length; i++) {
-            const currentXPosition = slices[i].data[0].position.x;
-            const previousXPosition = i > 0 ? slices[i - 1].data[0].position.x : null;
-            const nextXPosition = i < slices.length - 1 ? slices[i + 1].data[0].position.x : null;
-            const widthBetweenCurrentAndNext = (nextXPosition - currentXPosition);
-            const widthBetweenPreviousAndCurrent = (currentXPosition - previousXPosition);
+            const currentXPosition = slices[i].data[0].position.x
+            const previousXPosition = i > 0 ? slices[i - 1].data[0].position.x : null
+            const nextXPosition = i < slices.length - 1 ? slices[i + 1].data[0].position.x : null
+            const widthBetweenCurrentAndNext = nextXPosition - currentXPosition
+            const widthBetweenPreviousAndCurrent = currentXPosition - previousXPosition
             // offset: amount to add to the first and last slices' sliceWidths so that the tooltip appears when the
             // mouse is within the offset amount to the left of the first point and to the right of the last point.
-            const offset = 5;
+            const offset = 5
             if (i === 0) {
                 // This is the first slice, which does not have a previous x position
-                sliceWidth = widthBetweenCurrentAndNext / 2 + offset;
-                xOffset = -offset;
+                sliceWidth = widthBetweenCurrentAndNext / 2 + offset
+                xOffset = -offset
             } else if (i === slices.length - 1) {
                 // This is the last slice, which does not have a next x position
-                sliceWidth = widthBetweenPreviousAndCurrent / 2 + offset;
-                xOffset = -widthBetweenPreviousAndCurrent / 2;
+                sliceWidth = widthBetweenPreviousAndCurrent / 2 + offset
+                xOffset = -widthBetweenPreviousAndCurrent / 2
             } else {
                 // This slice is in the middle of the graph
-                sliceWidth = widthBetweenPreviousAndCurrent / 2 + widthBetweenCurrentAndNext / 2;
-                xOffset = -widthBetweenPreviousAndCurrent / 2;
+                sliceWidth = widthBetweenPreviousAndCurrent / 2 + widthBetweenCurrentAndNext / 2
+                xOffset = -widthBetweenPreviousAndCurrent / 2
             }
             lineSlicesItems.push(
                 <LineSlicesItem
@@ -64,7 +64,7 @@ class LineSlices extends React.Component {
                 />
             )
         }
-        return <g>{lineSlicesItems.map(i => i)}</g>;
+        return <g>{lineSlicesItems.map(i => i)}</g>
     }
 }
 

--- a/packages/line/src/LineSlicesItem.js
+++ b/packages/line/src/LineSlicesItem.js
@@ -50,7 +50,7 @@ const LineSlicesItem = ({ slice, height, width, showTooltip, hideTooltip, isHove
                 onMouseLeave={hideTooltip}
             />
         </g>
-    );
+    )
 }
 
 LineSlicesItem.propTypes = {

--- a/packages/line/src/LineSlicesItem.js
+++ b/packages/line/src/LineSlicesItem.js
@@ -25,41 +25,45 @@ Chip.propTypes = {
     color: PropTypes.string.isRequired,
 }
 
-const LineSlicesItem = ({ slice, height, showTooltip, hideTooltip, isHover }) => (
-    <g transform={`translate(${slice.x}, 0)`}>
-        {isHover && (
-            <line
-                x1={0}
-                x2={0}
-                y1={0}
-                y2={height}
-                stroke="#000"
-                strokeOpacity={0.35}
-                strokeWidth={1}
+const LineSlicesItem = ({ slice, height, width, showTooltip, hideTooltip, isHover, xOffset }) => {
+    return (
+        <g transform={`translate(${slice.x}, 0)`}>
+            {isHover && (
+                <line
+                    x1={0}
+                    x2={0}
+                    y1={0}
+                    y2={height}
+                    stroke="#000"
+                    strokeOpacity={0.35}
+                    strokeWidth={1}
+                />
+            )}
+            <rect
+                x={xOffset}
+                width={width}
+                height={height}
+                fill="#F00"
+                fillOpacity={0}
+                onMouseEnter={showTooltip}
+                onMouseMove={showTooltip}
+                onMouseLeave={hideTooltip}
             />
-        )}
-        <rect
-            x={-20}
-            width={40}
-            height={height}
-            fill="#F00"
-            fillOpacity={0}
-            onMouseEnter={showTooltip}
-            onMouseMove={showTooltip}
-            onMouseLeave={hideTooltip}
-        />
-    </g>
-)
+        </g>
+    );
+}
 
 LineSlicesItem.propTypes = {
     slice: PropTypes.object.isRequired,
     height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
     showTooltip: PropTypes.func.isRequired,
     hideTooltip: PropTypes.func.isRequired,
     isHover: PropTypes.bool.isRequired,
     theme: PropTypes.object.isRequired,
     tooltip: PropTypes.func,
     tooltipFormat: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+    xOffset: PropTypes.number.isRequired,
 }
 
 const enhance = compose(

--- a/packages/line/stories/line.stories.js
+++ b/packages/line/stories/line.stories.js
@@ -510,6 +510,61 @@ stories.add(
 )
 
 stories.add(
+    'unevenly spaced data',
+    withInfo()(() => (
+        <Line
+            {...commonProperties}
+            data={[
+                {
+                    id: 'fake corp. A',
+                    data: [
+                        { x: '2018-01-01T12:04:35', y: 7 },
+                        { x: '2018-01-03T12:04:35', y: 5 },
+                        { x: '2018-01-03T17:04:35', y: 11 },
+                        { x: '2018-01-07T12:04:35', y: 9 },
+                        { x: '2018-01-09T12:04:35', y: 12 },
+                        { x: '2018-01-15T12:04:35', y: 16 },
+                        { x: '2018-01-16T12:04:35', y: 13 },
+                        { x: '2018-01-17T12:04:35', y: 13 },
+                    ],
+                },
+                {
+                    id: 'fake corp. B',
+                    data: [
+                        { x: '2018-01-04T12:04:35', y: 14 },
+                        { x: '2018-01-06T12:04:35', y: 14 },
+                        { x: '2018-01-06T18:04:35', y: 15 },
+                        { x: '2018-01-07T12:04:35', y: 11 },
+                        { x: '2018-01-09T12:04:35', y: 10 },
+                        { x: '2018-01-10T12:04:35', y: 12 },
+                        { x: '2018-01-13T12:04:35', y: 9 },
+                        { x: '2018-01-14T12:04:35', y: 7 },
+                    ],
+                },
+            ]}
+            xScale={{
+                type: 'time',
+                format: '%Y-%m-%dT%H:%M:%S',
+                precision: 'second',
+            }}
+            yScale={{
+                type: 'linear',
+                stacked: boolean('stacked', false),
+            }}
+            axisBottom={{
+                format: '%b %d',
+            }}
+            curve={select('curve', curveOptions, 'linear')}
+            enableDotLabel={true}
+            dotSymbol={CustomSymbol}
+            dotSize={16}
+            dotBorderWidth={1}
+            dotBorderColor="inherit:darker(0.3)"
+        />
+    ))
+)
+
+stories.add(
     'custom min/max y',
     withInfo()(() => (
         <Line

--- a/packages/line/tests/__snapshots__/Line.test.js.snap
+++ b/packages/line/tests/__snapshots__/Line.test.js.snap
@@ -7190,8 +7190,8 @@ exports[`should render a basic line chart 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={67.5}
+            x={-5}
           />
         </g>
         <g
@@ -7204,8 +7204,8 @@ exports[`should render a basic line chart 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={125}
+            x={-62.5}
           />
         </g>
         <g
@@ -7218,8 +7218,8 @@ exports[`should render a basic line chart 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={125}
+            x={-62.5}
           />
         </g>
         <g
@@ -7232,8 +7232,8 @@ exports[`should render a basic line chart 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={125}
+            x={-62.5}
           />
         </g>
         <g
@@ -7246,8 +7246,8 @@ exports[`should render a basic line chart 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={67.5}
+            x={-62.5}
           />
         </g>
       </g>
@@ -8174,8 +8174,8 @@ exports[`should support multiple lines 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={67.5}
+            x={-5}
           />
         </g>
         <g
@@ -8188,8 +8188,8 @@ exports[`should support multiple lines 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={125}
+            x={-62.5}
           />
         </g>
         <g
@@ -8202,8 +8202,8 @@ exports[`should support multiple lines 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={125}
+            x={-62.5}
           />
         </g>
         <g
@@ -8216,8 +8216,8 @@ exports[`should support multiple lines 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={125}
+            x={-62.5}
           />
         </g>
         <g
@@ -8230,8 +8230,8 @@ exports[`should support multiple lines 1`] = `
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
-            width={40}
-            x={-20}
+            width={67.5}
+            x={-62.5}
           />
         </g>
       </g>


### PR DESCRIPTION
The slice width is currently hard coded to be 40px wide. This causes problems when the data on the graph is either closer together than 40px or farther apart than 40px. The slices then either overlap, causing the tooltip position to be off, or are too far apart, causing there to be spaces where the tooltip does not show. This pull request fixes this issue by making the width of the slices variable and determined by the position of the previous data point and the next data point on the graph.

Fixes #229.