### PR TITLE
fix(typescript): Allow axis to be AxisProps or `null`

### DIFF
--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -50,10 +50,10 @@ declare module '@nivo/line' {
 
         theme?: Theme
 
-        axisTop?: AxisProps
-        axisRight?: AxisProps
-        axisBottom?: AxisProps
-        axisLeft?: AxisProps
+        axisTop?: AxisProps | null
+        axisRight?: AxisProps | null
+        axisBottom?: AxisProps | null
+        axisLeft?: AxisProps | null
 
         enableGridX?: boolean
         enableGridY?: boolean

--- a/packages/scatterplot/index.d.ts
+++ b/packages/scatterplot/index.d.ts
@@ -38,10 +38,10 @@ declare module '@nivo/scatterplot' {
 
         margin?: Box
 
-        axisTop?: AxisProps
-        axisRight?: AxisProps
-        axisBottom?: AxisProps
-        axisLeft?: AxisProps
+        axisTop?: AxisProps | null
+        axisRight?: AxisProps | null
+        axisBottom?: AxisProps | null
+        axisLeft?: AxisProps | null
 
         enableGridX?: boolean
         enableGridY?: boolean


### PR DESCRIPTION
Setting an axis to `null` is the only way to disable it, so we have to specify it as an authorised value in the TypeScript definitions.