### PR TITLE
Respect useUTC option on x/y scale property

### DIFF
--- a/packages/axes/src/compute.js
+++ b/packages/axes/src/compute.js
@@ -102,7 +102,7 @@ export const getScaleTicks = (scale, spec) => {
                 // UTC is used as it's more predictible
                 // however local time could be used too
                 // let's see how it fits users' requirements
-                const timeType = timeByType[matches[2]][1]
+                const timeType = timeByType[matches[2]][scale.useUTC ? 1 : 0]
                 if (matches[1] === undefined) {
                     return scale.ticks(timeType)
                 }

--- a/packages/axes/tests/compute.test.js
+++ b/packages/axes/tests/compute.test.js
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import { scaleLinear, scaleOrdinal, scalePoint, scaleBand, scaleUtc } from 'd3-scale'
+import { scaleLinear, scaleOrdinal, scalePoint, scaleBand, scaleTime, scaleUtc } from 'd3-scale'
 import { getScaleTicks, computeCartesianTicks } from '../src/compute'
 
 describe('getTicks', () => {
@@ -69,6 +69,29 @@ describe('getTicks', () => {
                 new Date(Date.UTC(2000, 6, 1, 0, 0, 0, 0)),
                 new Date(Date.UTC(2000, 9, 1, 0, 0, 0, 0)),
                 new Date(Date.UTC(2001, 0, 1, 0, 0, 0, 0)),
+            ])
+        })
+
+        it('should support non-UTC dates', () => {
+            const noUtcTimeScale = scaleTime().domain([
+                new Date(2000, 0, 1, 0, 0, 0, 0),
+                new Date(2001, 0, 1, 0, 0, 0, 0),
+            ])
+
+            expect(getScaleTicks(noUtcTimeScale)).toEqual([
+                new Date(2000, 0, 1, 0, 0, 0, 0),
+                new Date(2000, 1, 1, 0, 0, 0, 0),
+                new Date(2000, 2, 1, 0, 0, 0, 0),
+                new Date(2000, 3, 1, 0, 0, 0, 0),
+                new Date(2000, 4, 1, 0, 0, 0, 0),
+                new Date(2000, 5, 1, 0, 0, 0, 0),
+                new Date(2000, 6, 1, 0, 0, 0, 0),
+                new Date(2000, 7, 1, 0, 0, 0, 0),
+                new Date(2000, 8, 1, 0, 0, 0, 0),
+                new Date(2000, 9, 1, 0, 0, 0, 0),
+                new Date(2000, 10, 1, 0, 0, 0, 0),
+                new Date(2000, 11, 1, 0, 0, 0, 0),
+                new Date(2001, 0, 1, 0, 0, 0, 0),
             ])
         })
 
@@ -159,6 +182,8 @@ describe('getTicks', () => {
         intervals.forEach(interval => {
             it(`should support ${interval.interval} interval`, () => {
                 const intervalTimeScale = scaleUtc().domain(interval.domain)
+
+                intervalTimeScale.useUTC = true
 
                 expect(getScaleTicks(intervalTimeScale, `every ${interval.interval}`)).toEqual(
                     interval.expect

--- a/packages/scales/src/timeScale.js
+++ b/packages/scales/src/timeScale.js
@@ -46,6 +46,7 @@ export const timeScale = (
     scale.domain([minValue, maxValue]).range([0, size])
 
     scale.type = 'time'
+    scale.useUTC = useUTC
 
     return scale
 }


### PR DESCRIPTION
If I am to disable UTC for the scale, then I would expect the tick values to also not use UTC. It looks like from the code we always use the UTC helpers when generating tick values. I'm not sure if this is the best way to pass that option from the `scale` package to the `axes` package. So feel free to tell me to do it a different way.

Here is my first CodeSandbox with my simple test case, and you can see the values are incorrect on the ticks. Also the first tick is missing a value. https://codesandbox.io/s/jyz1h

I used `patch-package` to apply the code changes in the PR here, but those weren't respected in CodeSandbox. I have a deployed version here (https://csb-jyz1h-crmzrjqkcn.now.sh/) where you can see the tick values are correct, including the first point.

To view the source for the above, you can go here: https://zeit.co/deployments/csb-jyz1h-crmzrjqkcn.now.sh/source to see that the code is the same as the first CodeSandbox, but the patches are applied.