### PR TITLE
feat(line): add onClick for slices

### DIFF
--- a/packages/line/src/Line.js
+++ b/packages/line/src/Line.js
@@ -204,6 +204,7 @@ const Line = props => {
                 tooltip={sliceTooltip}
                 current={currentSlice}
                 setCurrent={setCurrentSlice}
+                onClick={onClick}
             />
         )
     }

--- a/packages/line/src/Slices.js
+++ b/packages/line/src/Slices.js
@@ -10,7 +10,7 @@ import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import SlicesItem from './SlicesItem'
 
-const Slices = ({ slices, axis, debug, height, tooltip, current, setCurrent }) => {
+const Slices = ({ slices, axis, debug, height, tooltip, current, setCurrent, onClick }) => {
     return slices.map(slice => (
         <SlicesItem
             key={slice.id}
@@ -21,6 +21,7 @@ const Slices = ({ slices, axis, debug, height, tooltip, current, setCurrent }) =
             tooltip={tooltip}
             setCurrent={setCurrent}
             isCurrent={current !== null && current.id === slice.id}
+            onClick={onClick}
         />
     ))
 }
@@ -44,6 +45,7 @@ Slices.propTypes = {
     tooltip: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
     current: PropTypes.object,
     setCurrent: PropTypes.func.isRequired,
+    onClick: PropTypes.func,
 }
 
 export default memo(Slices)

--- a/packages/line/src/SlicesItem.js
+++ b/packages/line/src/SlicesItem.js
@@ -10,7 +10,7 @@ import React, { memo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useTooltip } from '@nivo/tooltip'
 
-const SlicesItem = ({ slice, axis, debug, tooltip, isCurrent, setCurrent }) => {
+const SlicesItem = ({ slice, axis, debug, tooltip, isCurrent, setCurrent, onClick }) => {
     const { showTooltipFromEvent, hideTooltip } = useTooltip()
 
     const handleMouseEnter = useCallback(
@@ -33,6 +33,13 @@ const SlicesItem = ({ slice, axis, debug, tooltip, isCurrent, setCurrent }) => {
         setCurrent(null)
     }, [hideTooltip])
 
+    const handleClick = useCallback(
+        event => {
+            onClick && onClick(slice, event)
+        },
+        [onClick]
+    )
+
     return (
         <rect
             x={slice.x0}
@@ -47,6 +54,7 @@ const SlicesItem = ({ slice, axis, debug, tooltip, isCurrent, setCurrent }) => {
             onMouseEnter={handleMouseEnter}
             onMouseMove={handleMouseMove}
             onMouseLeave={handleMouseLeave}
+            onClick={handleClick}
         />
     )
 }
@@ -59,6 +67,7 @@ SlicesItem.propTypes = {
     tooltip: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     isCurrent: PropTypes.bool.isRequired,
     setCurrent: PropTypes.func.isRequired,
+    onClick: PropTypes.func,
 }
 
 export default memo(SlicesItem)


### PR DESCRIPTION
Add onClick event for slices in Line graph. Actually onClick handler doesn't work with slice tooltip, with this functionallity onClick return the slices object.