### PR TITLE
fix: broken markdown description of the 'labelFormat' property (Fixes #747)

### DIFF
--- a/website/src/data/components/bar/props.js
+++ b/website/src/data/components/bar/props.js
@@ -350,13 +350,7 @@ const props = [
         help: 'How to format labels.',
         description: `
             How to format labels,
-            <a
-                href="https://github.com/d3/d3-format/blob/master/README.md#format"
-                target="_blank"
-                rel="noopener noreferrer"
-            >
-                see d3.format() documentation
-            </a>.
+            [see d3.format() documentation](https://github.com/d3/d3-format/blob/master/README.md#format).
         `,
         type: 'string | Function',
     },


### PR DESCRIPTION
The fix is based on the same field in bubbles which does properly use markdown, this can be found [here](https://github.com/plouc/nivo/blob/52feccbfdf9c65d01238edffe83efa75eb6e248a/website/src/data/components/bubble/props.js#L235).