### PR TITLE
fix(typescript): Fix TableTooltip and LineComputedSerieDatum-type on line

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -97,7 +97,7 @@ declare module '@nivo/core' {
 
     export interface TableTooltipProps {
         title?: React.ReactNode
-        rows?: React.ReactNode[]
+        rows: React.ReactNode[][]
         theme: Pick<Theme, 'tooltip'>
         renderContent?: () => React.ReactNode
     }

--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -26,15 +26,17 @@ declare module '@nivo/line' {
         [key: string]: any
     }
 
+    export interface LineComputedSerieDatum {
+        position: {
+            x: number
+            y: number
+        }
+        data: LineDatum
+    }
+
     export interface LineComputedSerieData {
         id: string | number
-        data: Array<{
-            position: {
-                x: number
-                y: number
-            }
-            data: LineDatum
-        }>
+        data: LineComputedSerieDatum[]
         color?: string
         [key: string]: any
     }


### PR DESCRIPTION
Slight fix for TableTooltip, sorry about that.

Also, I found `LineComputedSerieDatum` useful exported subtype when creating custom layers upon Line. Basically for when customizing computedData with additional effects.


```jsx
  getCustomLayer = (props: CustomProps) => {
    const { xScale, yScale, computedData } = props;
    const { train, overrides } = this.props;
    const areaGenerator = area<LineComputedSerieDatum>()
      .x(d => xScale(d.data.x))
      .y0(() => yScale(0))
      .y1(d => yScale(d.data.y))
      .curve(curveMonotoneX);
    ...
    return <path
        ...
        d={areaGenerator(data)}
      />;
  };
```


@plouc How accepting would you be of a PR adding `defs` to `Line`?
Line isn't using it directly, but custom layers might, and therefore it would be helpful to add patterns to the main SVG element.

Work-around is to have a seperate svg element with pattern defined in the custom layer itself.