### PR TITLE
Adds props an path to choropleth maps

### DIFF
--- a/packages/geo/src/Choropleth.js
+++ b/packages/geo/src/Choropleth.js
@@ -15,9 +15,8 @@ import GeoGraticule from './GeoGraticule'
 import GeoMapFeature from './GeoMapFeature'
 import { useGeoMap, useChoropleth } from './hooks'
 
-const Choropleth = memo(
-    (props) => {
-        const {
+const Choropleth = memo(props => {
+    const {
         width,
         height,
         margin: partialMargin,
@@ -45,112 +44,107 @@ const Choropleth = memo(
         onClick,
         tooltip: Tooltip,
     } = props
-        const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
-        const { graticule, path, getBorderWidth, getBorderColor } = useGeoMap({
-            width,
-            height,
-            projectionType,
-            projectionScale,
-            projectionTranslation,
-            projectionRotation,
-            fillColor: () => {},
-            borderWidth,
-            borderColor,
-        })
-        const { getFillColor, boundFeatures, legendData } = useChoropleth({
-            features,
-            data,
-            match,
-            label,
-            value,
-            valueFormat,
-            colors,
-            unknownColor,
-            domain,
-        })
+    const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
+    const { graticule, path, getBorderWidth, getBorderColor } = useGeoMap({
+        width,
+        height,
+        projectionType,
+        projectionScale,
+        projectionTranslation,
+        projectionRotation,
+        fillColor: () => {},
+        borderWidth,
+        borderColor,
+    })
+    const { getFillColor, boundFeatures, legendData } = useChoropleth({
+        features,
+        data,
+        match,
+        label,
+        value,
+        valueFormat,
+        colors,
+        unknownColor,
+        domain,
+    })
 
-        const theme = useTheme()
+    const theme = useTheme()
 
-        const { showTooltipFromEvent, hideTooltip } = useTooltip()
-        const handleClick = useCallback(
-            (feature, event) => isInteractive && onClick && onClick(feature, event),
-            [isInteractive, onClick]
-        )
-        const handleMouseEnter = useCallback(
-            (feature, event) =>
-                isInteractive &&
-                Tooltip &&
-                showTooltipFromEvent(<Tooltip feature={feature} />, event),
-            [isInteractive, showTooltipFromEvent, Tooltip]
-        )
-        const handleMouseMove = useCallback(
-            (feature, event) =>
-                isInteractive &&
-                Tooltip &&
-                showTooltipFromEvent(<Tooltip feature={feature} />, event),
-            [isInteractive, showTooltipFromEvent, Tooltip]
-        )
-        const handleMouseLeave = useCallback(() => isInteractive && hideTooltip(), [
-            isInteractive,
-            hideTooltip,
-        ])
+    const { showTooltipFromEvent, hideTooltip } = useTooltip()
+    const handleClick = useCallback(
+        (feature, event) => isInteractive && onClick && onClick(feature, event),
+        [isInteractive, onClick]
+    )
+    const handleMouseEnter = useCallback(
+        (feature, event) =>
+            isInteractive && Tooltip && showTooltipFromEvent(<Tooltip feature={feature} />, event),
+        [isInteractive, showTooltipFromEvent, Tooltip]
+    )
+    const handleMouseMove = useCallback(
+        (feature, event) =>
+            isInteractive && Tooltip && showTooltipFromEvent(<Tooltip feature={feature} />, event),
+        [isInteractive, showTooltipFromEvent, Tooltip]
+    )
+    const handleMouseLeave = useCallback(() => isInteractive && hideTooltip(), [
+        isInteractive,
+        hideTooltip,
+    ])
 
-        return (
-            <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
-                {layers.map((layer, i) => {
-                    if (layer === 'graticule') {
-                        if (enableGraticule !== true) return null
+    return (
+        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+            {layers.map((layer, i) => {
+                if (layer === 'graticule') {
+                    if (enableGraticule !== true) return null
 
+                    return (
+                        <GeoGraticule
+                            key="graticule"
+                            path={path}
+                            graticule={graticule}
+                            lineWidth={graticuleLineWidth}
+                            lineColor={graticuleLineColor}
+                        />
+                    )
+                }
+                if (layer === 'features') {
+                    return (
+                        <Fragment key="features">
+                            {boundFeatures.map(feature => (
+                                <GeoMapFeature
+                                    key={feature.id}
+                                    feature={feature}
+                                    path={path}
+                                    fillColor={getFillColor(feature)}
+                                    borderWidth={getBorderWidth(feature)}
+                                    borderColor={getBorderColor(feature)}
+                                    onMouseEnter={handleMouseEnter}
+                                    onMouseMove={handleMouseMove}
+                                    onMouseLeave={handleMouseLeave}
+                                    onClick={handleClick}
+                                />
+                            ))}
+                        </Fragment>
+                    )
+                }
+                if (layer === 'legends') {
+                    return legends.map((legend, i) => {
                         return (
-                            <GeoGraticule
-                                key="graticule"
-                                path={path}
-                                graticule={graticule}
-                                lineWidth={graticuleLineWidth}
-                                lineColor={graticuleLineColor}
+                            <BoxLegendSvg
+                                key={i}
+                                containerWidth={width}
+                                containerHeight={height}
+                                data={legendData}
+                                {...legend}
                             />
                         )
-                    }
-                    if (layer === 'features') {
-                        return (
-                            <Fragment key="features">
-                                {boundFeatures.map(feature => (
-                                    <GeoMapFeature
-                                        key={feature.id}
-                                        feature={feature}
-                                        path={path}
-                                        fillColor={getFillColor(feature)}
-                                        borderWidth={getBorderWidth(feature)}
-                                        borderColor={getBorderColor(feature)}
-                                        onMouseEnter={handleMouseEnter}
-                                        onMouseMove={handleMouseMove}
-                                        onMouseLeave={handleMouseLeave}
-                                        onClick={handleClick}
-                                    />
-                                ))}
-                            </Fragment>
-                        )
-                    }
-                    if (layer === 'legends') {
-                        return legends.map((legend, i) => {
-                            return (
-                                <BoxLegendSvg
-                                    key={i}
-                                    containerWidth={width}
-                                    containerHeight={height}
-                                    data={legendData}
-                                    {...legend}
-                                />
-                            )
-                        })
-                    }
+                    })
+                }
 
-                    return <Fragment key={i}>{layer(props, path)}</Fragment>
-                })}
-            </SvgWrapper>
-        )
-    }
-)
+                return <Fragment key={i}>{layer(props, path)}</Fragment>
+            })}
+        </SvgWrapper>
+    )
+})
 
 Choropleth.displayName = 'Choropleth'
 Choropleth.propTypes = ChoroplethPropTypes

--- a/packages/geo/src/Choropleth.js
+++ b/packages/geo/src/Choropleth.js
@@ -16,7 +16,8 @@ import GeoMapFeature from './GeoMapFeature'
 import { useGeoMap, useChoropleth } from './hooks'
 
 const Choropleth = memo(
-    ({
+    (props) => {
+        const {
         width,
         height,
         margin: partialMargin,
@@ -43,7 +44,7 @@ const Choropleth = memo(
         isInteractive,
         onClick,
         tooltip: Tooltip,
-    }) => {
+    } = props
         const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
         const { graticule, path, getBorderWidth, getBorderColor } = useGeoMap({
             width,
@@ -144,7 +145,7 @@ const Choropleth = memo(
                         })
                     }
 
-                    return <Fragment key={i}>{layer({})}</Fragment>
+                    return <Fragment key={i}>{layer(props, path)}</Fragment>
                 })}
             </SvgWrapper>
         )

--- a/packages/geo/src/GeoMap.js
+++ b/packages/geo/src/GeoMap.js
@@ -107,7 +107,7 @@ const GeoMap = memo(props => {
                     )
                 }
 
-                return <Fragment key={i}>{layer(props)}</Fragment>
+                return <Fragment key={i}>{layer(props, path)}</Fragment>
             })}
         </SvgWrapper>
     )


### PR DESCRIPTION
As written in the docs

> You can also use this to insert extra layers to the chart, this extra layer must be a function which will receive the chart computed data and must return a valid SVG element for the SVG implementation or receive a Canvas 2d context for the canvas one. Custom layers will also receive the computed data/projection.

Nevertheless this is not implemented in choropleth svg map (canvas custom layers is not even impmented). I've went one step further and I'm also passing `path` to the custom layer, to allow for simple rendering of new paths/layers without the need to create new d3 projection & path generator.

Unfortunately the code is not prettified because it was taking really long to clone this project on my workplace wifi.