### PR TITLE
Adding showEmpty prop

### DIFF
--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -108,6 +108,7 @@ const Bar = props => {
         animate,
         motionStiffness,
         motionDamping,
+        showEmpty
     } = props
     const options = {
         layout,
@@ -122,6 +123,7 @@ const Bar = props => {
         getColor,
         padding,
         innerPadding,
+        showEmpty,
     }
     const result =
         groupMode === 'grouped' ? generateGroupedBars(options) : generateStackedBars(options)

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -69,6 +69,7 @@ export const generateVerticalGroupedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    showEmpty = false,
 }) => {
     const xScale = getIndexedScale(data, getIndex, [0, width], padding)
     const yRange = reverse ? [0, height] : [height, 0]
@@ -92,7 +93,7 @@ export const generateVerticalGroupedBars = ({
                 const y = getY(data[index][key])
                 const barHeight = getHeight(data[index][key], y)
 
-                if (barWidth > 0 && barHeight > 0) {
+                if (showEmpty || (barWidth > 0 && barHeight > 0)) {
                     const barData = {
                         id: key,
                         value: data[index][key],
@@ -132,6 +133,7 @@ export const generateVerticalGroupedBars = ({
  * @param {Function}       getColor
  * @param {number}         [padding=0]
  * @param {number}         [innerPadding=0]
+ * @param {boolean}        [showEmpty=false]
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
 export const generateHorizontalGroupedBars = ({
@@ -146,6 +148,7 @@ export const generateHorizontalGroupedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    showEmpty = false,
 }) => {
     const xRange = reverse ? [width, 0] : [0, width]
     const xScale = getGroupedScale(data, keys, minValue, maxValue, xRange)
@@ -162,14 +165,14 @@ export const generateHorizontalGroupedBars = ({
     }
 
     const bars = []
-    if (barHeight > 0) {
+    if (barHeight > 0 || showEmpty) {
         keys.forEach((key, i) => {
             range(yScale.domain().length).forEach(index => {
                 const x = getX(data[index][key])
                 const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
                 const barWidth = getWidth(data[index][key], x)
 
-                if (barWidth > 0) {
+                if (barWidth > 0 || showEmpty) {
                     const barData = {
                         id: key,
                         value: data[index][key],


### PR DESCRIPTION
Regular Bar component won't display 0 values (or values with a size near to 0), but sometimes, we need to display those values, or at least, the labels/tooltips.

This update allows us to pass the `showEmpty` prop (boolean) so we can force display 0 (or near to 0) values.