### PR TITLE
Added custom `colorScale`

### DIFF
--- a/packages/calendar/src/enhance.js
+++ b/packages/calendar/src/enhance.js
@@ -22,15 +22,16 @@ const commonEnhancers = [
     withTheme(),
     withDimensions(),
     withPropsOnChange(
-        ['data', 'minValue', 'maxValue', 'colors'],
-        ({ data, minValue, maxValue, colors }) => {
+        ['data', 'minValue', 'maxValue', 'colors', 'colorScale'],
+        ({ data, minValue, maxValue, colors, colorScale }) => {
+            if (colorScale) return { colorScale }
             const domain = computeDomain(data, minValue, maxValue)
 
-            const colorScale = scaleQuantize()
+            const defaultColorScale = scaleQuantize()
                 .domain(domain)
                 .range(colors)
 
-            return { colorScale }
+            return { colorScale: defaultColorScale }
         }
     ),
     withPropsOnChange(


### PR DESCRIPTION
### NEED HELP 

I needed a custom `color` on the calendar heatmap based on my scale so I added this functionality. I have made it successfully work in my codebase. 
I need more clarity on what needs to be changed and if there's a better way to do this rather than what I have currently done. 

It also needs an update in the documentation.

Resolves #693 

![image](https://user-images.githubusercontent.com/20891087/66475204-7afc2780-eab0-11e9-8396-abb9371e7340.png)

