### PR TITLE
add borderColor type definition for nivo/bar

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -113,6 +113,7 @@ declare module '@nivo/bar' {
         labelTextColor: InheritedColorProp<BarDatumWithColor>
 
         colors: OrdinalColorsInstruction
+        borderColor: InheritedColorProp<BarDatumWithColor>
         borderRadius: number
         borderWidth: number
         theme: Theme


### PR DESCRIPTION
contributes to #197 where borderColor was missing from TypeScript definitions in nivo/bar. From what I could see in the documentation borderColor has the same definitions as labelTextColor so I just simply reused them