### PR TITLE
Add numbers to BarChart PropTypes for gridXValues and gridYValues

### DIFF
--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -44,8 +44,14 @@ export const BarPropTypes = {
     axisLeft: axisPropType,
     enableGridX: PropTypes.bool.isRequired,
     enableGridY: PropTypes.bool.isRequired,
-    gridXValues: PropTypes.arrayOf(PropTypes.number),
-    gridYValues: PropTypes.arrayOf(PropTypes.number),
+    gridXValues: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    ]),
+    gridYValues: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    ]),
 
     barComponent: PropTypes.func.isRequired,
 


### PR DESCRIPTION
Adds BarChart PropTypes to match changes made in https://github.com/plouc/nivo/pull/391