### PR TITLE
Added export classes for canvas calendar

### DIFF
--- a/packages/calendar/index.d.ts
+++ b/packages/calendar/index.d.ts
@@ -73,4 +73,6 @@ declare module '@nivo/calendar' {
 
     export class Calendar extends React.Component<CalendarSvgProps & Dimensions> {}
     export class ResponsiveCalendar extends React.Component<CalendarSvgProps> {}
+    export class CalendarCanvas extends React.Component<CalendarSvgProps & Dimensions> {}
+    export class ResponsiveCalendarCanvas extends React.Component<CalendarSvgProps> {}
 }


### PR DESCRIPTION
I have noticed that these classes were never exported and I could not import them in typescript. After adding these 2 lines it was working very well. We had big data to display and with the svg canvas it was very laggy. As soon as I exported these 2 classes, calendar was displayed in canvas and the response speed was amazing!