### PR TITLE
fix(scales): fix timeScale min/max values and typings

### DIFF
--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -19,11 +19,21 @@ declare module '@nivo/scales' {
         type: 'point'
     }
 
-    export interface TimeScale {
+    export interface TimeScaleFormatted {
         type: 'time'
-        format?: string
+        format: string
         precision?: 'millisecond' | 'second' | 'minute' | 'hour' | 'month' | 'year' | 'day'
         useUTC?: boolean
+        min?: 'auto' | string
+        max?: 'auto' | string
+    }
+
+    export interface TimeScale {
+        type: 'time'
+        precision?: 'millisecond' | 'second' | 'minute' | 'hour' | 'month' | 'year' | 'day'
+        useUTC?: boolean
+        min?: 'auto' | Date
+        max?: 'auto' | Date
     }
 
     export interface LogScale {
@@ -33,7 +43,7 @@ declare module '@nivo/scales' {
         max?: 'auto' | number
     }
 
-    export type Scale = LinearScale | PointScale | TimeScale | LogScale
+    export type Scale = LinearScale | PointScale | TimeScale | TimeScaleFormatted | LogScale
 
     export type ScaleFunc = (value: string | number | Date) => number
 }

--- a/packages/scales/src/timeScale.js
+++ b/packages/scales/src/timeScale.js
@@ -32,14 +32,14 @@ export const timeScale = (
     if (min === 'auto') {
         minValue = values.min
     } else if (format !== 'native') {
-        minValue = normalize(values.min)
+        minValue = normalize(min)
     }
 
     let maxValue = max
     if (max === 'auto') {
         maxValue = values.max
     } else if (format !== 'native') {
-        maxValue = normalize(values.max)
+        maxValue = normalize(max)
     }
 
     const scale = useUTC ? scaleUtc() : scaleTime()


### PR DESCRIPTION
* updated the TypeScript definition to allow for `min` and `max` properties in the `TimeScale`
* updated the implementation to behave correctly with custom `min`/`max` values when the `TimeScale` has `format` property specified. 