### PR TITLE
Update TS declaration for LineSliceDate

### DIFF
--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -40,8 +40,10 @@ declare module '@nivo/line' {
         id: string | number | Date
         x: number
         data: Array<{
-            x?: string | number | Date
-            y?: string | number | Date
+            data: {
+                x?: string | number | Date
+                y?: string | number | Date
+            }
             position: {
                 x: number
                 y: number


### PR DESCRIPTION
Hello! 👋

I noticed the type definition for `LineSliceData` was not matching the actual implementation. Here what I saw in the console:
![Skärmavbild 2019-03-19 kl  10 11 01 fm](https://user-images.githubusercontent.com/587388/54570730-b6130c80-4a33-11e9-84e6-d5bd8189e374.jpg)

Looking at the code also confirmed my suspicions
https://github.com/plouc/nivo/blob/master/packages/line/src/LineSlices.js#L39-L73

It's a quick fix, but do let me know if there's something else