### PR TITLE
feat: add id to symbolShape

### DIFF
--- a/packages/legends/src/svg/LegendSvgItem.js
+++ b/packages/legends/src/svg/LegendSvgItem.js
@@ -124,6 +124,7 @@ const LegendSvgItem = ({
                 onMouseLeave={handleMouseLeave}
             />
             {React.createElement(Symbol, {
+                id: data.id,
                 x: symbolX,
                 y: symbolY,
                 size: style.symbolSize || symbolSize,


### PR DESCRIPTION
This simple modification adds access to the legend id in the symbolShape property. This is useful because it enables the possibility of rendering a custom icon next to each legend, based on the id. It is then possible to implement a toggling button on each legend, which can show and hide part of the data from the graph.