### PR TITLE
Legend theme fill color always being overwritten

### DIFF
--- a/packages/legends/src/svg/LegendSvgItem.js
+++ b/packages/legends/src/svg/LegendSvgItem.js
@@ -178,7 +178,7 @@ LegendSvgItem.defaultProps = {
     direction: 'left-to-right',
     justify: false,
 
-    textColor: 'black',
+    textColor: '#333333',
     background: 'transparent',
     opacity: 1,
 

--- a/packages/legends/src/svg/LegendSvgItem.js
+++ b/packages/legends/src/svg/LegendSvgItem.js
@@ -104,6 +104,8 @@ const LegendSvgItem = ({
     } else {
         Symbol = symbolByShape[symbolShape]
     }
+    
+    const themeSettings = { fill: textColor, ...theme.legends.text };
 
     return (
         <g
@@ -137,8 +139,8 @@ const LegendSvgItem = ({
             <text
                 textAnchor={labelAnchor}
                 style={{
-                    ...theme.legends.text,
-                    fill: style.itemTextColor || textColor,
+                    ...themeSettings,
+                    fill: style.itemTextColor || themeSettings.fill,
                     dominantBaseline: labelAlignment,
                     pointerEvents: 'none',
                     userSelect: 'none',


### PR DESCRIPTION
The `textColor` prop has a default value of black which means the `fill` in the style property was always overwriting the `fill` property coming from the theme.