### PR TITLE
Fixed the website for internet explorer

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
     "@nivo/treemap": "0.52.1",
     "@nivo/voronoi": "0.52.1",
     "@nivo/waffle": "0.52.1",
+    "babel-polyfill": "^6.26.0",
     "classnames": "2.2.4",
     "d3-scale": "^2.1.2",
     "d3-scale-chromatic": "^1.3.3",

--- a/website/src/index.js
+++ b/website/src/index.js
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import 'babel-polyfill';
+import ' babel-polyfill'
 import './styles/index.css'
 import './polyfills'
 import React, { Component } from 'react'

--- a/website/src/index.js
+++ b/website/src/index.js
@@ -6,6 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+import 'babel-polyfill';
 import './styles/index.css'
 import './polyfills'
 import React, { Component } from 'react'

--- a/website/src/index.js
+++ b/website/src/index.js
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import ' babel-polyfill'
+import 'babel-polyfill'
 import './styles/index.css'
 import './polyfills'
 import React, { Component } from 'react'

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1584,6 +1584,15 @@ babel-plugin-transform-react-remove-prop-types@0.4.18:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.18.tgz#85ff79d66047b34288c6f7cc986b8854ab384f8c"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-jest@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
@@ -7442,6 +7451,11 @@ regenerate-unicode-properties@^7.0.0:
 regenerate@^1.2.1, regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
Fixes: #301 

Babel was transpiling stuff properly, but IE was still lacking basic functions like `Array.prototype.includes` 

The css is still defective but the website is now functional on IE 11 and older browsers.
