### PR TITLE
Update documentation for legend

### DIFF
--- a/website/src/components/guides/axes/AxesLegend.js
+++ b/website/src/components/guides/axes/AxesLegend.js
@@ -27,7 +27,7 @@ export default class AxesLegend extends Component {
                     <p>
                         Legend position is controlled by two properties, <code>legendPosition</code>{' '}
                         and <code>legendOffset</code>.<code>legendPosition</code> must be one of:{' '}
-                        <code>start</code>, <code>center</code> or <code>end</code>,{' '}
+                        <code>start</code>, <code>middle</code> or <code>end</code>,{' '}
                         <code>legendOffset</code> will affect y position for <strong>top</strong>{' '}
                         and <strong>bottom</strong> axes and x position for <strong>left</strong>{' '}
                         and <strong>right</strong> axes.


### PR DESCRIPTION
The documentation still says `legendPosition must be one of: start, center or end` ([Source](https://nivo.rocks/guides/axes)) so it should be updated too.
This is related to [PR 475](https://github.com/plouc/nivo/pull/475)