### PR TITLE
Fix domain not in index.d.ts file, even though it is required

### DIFF
--- a/packages/geo/index.d.ts
+++ b/packages/geo/index.d.ts
@@ -97,6 +97,7 @@ declare module '@nivo/geo' {
 
     interface ChoroplethCommonProps extends CommonProps {
         data: any[]
+        domain: number[]
 
         match?: string | DatumMatcher
         label?: string | FeatureAccessor<any, string>


### PR DESCRIPTION
I'm getting an error when running ResponsiveChloropleth when using it without a domain prop. Typescript should have caught this, since it is a required prop, but it didn't because it's not in the index.d.ts file.