### PR TITLE
doc(Bar): Add labelFormat prop to Bar docs

### DIFF
--- a/website/src/components/charts/bar/props.js
+++ b/website/src/components/charts/bar/props.js
@@ -324,6 +324,24 @@ export default [
         controlGroup: 'Labels',
     },
     {
+        key: 'labelFormat',
+        scopes: '*',
+        description: (
+            <span>
+                how to format label,{' '}
+                <a
+                    href="https://github.com/d3/d3-format/blob/master/README.md#format"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    see d3.format() documentation
+                </a>
+                .
+            </span>
+        ),
+        type: '{string|Function}',
+    },
+    {
         key: 'labelSkipWidth',
         scopes: '*',
         description: 'Skip label if bar width is lower than provided value, ignored if 0 (px).',


### PR DESCRIPTION
Added the formatLabel prop to the Bar chart documentation. I was looking for this and didn't notice it in the diverged staked story, and didn't see the prop was an option until I saw the conversation in #64 . Figured this might save someone some time in the future.