### PR TITLE
Make LineDots datum key more unique

### DIFF
--- a/packages/line/src/LineDots.js
+++ b/packages/line/src/LineDots.js
@@ -40,9 +40,9 @@ const LineDots = ({
             ...acc,
             ...data
                 .filter(datum => datum.position.x !== null && datum.position.y !== null)
-                .map(datum => {
+                .map((datum, datumIdx) => {
                     return {
-                        key: `${id}.${datum.data.x}`,
+                        key: `${datumIdx}.${id}.${datum.data.x}`,
                         x: datum.position.x,
                         y: datum.position.y,
                         datum: datum,


### PR DESCRIPTION
# Problem

React `key` values created by `LineDots` are not unique enough for some `data`.

# Example

```jsx
const data = [{
  data: [
    {
      name: 'Jane',
      x: '2016-07-15'
      y: 'Birthday'
    },
    {
      name: 'Joe',
      x: '2016-07-15'
      y: 'Birthday'
    },
  ],
  id: 'birthday',
}]

const MyLine = ({ data }) => (
  <ResponsiveLine
    axisBottom={{ format: '%Y' }}
    data={data}
    xScale={{
      type: 'time',
      format: '%Y-%m-%d',
      precision: 'day',
    }}
    yScale={{ type: 'point' }}
  />
)
```

If `data` contains two birthdays on the same day (e.g. `2016-07-15`), the `key`s created by the `LineDots` component are not unique and React throws a warning. However these warnings are generated hundreds at a time, and never stop. I have seen upwards of 60,000 identical warnings thrown in matter of minutes.

# Solution

The proposed solution is to add the iteration index from `map` to the `key` value:

```jsx
// before
'birthday.Fri Jul 15 2016 00:00:00 GMT-0400 (Eastern Daylight Time)' 
'birthday.Fri Jul 15 2016 00:00:00 GMT-0400 (Eastern Daylight Time)' 

// after
'0.birthday.Fri Jul 15 2016 00:00:00 GMT-0400 (Eastern Daylight Time)'
'1.birthday.Fri Jul 15 2016 00:00:00 GMT-0400 (Eastern Daylight Time)' 
```