### PR TITLE
Adding a ScatterPlotScale interface

### DIFF
--- a/packages/scatterplot/index.d.ts
+++ b/packages/scatterplot/index.d.ts
@@ -113,12 +113,18 @@ declare module '@nivo/scatterplot' {
 
     export type CustomLayerId = 'grid' | 'axes' | 'nodes' | 'markers' | 'mesh' | 'legends'
 
+    export interface ScatterPlotScale {
+        type: 'linear'
+        min?: 'auto' | number
+        max?: 'auto' | number
+    }
+
     export interface ScatterPlotProps {
         data: Serie[]
 
-        xScale?: Scale
+        xScale?: ScatterPlotScale
         xFormat?: string | ValueFormatter
-        yScale?: Scale
+        yScale?: ScatterPlotScale
         yFormat?: string | ValueFormatter
 
         margin?: Box


### PR DESCRIPTION
Adding a wrong typing for the ScatterPlot's scale prop

![image](https://user-images.githubusercontent.com/5884902/63400565-3d174700-c40f-11e9-89dc-973c219d86cd.png)

So, I Added ScatterPlotScale interface and updated ScatterPlotProps interface.

PS)  It's an honor to be able to use this wonderful open source.