### PR TITLE
fix(imports): replace root "lodash" package imports with more specific ones

### DIFF
--- a/packages/legends/src/svg/LegendSvgItem.js
+++ b/packages/legends/src/svg/LegendSvgItem.js
@@ -8,7 +8,7 @@
  */
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { isFunction } from 'lodash'
+import isFunction from 'lodash/isFunction'
 import {
     DIRECTION_LEFT_TO_RIGHT,
     DIRECTION_RIGHT_TO_LEFT,

--- a/packages/stream/stories/stream.stories.js
+++ b/packages/stream/stories/stream.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { range, random } from 'lodash'
+import range from 'lodash/range'
+import random from 'lodash/random'
 import { storiesOf } from '@storybook/react'
 import { withKnobs, select } from '@storybook/addon-knobs'
 import { withInfo } from '@storybook/addon-info'


### PR DESCRIPTION
This prevents the whole "lodash" package to be imported in the resulting JavaScript files when using bundlers that don't do advanced tree-shaking.
