### PR TITLE
GH-122: Add new faq when responsive component is not render

### DIFF
--- a/website/src/components/pages/Faq.js
+++ b/website/src/components/pages/Faq.js
@@ -64,6 +64,11 @@ const Faq = () => (
                     </Link>{' '}
                     which are able to handle pretty large ones.
                 </p>
+                <h4>My component isn't rendering</h4>
+                <p>
+                    Check if the parent have a define height, otherwise the responsive component
+                    won't be able to render.
+                </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Currently, there are some cases that the component doesn't render because it finds that the height is 0. You will see an output like

This can be avoided by providing the desire height for the responsive chart