### PR TITLE
Add missing pointSymbol prop to line typings

### DIFF
--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -107,6 +107,14 @@ declare module '@nivo/line' {
     }
     export type SliceTooltip = React.FunctionComponent<SliceTooltipProps>
 
+    export interface PointSymbolProps {
+        borderColor: string
+        borderWidth: number
+        color: string
+        datum: Datum
+        size: number
+    }
+
     export interface LineProps {
         data: Serie[]
 
@@ -143,6 +151,7 @@ declare module '@nivo/line' {
         gridYValues?: number | number[] | string[] | Date[]
 
         enablePoints?: boolean
+        pointSymbol?: (props: Readonly<PointSymbolProps>) => React.ReactNode
         pointSize?: number
         pointColor?: any
         pointBorderWidth?: number


### PR DESCRIPTION
The `pointSymbol` is missing in the line typings. Fixes the following error:

<img width="1410" alt="pointSymbol" src="https://user-images.githubusercontent.com/1798949/64456306-96ae8f80-d0f8-11e9-9b27-1c521fb69d0f.png">
