### PR TITLE
fix(bar): add missing grid value types

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -100,7 +100,9 @@ declare module '@nivo/bar' {
         axisTop: Axis | null
 
         enableGridX: boolean
+        gridXValues: Array<number | string>
         enableGridY: boolean
+        gridYValues: Array<number | string>
 
         barComponent: React.StatelessComponent<BarItemProps>
 


### PR DESCRIPTION
Currently the props: gridXValues & gridYValues can't be used in a TypeScript project.
This PR adds them to the type definition.