### PR TITLE
Adding a tooltip typing to the LineProps interface (Line/ResponsiveLine)

### DIFF
--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -89,8 +89,8 @@ declare module '@nivo/line' {
             index: number
             serieId: string | number
             serieColor: string
-            x: number
-            y: number
+            x: number | string | Date
+            y: number | string | Date
             color: string
             borderColor: string
             data: {
@@ -98,7 +98,7 @@ declare module '@nivo/line' {
                 x: string | number
                 y: number
                 yStacked: number
-                xFormatted: string
+                xFormatted: string | number
                 yFormatted: string | number
             }
         }

--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -83,6 +83,8 @@ declare module '@nivo/line' {
     export type LineCustomLayer = (props: LineCustomLayerProps) => React.ReactNode
     export type Layer = LineLayerType | LineCustomLayer
 
+    export type TooltipProp = React.StatelessComponent<LineComputedSerieData[]>
+
     export interface LineProps {
         data: LineSerieData[]
 
@@ -137,6 +139,7 @@ declare module '@nivo/line' {
         sliceTooltip?: (data: LineSliceData) => React.ReactNode
 
         tooltipFormat?: TooltipFormatter | string
+        tooltip?: TooltipProp
 
         enableCrosshair?: boolean
         crosshairType?: CrosshairType

--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -83,7 +83,28 @@ declare module '@nivo/line' {
     export type LineCustomLayer = (props: LineCustomLayerProps) => React.ReactNode
     export type Layer = LineLayerType | LineCustomLayer
 
-    export type TooltipProp = React.StatelessComponent<LineComputedSerieData[]>
+    export interface LineTooltipProps {
+        point: {
+            id: string
+            index: number
+            serieId: string | number
+            serieColor: string
+            x: number
+            y: number
+            color: string
+            borderColor: string
+            data: {
+                color: string
+                x: string | number
+                y: number
+                yStacked: number
+                xFormatted: string
+                yFormatted: string | number
+            }
+        }
+    }
+
+    export type TooltipProp = React.FC<LineTooltipProps>
 
     export interface LineProps {
         data: LineSerieData[]


### PR DESCRIPTION
Adding a missing typing for the tooltip on the Line and ResponsiveLine components.

[TS error of the missing property definition](https://i.imgur.com/EuMHjYg.png)