### PR TITLE
fix(tooltip): fix tooltip overflow

### DIFF
--- a/packages/core/src/hocs/withContainer.js
+++ b/packages/core/src/hocs/withContainer.js
@@ -50,7 +50,11 @@ const Container = ({
                         <div style={containerStyle} ref={container}>
                             {children}
                             {isTooltipVisible && (
-                                <TooltipWrapper position={tooltipPosition} anchor={tooltipAnchor}>
+                                <TooltipWrapper
+                                    position={tooltipPosition}
+                                    anchor={tooltipAnchor}
+                                    container={container}
+                                >
                                     {tooltipContent}
                                 </TooltipWrapper>
                             )}

--- a/packages/tooltip/src/hooks.js
+++ b/packages/tooltip/src/hooks.js
@@ -13,13 +13,15 @@ export const useTooltipHandlers = container => {
     const [state, setState] = useState({
         isVisible: false,
         content: null,
-        position: {},
+        position: {}, // the coords are absolute
     })
 
     const showTooltipAt = useCallback((content, [x, y], anchor) => {
+        const bounds = container.current.getBoundingClientRect()
+
         setState({
             isVisible: true,
-            position: [x, y],
+            position: [bounds.left + x, bounds.top + y],
             anchor,
             content,
         })
@@ -27,13 +29,9 @@ export const useTooltipHandlers = container => {
 
     const showTooltipFromEvent = useCallback(
         (content, event, anchor) => {
-            const bounds = container.current.getBoundingClientRect()
-            const x = event.clientX - bounds.left
-            const y = event.clientY - bounds.top
-
             setState({
                 isVisible: true,
-                position: [x, y],
+                position: [event.clientX, event.clientY],
                 anchor,
                 content,
             })


### PR DESCRIPTION
Hi!
The purpose of the PR is to avoid that tooltip is not visible when it is out of the browser window.

GIF examples:
<details>
<summary>
Before:
</summary>

![Aug-10-2019 12-13-16](https://user-images.githubusercontent.com/1674582/62818970-4fb89300-bb68-11e9-821d-c1ac71ce4cdf.gif)
</details>

<details>
<summary>
After:
</summary>

![Aug-10-2019 12-09-22](https://user-images.githubusercontent.com/1674582/62818925-d02ac400-bb67-11e9-94f5-3f8bc5b74c0f.gif)
</details>
