### PR TITLE
Minor bug fix for when clicking in canvas margin

### DIFF
--- a/packages/scatterplot/src/ScatterPlotCanvas.js
+++ b/packages/scatterplot/src/ScatterPlotCanvas.js
@@ -119,7 +119,7 @@ class ScatterPlotCanvas extends Component {
 
     handleClick = event => {
         const point = this.getPointForMouseEvent(event)
-        if (point !== undefined) {
+        if (point !== undefined && point !== null) {
             this.props.onClick(point.data, event)
         }
     }


### PR DESCRIPTION
Referencing https://github.com/plouc/nivo/issues/507


An alternative solution would be to check for Truthyness of the point object.
I.E. At line 122
```
if (point) { ...
```

It's unclear to me at this point which is a better solution.