### PR TITLE
Support custom font family setting in canvas charts / axes

### DIFF
--- a/packages/axes/src/canvas.js
+++ b/packages/axes/src/canvas.js
@@ -49,7 +49,8 @@ export const renderAxisToCanvas = (
 
     ctx.textAlign = textAlign
     ctx.textBaseline = textBaseline
-    ctx.font = `${theme.axis.ticks.text.fontSize}px sans-serif`
+    ctx.font = `${theme.axis.ticks.text.fontSize}px ${theme.axis.ticks.text.fontFamily ||
+        'sans-serif'}`
 
     ctx.lineWidth = theme.axis.domain.line.strokeWidth
     ctx.lineCap = 'square'

--- a/packages/circle-packing/src/BubbleCanvas.js
+++ b/packages/circle-packing/src/BubbleCanvas.js
@@ -89,7 +89,8 @@ class BubbleCanvas extends Component {
         if (enableLabel) {
             this.ctx.textAlign = 'center'
             this.ctx.textBaseline = 'middle'
-            this.ctx.font = `${theme.labels.text.fontSize}px sans-serif`
+            this.ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily ||
+                'sans-serif'}`
 
             // draw labels on top
             nodes.filter(({ r }) => r > labelSkipRadius).forEach(node => {

--- a/packages/heatmap/src/HeatMapCanvas.js
+++ b/packages/heatmap/src/HeatMapCanvas.js
@@ -74,9 +74,9 @@ class HeatMapCanvas extends Component {
 
         let renderNode
         if (cellShape === 'rect') {
-            renderNode = partial(renderRect, this.ctx, { enableLabels })
+            renderNode = partial(renderRect, this.ctx, { enableLabels, theme })
         } else {
-            renderNode = partial(renderCircle, this.ctx, { enableLabels })
+            renderNode = partial(renderCircle, this.ctx, { enableLabels, theme })
         }
 
         const nodes = computeNodes(props)

--- a/packages/heatmap/src/canvas.js
+++ b/packages/heatmap/src/canvas.js
@@ -23,7 +23,7 @@
  */
 export const renderRect = (
     ctx,
-    { enableLabels },
+    { enableLabels, theme },
     { x, y, width, height, color, opacity, labelTextColor, value }
 ) => {
     ctx.save()
@@ -34,6 +34,7 @@ export const renderRect = (
 
     if (enableLabels === true) {
         ctx.fillStyle = labelTextColor
+        ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily || 'sans-serif'}`
         ctx.fillText(value, x, y)
     }
 
@@ -56,7 +57,7 @@ export const renderRect = (
  */
 export const renderCircle = (
     ctx,
-    { enableLabels },
+    { enableLabels, theme },
     { x, y, width, height, color, opacity, labelTextColor, value }
 ) => {
     ctx.save()
@@ -71,6 +72,7 @@ export const renderCircle = (
 
     if (enableLabels === true) {
         ctx.fillStyle = labelTextColor
+        ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily || 'sans-serif'}`
         ctx.fillText(value, x, y)
     }
 

--- a/packages/pie/src/canvas.js
+++ b/packages/pie/src/canvas.js
@@ -16,7 +16,7 @@ export const drawSliceLabels = (
 ) => {
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
-    ctx.font = `${theme.labels.text.fontSize}px sans-serif`
+    ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily || 'sans-serif'}`
 
     arcs.filter(arc => skipAngle === 0 || arc.angleDeg > skipAngle).forEach(arc => {
         const [centroidX, centroidY] = arcGenerator.centroid(arc)
@@ -60,7 +60,7 @@ export const drawRadialLabels = (
     })
 
     ctx.textBaseline = 'middle'
-    ctx.font = `${theme.labels.text.fontSize}px sans-serif`
+    ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily || 'sans-serif'}`
 
     radialLabels.forEach(label => {
         const dataWithColor = {

--- a/packages/treemap/src/TreeMapCanvas.js
+++ b/packages/treemap/src/TreeMapCanvas.js
@@ -73,7 +73,8 @@ class TreeMapCanvas extends Component {
         if (enableLabel) {
             this.ctx.textAlign = 'center'
             this.ctx.textBaseline = 'middle'
-            this.ctx.font = `${theme.labels.text.fontSize}px sans-serif`
+            this.ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily ||
+                'sans-serif'}`
 
             // draw labels on top
             nodes.filter(({ label }) => label !== undefined).forEach(node => {


### PR DESCRIPTION
I just saw how it's enabled in Chord Canvas chart https://github.com/plouc/nivo/commit/c4f29c51408b9be6ad513d0eaf9e303ac12a19eb
using `theme`

and applied in several Canvas packages 
 - Canvas/Axes (Ticks)
 - PieCanvas (Label / Radiar)
 - Heatmap (Label)
 - TreeMap (Label)
 - Bubble (Label)

I tried some in storybook (I built it locally)

 - Ticks 
<img width="859" alt="screen shot 2019-01-18 at 6 05 21 pm" src="https://user-images.githubusercontent.com/10060731/51377036-2d6c1300-1b4d-11e9-8284-59b11b5b090e.png">

 - Label in heatmap cells
<img width="915" alt="screen shot 2019-01-18 at 6 04 28 pm" src="https://user-images.githubusercontent.com/10060731/51377033-2cd37c80-1b4d-11e9-90d4-b37433c7bef2.png">
