### PR TITLE
Add custom tooltips for Chord

### DIFF
--- a/packages/chord/src/Chord.js
+++ b/packages/chord/src/Chord.js
@@ -43,6 +43,8 @@ const Chord = ({
 
     isInteractive,
     tooltipFormat,
+    arcTooltip,
+    ribbonTooltip,
 
     animate,
     motionDamping,
@@ -95,6 +97,7 @@ const Chord = ({
                                         blendMode={ribbonBlendMode}
                                         setCurrent={setCurrentRibbon}
                                         theme={theme}
+                                        ribbonTooltip={ribbonTooltip}
                                         tooltipFormat={tooltipFormat}
                                         showTooltip={showTooltip}
                                         hideTooltip={hideTooltip}
@@ -109,6 +112,7 @@ const Chord = ({
                                     getOpacity={getArcOpacity}
                                     setCurrent={setCurrentArc}
                                     theme={theme}
+                                    arcTooltip={arcTooltip}
                                     tooltipFormat={tooltipFormat}
                                     showTooltip={showTooltip}
                                     hideTooltip={hideTooltip}

--- a/packages/chord/src/ChordArcs.js
+++ b/packages/chord/src/ChordArcs.js
@@ -21,6 +21,7 @@ const ChordArcs = ({
     getOpacity,
     shapeGenerator,
     theme,
+    arcTooltip,
     tooltipFormat,
     setCurrent,
     showTooltip,
@@ -32,16 +33,20 @@ const ChordArcs = ({
     motionStiffness,
 }) => {
     const commonProps = arc => {
-        const arcTooltip = <ChordArcTooltip arc={arc} theme={theme} format={tooltipFormat} />
+        const tooltip = arcTooltip ? (
+            arcTooltip({ arc, theme })
+        ) : (
+            <ChordArcTooltip arc={arc} theme={theme} format={tooltipFormat} />
+        )
 
         return {
             strokeWidth: borderWidth,
             onMouseEnter: e => {
                 setCurrent(arc)
-                showTooltip(arcTooltip, e)
+                showTooltip(tooltip, e)
             },
             onMouseMove: e => {
-                showTooltip(arcTooltip, e)
+                showTooltip(tooltip, e)
             },
             onMouseLeave: () => {
                 setCurrent(null)

--- a/packages/chord/src/ChordRibbonTooltip.js
+++ b/packages/chord/src/ChordRibbonTooltip.js
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import React from 'react'
+import PropTypes from 'prop-types'
+import pure from 'recompose/pure'
+import { Chip, TableTooltip } from '@nivo/core'
+
+const ChordRibbonTooltip = ({ ribbon, theme, format }) => (
+    <TableTooltip
+        theme={theme}
+        rows={[
+            [
+                <Chip key="chip" color={ribbon.source.color} />,
+                <strong key="id">{ribbon.source.id}</strong>,
+                format ? format(ribbon.source.value) : ribbon.source.value,
+            ],
+            [
+                <Chip key="chip" color={ribbon.target.color} />,
+                <strong key="id">{ribbon.target.id}</strong>,
+                format ? format(ribbon.target.value) : ribbon.target.value,
+            ],
+        ]}
+    />
+)
+
+ChordRibbonTooltip.propTypes = {
+    ribbon: PropTypes.object.isRequired,
+    theme: PropTypes.object.isRequired,
+    format: PropTypes.func,
+}
+
+export default pure(ChordRibbonTooltip)

--- a/packages/chord/src/ChordRibbons.js
+++ b/packages/chord/src/ChordRibbons.js
@@ -20,10 +20,9 @@ import {
     getInterpolatedColor,
     blendModePropType,
     midAngle,
-    TableTooltip,
-    Chip,
     motionPropTypes,
 } from '@nivo/core'
+import ChordRibbonTooltip from './ChordRibbonTooltip'
 
 /**
  * Used to get ribbon angles, instead of using source and target arcs,
@@ -93,6 +92,7 @@ const ChordRibbons = ({
     getOpacity,
     blendMode,
     theme,
+    ribbonTooltip,
     tooltipFormat,
     setCurrent,
     showTooltip,
@@ -104,32 +104,20 @@ const ChordRibbons = ({
     motionStiffness,
 }) => {
     const commonProps = ribbon => {
-        const ribbonTooltip = (
-            <TableTooltip
-                theme={theme}
-                rows={[
-                    [
-                        <Chip key="chip" color={ribbon.source.color} />,
-                        <strong key="id">{ribbon.source.id}</strong>,
-                        tooltipFormat ? tooltipFormat(ribbon.source.value) : ribbon.source.value,
-                    ],
-                    [
-                        <Chip key="chip" color={ribbon.target.color} />,
-                        <strong key="id">{ribbon.target.id}</strong>,
-                        tooltipFormat ? tooltipFormat(ribbon.target.value) : ribbon.target.value,
-                    ],
-                ]}
-            />
+        const tooltip = ribbonTooltip ? (
+            ribbonTooltip({ ribbon, theme })
+        ) : (
+            <ChordRibbonTooltip ribbon={ribbon} format={tooltipFormat} theme={theme} />
         )
 
         return {
             strokeWidth: borderWidth,
             onMouseEnter: e => {
                 setCurrent(ribbon)
-                showTooltip(ribbonTooltip, e)
+                showTooltip(tooltip, e)
             },
             onMouseMove: e => {
-                showTooltip(ribbonTooltip, e)
+                showTooltip(tooltip, e)
             },
             onMouseLeave: () => {
                 setCurrent(null)

--- a/packages/chord/stories/chord.stories.js
+++ b/packages/chord/stories/chord.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { generateChordData } from '@nivo/generators'
+import { TableTooltip, BasicTooltip } from '@nivo/core'
 import { Chord } from '../src'
 
 const commonProperties = {
@@ -61,5 +62,40 @@ stories.add('with formatted values', () => (
                 minimumFractionDigits: 2,
             })} ₽`
         }
+    />
+))
+
+stories.add('custom tooltips', () => (
+    <Chord
+        {...commonProperties}
+        {...generateChordData({ size: 5 })}
+        arcTooltip={({ arc, theme }) => (
+            <BasicTooltip
+                id={`Node: ${arc.id}`}
+                value={arc.value}
+                color={arc.color}
+                enableChip={true}
+                theme={theme}
+            />
+        )}
+        ribbonTooltip={({ ribbon, theme }) => (
+            <TableTooltip
+                theme={theme}
+                rows={[
+                    [
+                        <Chip key="chip" color={ribbon.source.color} />,
+                        'Source',
+                        <strong key="id">{ribbon.source.id}</strong>,
+                        format ? format(ribbon.source.value) : ribbon.source.value,
+                    ],
+                    [
+                        <Chip key="chip" color={ribbon.target.color} />,
+                        'Target',
+                        <strong key="id">{ribbon.target.id}</strong>,
+                        format ? format(ribbon.target.value) : ribbon.target.value,
+                    ],
+                ]}
+            />
+        )}
     />
 ))


### PR DESCRIPTION
This PR adds the `arcTooltip` and `ribbonTooltip` properties to the `Chord` chart in the same style as `tooltip` props to other chart types. I could not get the storybook to show the Chord (it only built with 4 component types, instead of all of them...), but I was able to test locally in another project.