### PR TITLE
Add colorBy type declaration in BarProps type

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -48,6 +48,8 @@ declare module '@nivo/bar' {
 
     export type ValueFormatter = (value: number) => string | number
 
+    export type ColorByFunc = (datum: BarDatum) => string | number
+
     export type BarClickHandler = (
         datum: BarExtendedDatum,
         event: React.MouseEvent<HTMLCanvasElement>
@@ -113,6 +115,7 @@ declare module '@nivo/bar' {
         labelTextColor: InheritedColorProp<BarDatumWithColor>
 
         colors: OrdinalColorsInstruction
+        colorBy: string | ColorByFunc
         borderColor: InheritedColorProp<BarDatumWithColor>
         borderRadius: number
         borderWidth: number


### PR DESCRIPTION
`BarProps` type lacks the `colorBy` type definition, the goal of this PR is to add it to allow users to specify a custom value for `colorBy` while using typescript.

Thanks for your time :)