### PR TITLE
Fix PropType for Line markers when using dates in the X axis.

### DIFF
--- a/packages/core/src/components/cartesian/markers/CartesianMarkers.js
+++ b/packages/core/src/components/cartesian/markers/CartesianMarkers.js
@@ -34,7 +34,11 @@ CartesianMarkers.propTypes = {
     markers: PropTypes.arrayOf(
         PropTypes.shape({
             axis: PropTypes.oneOf(['x', 'y']).isRequired,
-            value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+            value: PropTypes.oneOfType([
+                PropTypes.number,
+                PropTypes.string,
+                PropTypes.instanceOf(Date),
+            ]).isRequired,
             lineStyle: PropTypes.object,
             textStyle: PropTypes.object,
         })

--- a/packages/core/src/components/cartesian/markers/CartesianMarkersItem.js
+++ b/packages/core/src/components/cartesian/markers/CartesianMarkersItem.js
@@ -238,7 +238,8 @@ CartesianMarkersItem.propTypes = {
 
     axis: PropTypes.oneOf(['x', 'y']).isRequired,
     scale: PropTypes.func.isRequired,
-    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)])
+        .isRequired,
     lineStyle: PropTypes.object,
     textStyle: PropTypes.object,
 

--- a/packages/line/src/props.js
+++ b/packages/line/src/props.js
@@ -92,7 +92,11 @@ const commonPropTypes = {
     markers: PropTypes.arrayOf(
         PropTypes.shape({
             axis: PropTypes.oneOf(['x', 'y']).isRequired,
-            value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)]).isRequired,
+            value: PropTypes.oneOfType([
+                PropTypes.number,
+                PropTypes.string,
+                PropTypes.instanceOf(Date),
+            ]).isRequired,
             style: PropTypes.object,
         })
     ),

--- a/packages/line/src/props.js
+++ b/packages/line/src/props.js
@@ -92,7 +92,7 @@ const commonPropTypes = {
     markers: PropTypes.arrayOf(
         PropTypes.shape({
             axis: PropTypes.oneOf(['x', 'y']).isRequired,
-            value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+            value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)]).isRequired,
             style: PropTypes.object,
         })
     ),


### PR DESCRIPTION
When using a Line chart with time in the X axis, passing a date as a marker's x value works but raises a PropTypes warning. This change allows dates in the markers' values.