### PR TITLE
Add `useUTC` to types

### DIFF
--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -23,6 +23,7 @@ declare module '@nivo/scales' {
         type: 'time'
         format?: string
         precision?: 'millisecond' | 'second' | 'minute' | 'hour' | 'month' | 'year' | 'day'
+        useUTC: boolean
     }
 
     export interface LogScale {

--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -23,7 +23,7 @@ declare module '@nivo/scales' {
         type: 'time'
         format?: string
         precision?: 'millisecond' | 'second' | 'minute' | 'hour' | 'month' | 'year' | 'day'
-        useUTC: boolean
+        useUTC?: boolean
     }
 
     export interface LogScale {


### PR DESCRIPTION
After some messing around with Nivo and line charts, I had a issue where I discovered the dates I was passing in were being converted to the clients timezone, even though I wasn't supplying a timezone with the date and these dates I was passing in were actually already correct. To get around this we discovered a `useUTC` option which we set to `false`. 

Although it seems like its missing from the types.