### PR TITLE
[BarCanvas] Fix tickValues setting in BarCanvas chart

### DIFF
--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -10,13 +10,13 @@ import React, { Component } from 'react'
 import uniqBy from 'lodash/uniqBy'
 import setDisplayName from 'recompose/setDisplayName'
 import {
-    renderAxesToCanvas,
     getRelativeCursor,
     isCursorInRect,
     Container,
     BasicTooltip,
     renderGridLinesToCanvas,
 } from '@nivo/core'
+import { renderAxesToCanvas } from '@nivo/axes'
 import { renderLegendToCanvas } from '@nivo/legends'
 import { generateGroupedBars, generateStackedBars } from './compute'
 import { BarPropTypes } from './props'


### PR DESCRIPTION
Fixes https://github.com/plouc/nivo/issues/419

I tried `tickValues` setting in `ScatterPlotCanvas` chart (as another example of canvas chart) and found that the setting works in there.
I think it's because two canvas chart components use different `renderAxesToCanvas` util func.

 - ScatterPlotCanvas : `renderAxesToCanvas` is come from  `@nivo/axes` -> https://github.com/plouc/nivo/blob/master/packages/scatterplot/src/ScatterPlotCanvas.js#L11
 - BarCanvas : `renderAxesToCanvas` is come from  `@nivo/core` -> https://github.com/plouc/nivo/blob/master/packages/bar/src/BarCanvas.js#L13

As you can see `nivo/core`'s `renderAxesToCanvas` doesn't accept `tickValues` whereas `nivo/axes`'s does. 
 - `nivo/axes/canvas` -> https://github.com/plouc/nivo/blob/master/packages/axes/src/canvas.js#L22
 - `nivo/core/lib/canvas/axes` -> https://github.com/plouc/nivo/blob/master/packages/core/src/lib/canvas/axes.js#L15 

I don't know which one is legacy or deprecated one. Or there must be a reason that there are two `renderAxesToCanvas` in two places `nivo/axes` &  `nivo/core`?

Anyways, #419 is gone with this patch.

####  - Without this patch
<img width="657" alt="screen shot 2019-01-13 at 5 29 14 pm" src="https://user-images.githubusercontent.com/10060731/51083165-cddec380-1758-11e9-8acf-bfe9cd6c1665.png">

####  - With this patch
<img width="640" alt="screen shot 2019-01-13 at 5 28 41 pm" src="https://user-images.githubusercontent.com/10060731/51083166-cf0ff080-1758-11e9-9515-7ddd98e701eb.png">



