### PR TITLE
Fix bar legend order

### DIFF
--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -278,6 +278,7 @@ const Bar = props => {
                             from: legend.dataFrom,
                             bars: result.bars,
                             layout,
+                            direction: legend.direction,
                             groupMode,
                             reverse,
                         })

--- a/packages/bar/src/compute/legends.js
+++ b/packages/bar/src/compute/legends.js
@@ -8,7 +8,7 @@
  */
 import { uniqBy } from 'lodash'
 
-export const getLegendDataForKeys = (bars, layout, groupMode, reverse) => {
+export const getLegendDataForKeys = (bars, layout, direction, groupMode, reverse) => {
     const data = uniqBy(
         bars.map(bar => ({
             id: bar.data.id,
@@ -20,7 +20,10 @@ export const getLegendDataForKeys = (bars, layout, groupMode, reverse) => {
     )
 
     if (
-        (layout === 'vertical' && groupMode === 'stacked' && reverse !== true) ||
+        (layout === 'vertical' &&
+            groupMode === 'stacked' &&
+            direction === 'column' &&
+            reverse !== true) ||
         (layout === 'horizontal' && groupMode === 'stacked' && reverse === true)
     ) {
         data.reverse()
@@ -41,10 +44,10 @@ export const getLegendDataForIndexes = bars => {
     )
 }
 
-export const getLegendData = ({ from, bars, layout, groupMode, reverse }) => {
+export const getLegendData = ({ from, bars, layout, direction, groupMode, reverse }) => {
     if (from === 'indexes') {
         return getLegendDataForIndexes(bars)
     }
 
-    return getLegendDataForKeys(bars, layout, groupMode, reverse)
+    return getLegendDataForKeys(bars, layout, direction, groupMode, reverse)
 }


### PR DESCRIPTION
When using the `vertical stacked bar` chart with a `row` legend, the legend order was in reverse. This PR fixes this issue by preventing the legend data to be reversed, when it is in `row` format. 

**Before**
![image](https://user-images.githubusercontent.com/3809419/73002255-07ceb500-3e04-11ea-8f44-b4bd348bf8b8.png)

**After**
![image](https://user-images.githubusercontent.com/3809419/73002078-baeade80-3e03-11ea-9f4c-77ea33ed2791.png)
