### PR TITLE
Add a minBarLength (Sizing) Option to @nivo/bar

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -117,6 +117,8 @@ declare module '@nivo/bar' {
             legends: Array<{ dataFrom: 'indexes' | 'keys' } & LegendProps>
 
             markers: CartesianMarkerProps[]
+
+            minBarLength: number
         }>
 
     export type Axis = Partial<{

--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -121,7 +121,7 @@ const Bar = props => {
         getColor,
         padding,
         innerPadding,
-        minBarLength
+        minBarLength,
     }
     const result =
         groupMode === 'grouped' ? generateGroupedBars(options) : generateStackedBars(options)

--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -104,6 +104,8 @@ const Bar = props => {
         onMouseEnter,
         onMouseLeave,
 
+        minBarLength,
+
         legends,
     } = props
     const options = {
@@ -119,6 +121,7 @@ const Bar = props => {
         getColor,
         padding,
         innerPadding,
+        minBarLength
     }
     const result =
         groupMode === 'grouped' ? generateGroupedBars(options) : generateStackedBars(options)

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -94,7 +94,7 @@ export const generateVerticalGroupedBars = ({
                 let y = getY(data[index][key])
                 let barHeight = getHeight(data[index][key], y)
 
-                if (minBarLength && minBarLength > 0 && barHeight < minBarLength) {
+                if (minBarLength && minBarLength > 0 && barHeight < minBarLength && 0 !== data[index][key]) {
                     y = height - minBarLength
                     barHeight = minBarLength
                 }
@@ -178,7 +178,7 @@ export const generateHorizontalGroupedBars = ({
                 const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
                 let barWidth = getWidth(data[index][key], x)
 
-                if (minBarLength && minBarLength > 0 && barWidth < minBarLength) {
+                if (minBarLength && minBarLength > 0 && barWidth < minBarLength && 0 !== data[index][key]) {
                     barWidth = minBarLength
                 }
 

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -55,6 +55,7 @@ export const getGroupedScale = (data, keys, _minValue, _maxValue, range) => {
  * @param {Function}       getColor
  * @param {number}         [padding=0]
  * @param {number}         [innerPadding=0]
+ * @param {number}         minBarLength
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
 export const generateVerticalGroupedBars = ({
@@ -69,6 +70,7 @@ export const generateVerticalGroupedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    minBarLength
 }) => {
     const xScale = getIndexedScale(data, getIndex, [0, width], padding)
     const yRange = reverse ? [0, height] : [height, 0]
@@ -89,8 +91,13 @@ export const generateVerticalGroupedBars = ({
         keys.forEach((key, i) => {
             range(xScale.domain().length).forEach(index => {
                 const x = xScale(getIndex(data[index])) + barWidth * i + innerPadding * i
-                const y = getY(data[index][key])
-                const barHeight = getHeight(data[index][key], y)
+                let y = getY(data[index][key])
+                let barHeight = getHeight(data[index][key], y)
+
+                if (minBarLength && minBarLength > 0 && barHeight < minBarLength) {
+                    y = height - minBarLength
+                    barHeight = minBarLength
+                }
 
                 if (barWidth > 0 && barHeight > 0) {
                     const barData = {
@@ -132,6 +139,7 @@ export const generateVerticalGroupedBars = ({
  * @param {Function}       getColor
  * @param {number}         [padding=0]
  * @param {number}         [innerPadding=0]
+ * @param {number}         minBarLength
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
 export const generateHorizontalGroupedBars = ({
@@ -146,6 +154,7 @@ export const generateHorizontalGroupedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    minBarLength
 }) => {
     const xRange = reverse ? [width, 0] : [0, width]
     const xScale = getGroupedScale(data, keys, minValue, maxValue, xRange)
@@ -167,7 +176,11 @@ export const generateHorizontalGroupedBars = ({
             range(yScale.domain().length).forEach(index => {
                 const x = getX(data[index][key])
                 const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
-                const barWidth = getWidth(data[index][key], x)
+                let barWidth = getWidth(data[index][key], x)
+
+                if (minBarLength && minBarLength > 0 && barWidth < minBarLength) {
+                    barWidth = minBarLength
+                }
 
                 if (barWidth > 0) {
                     const barData = {

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -70,7 +70,7 @@ export const generateVerticalGroupedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
-    minBarLength
+    minBarLength,
 }) => {
     const xScale = getIndexedScale(data, getIndex, [0, width], padding)
     const yRange = reverse ? [0, height] : [height, 0]
@@ -94,7 +94,12 @@ export const generateVerticalGroupedBars = ({
                 let y = getY(data[index][key])
                 let barHeight = getHeight(data[index][key], y)
 
-                if (minBarLength && minBarLength > 0 && barHeight < minBarLength && 0 !== data[index][key]) {
+                if (
+                    minBarLength &&
+                    minBarLength > 0 &&
+                    barHeight < minBarLength &&
+                    0 !== data[index][key]
+                ) {
                     y = height - minBarLength
                     barHeight = minBarLength
                 }
@@ -154,7 +159,7 @@ export const generateHorizontalGroupedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
-    minBarLength
+    minBarLength,
 }) => {
     const xRange = reverse ? [width, 0] : [0, width]
     const xScale = getGroupedScale(data, keys, minValue, maxValue, xRange)
@@ -178,7 +183,12 @@ export const generateHorizontalGroupedBars = ({
                 const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
                 let barWidth = getWidth(data[index][key], x)
 
-                if (minBarLength && minBarLength > 0 && barWidth < minBarLength && 0 !== data[index][key]) {
+                if (
+                    minBarLength &&
+                    minBarLength > 0 &&
+                    barWidth < minBarLength &&
+                    0 !== data[index][key]
+                ) {
                     barWidth = minBarLength
                 }
 

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -54,6 +54,7 @@ export const getStackedScale = (data, _minValue, _maxValue, range) => {
  * @param {Function}       getColor
  * @param {number}         [padding=0]
  * @param {number}         [innerPadding=0]
+ * @param {number}         minBarLength
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
 export const generateVerticalStackedBars = ({
@@ -68,6 +69,7 @@ export const generateVerticalStackedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    minBarLength
 }) => {
     const stackedData = stack()
         .keys(keys)
@@ -95,6 +97,18 @@ export const generateVerticalStackedBars = ({
 
                 let y = getY(d)
                 let barHeight = getHeight(d, y)
+
+                //If bar has no data value associated, barData.value will be undefined or 0
+                const doesBarHaveData = d.data[stackedDataItem.key] 
+                //If minBarLength prop is specified, valid data exists for the bar, and it's calculated length is less than the minBarLength specified
+                if ( minBarLength && minBarLength > 0 && doesBarHaveData && barHeight < minBarLength) {
+                    const minY = height - ((stackedDataItem.index + 1) * minBarLength)
+                    if (y > minY) {
+                        y = minY 
+                    }
+                    barHeight = minBarLength
+                }
+
                 if (innerPadding > 0) {
                     y += innerPadding * 0.5
                     barHeight -= innerPadding
@@ -140,6 +154,7 @@ export const generateVerticalStackedBars = ({
  * @param {Function}       getColor
  * @param {number}         [padding=0]
  * @param {number}         [innerPadding=0]
+ * @param {number}         minBarLength
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
 export const generateHorizontalStackedBars = ({
@@ -154,6 +169,7 @@ export const generateHorizontalStackedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    minBarLength
 }) => {
     const stackedData = stack()
         .keys(keys)
@@ -189,6 +205,18 @@ export const generateHorizontalStackedBars = ({
 
                 let x = getX(d)
                 let barWidth = getWidth(d, x)
+
+                //If bar has no data value associated, barData.value will be undefined or 0
+                const doesBarHaveData = barData.value 
+                //If minBarLength prop is specified, valid data exists for the bar, and it's calculated length is less than the minBarLength specified
+                if ( minBarLength && minBarLength > 0 && doesBarHaveData && barWidth < minBarLength) {
+                    const minX = stackedDataItem.index * minBarLength
+                    if (x < minX) {
+                        x = minX
+                    }
+                    barWidth = minBarLength
+                }
+
                 if (innerPadding > 0) {
                     x += innerPadding * 0.5
                     barWidth -= innerPadding

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -90,22 +90,23 @@ export const generateVerticalStackedBars = ({
     }
 
     if (barWidth > 0) {
+        //Array of bar offsets the size of the data, where each item corresponds to the current additional offset of that bar
+        const barOffsets = new Array(data.length).fill(0) 
+
         stackedData.forEach(stackedDataItem => {
             xScale.domain().forEach((index, i) => {
                 const d = stackedDataItem[i]
                 const x = xScale(getIndex(d.data))
 
                 let y = getY(d)
+                let offsetAdjusted = 0
                 let barHeight = getHeight(d, y)
 
-                //If bar has no data value associated, barData.value will be undefined or 0
+                //If bar has no data value associated or that data is zero, don't render the barItem
                 const doesBarHaveData = d.data[stackedDataItem.key]
                 //If minBarLength prop is specified, valid data exists for the bar, and it's calculated length is less than the minBarLength specified
                 if ( minBarLength && minBarLength > 0 && doesBarHaveData && barHeight < minBarLength) {
-                    const minY = height - ((stackedDataItem.index + 1) * minBarLength)
-                    if (y > minY) {
-                        y = minY 
-                    }
+                    offsetAdjusted += minBarLength - barHeight
                     barHeight = minBarLength
                 }
 
@@ -127,12 +128,16 @@ export const generateVerticalStackedBars = ({
                         key: `${stackedDataItem.key}.${index}`,
                         data: barData,
                         x,
-                        y,
+                        //Subtract both the current offset, as well as any offset from the resizing
+                        y: y - offsetAdjusted - barOffsets[i],
                         width: barWidth,
                         height: barHeight,
                         color: getColor(barData),
                     })
                 }
+
+                //Increment that bar's offset (so the next stacked bar item within that bar is offset correctly)
+                barOffsets[i] += offsetAdjusted
             })
         })
     }
@@ -190,6 +195,9 @@ export const generateHorizontalStackedBars = ({
     }
 
     if (barHeight > 0) {
+        //Array of bar offsets the size of the data, where each item corresponds to the current additional offset of that bar
+        const barOffsets = new Array(data.length).fill(0)
+
         stackedData.forEach(stackedDataItem => {
             yScale.domain().forEach((index, i) => {
                 const d = stackedDataItem[i]
@@ -204,16 +212,14 @@ export const generateHorizontalStackedBars = ({
                 }
 
                 let x = getX(d)
+                let offsetAdjusted = 0
                 let barWidth = getWidth(d, x)
 
-                //If bar has no data value associated, barData.value will be undefined or 0, also make sure the data existing for it is not 0
+                //If bar has no data value associated or that data is zero, don't render the barItem
                 const doesBarHaveData = d.data[stackedDataItem.key] 
                 //If minBarLength prop is specified, valid data that is greater than 0 exists for the bar, and it's calculated length is less than the minBarLength specified
                 if ( minBarLength && minBarLength > 0 && doesBarHaveData && barWidth < minBarLength) {
-                    const minX = stackedDataItem.index * minBarLength
-                    if (x < minX) {
-                        x = minX
-                    }
+                    offsetAdjusted += minBarLength - barWidth
                     barWidth = minBarLength
                 }
 
@@ -226,13 +232,16 @@ export const generateHorizontalStackedBars = ({
                     bars.push({
                         key: `${stackedDataItem.key}.${index}`,
                         data: barData,
-                        x,
+                        x: x + barOffsets[i],
                         y,
                         width: barWidth,
                         height: barHeight,
                         color: getColor(barData),
                     })
                 }
+
+                //Increment that bar's offset (so the next stacked bar item within that bar is offset correctly)
+                barOffsets[i] += offsetAdjusted
             })
         })
     }

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -99,7 +99,7 @@ export const generateVerticalStackedBars = ({
                 let barHeight = getHeight(d, y)
 
                 //If bar has no data value associated, barData.value will be undefined or 0
-                const doesBarHaveData = d.data[stackedDataItem.key] 
+                const doesBarHaveData = d.data[stackedDataItem.key]
                 //If minBarLength prop is specified, valid data exists for the bar, and it's calculated length is less than the minBarLength specified
                 if ( minBarLength && minBarLength > 0 && doesBarHaveData && barHeight < minBarLength) {
                     const minY = height - ((stackedDataItem.index + 1) * minBarLength)
@@ -206,9 +206,9 @@ export const generateHorizontalStackedBars = ({
                 let x = getX(d)
                 let barWidth = getWidth(d, x)
 
-                //If bar has no data value associated, barData.value will be undefined or 0
-                const doesBarHaveData = barData.value 
-                //If minBarLength prop is specified, valid data exists for the bar, and it's calculated length is less than the minBarLength specified
+                //If bar has no data value associated, barData.value will be undefined or 0, also make sure the data existing for it is not 0
+                const doesBarHaveData = d.data[stackedDataItem.key] 
+                //If minBarLength prop is specified, valid data that is greater than 0 exists for the bar, and it's calculated length is less than the minBarLength specified
                 if ( minBarLength && minBarLength > 0 && doesBarHaveData && barWidth < minBarLength) {
                     const minX = stackedDataItem.index * minBarLength
                     if (x < minX) {

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -69,7 +69,7 @@ export const generateVerticalStackedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
-    minBarLength
+    minBarLength,
 }) => {
     const stackedData = stack()
         .keys(keys)
@@ -91,7 +91,7 @@ export const generateVerticalStackedBars = ({
 
     if (barWidth > 0) {
         //Array of bar offsets the size of the data, where each item corresponds to the current additional offset of that bar
-        const barOffsets = new Array(data.length).fill(0) 
+        const barOffsets = new Array(data.length).fill(0)
 
         stackedData.forEach(stackedDataItem => {
             xScale.domain().forEach((index, i) => {
@@ -105,7 +105,12 @@ export const generateVerticalStackedBars = ({
                 //If bar has no data value associated or that data is zero, don't render the barItem
                 const doesBarHaveData = d.data[stackedDataItem.key]
                 //If minBarLength prop is specified, valid data exists for the bar, and it's calculated length is less than the minBarLength specified
-                if ( minBarLength && minBarLength > 0 && doesBarHaveData && barHeight < minBarLength) {
+                if (
+                    minBarLength &&
+                    minBarLength > 0 &&
+                    doesBarHaveData &&
+                    barHeight < minBarLength
+                ) {
                     offsetAdjusted += minBarLength - barHeight
                     barHeight = minBarLength
                 }
@@ -174,7 +179,7 @@ export const generateHorizontalStackedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
-    minBarLength
+    minBarLength,
 }) => {
     const stackedData = stack()
         .keys(keys)
@@ -216,9 +221,14 @@ export const generateHorizontalStackedBars = ({
                 let barWidth = getWidth(d, x)
 
                 //If bar has no data value associated or that data is zero, don't render the barItem
-                const doesBarHaveData = d.data[stackedDataItem.key] 
+                const doesBarHaveData = d.data[stackedDataItem.key]
                 //If minBarLength prop is specified, valid data that is greater than 0 exists for the bar, and it's calculated length is less than the minBarLength specified
-                if ( minBarLength && minBarLength > 0 && doesBarHaveData && barWidth < minBarLength) {
+                if (
+                    minBarLength &&
+                    minBarLength > 0 &&
+                    doesBarHaveData &&
+                    barWidth < minBarLength
+                ) {
                     offsetAdjusted += minBarLength - barWidth
                     barWidth = minBarLength
                 }


### PR DESCRIPTION
I've found that when dealing with large data quantities, the d3-scaleLinear function will sometimes return bars that have no width.

An example of this is seen below.

![Screen Shot 2019-03-15 at 13 24 59](https://user-images.githubusercontent.com/17368530/54790813-bc9cb200-4bf4-11e9-9555-d637bbe30073.png)

To fix this, one can set `minBarLength={x}`, where x is a number in order to ensure that all bars width a measureable quantity will render with that min length. If a data value is zero, it will still not render a bar, as expected.

The result of this change with `minBarLength={3}` is below

![Screen Shot 2019-03-15 at 13 25 40](https://user-images.githubusercontent.com/17368530/54790946-2a48de00-4bf5-11e9-8006-813219d6f0bd.png)

Note that this change works for both vertical and horizontal chart orientations. In the case of a horizontal chart, `minBarLength` will apply to each bar's width, whereas in a vertical chart, `minBarLength` will apply to each bar's height

Additionally, this feature will work for both grouped and stacked bars, with an example of this below.

Stacked bar chart w/o `minBarLength`

![Screen Shot 2019-03-15 at 13 25 14](https://user-images.githubusercontent.com/17368530/54791153-e5717700-4bf5-11e9-9e57-bad3982fc181.png)

Stacked bar chart with `minBarLength={3}`

![Screen Shot 2019-03-15 at 13 25 48](https://user-images.githubusercontent.com/17368530/54791163-f7ebb080-4bf5-11e9-9f31-a3c2e06ad563.png)

The one possible edge case where users can run into trouble is if they are using a stackedBarChart with a either an extremely large minBarLength, or many stacked BarItem sections that trigger the minBarLength resize adjustment. This can potentially cause bars to expand past the max size of the chart. I think, however, if developers have this in mind when testing it out, and are reasonable in their `minBarLength` usage, this will be an extremely helpful feature.