### PR TITLE
add grid{X/Y]Values to ScatterPlot

### DIFF
--- a/packages/scatterplot/src/ScatterPlot.js
+++ b/packages/scatterplot/src/ScatterPlot.js
@@ -45,6 +45,8 @@ const ScatterPlot = props => {
 
         enableGridX,
         enableGridY,
+        gridXValues,
+        gridYValues,
         axisTop,
         axisRight,
         axisBottom,
@@ -110,6 +112,8 @@ const ScatterPlot = props => {
                 height={innerHeight}
                 xScale={enableGridX ? xScale : null}
                 yScale={enableGridY ? yScale : null}
+                xValues={gridXValues}
+                yValues={gridYValues}
             />
         ),
         axes: (


### PR DESCRIPTION
These props are defined here: https://nivo.rocks/scatterplot/
but they're not actually in the ScatterPlot component.