### PR TITLE
fix(scatterplot): fix no implicit any error on CustomTooltip

### DIFF
--- a/packages/scatterplot/index.d.ts
+++ b/packages/scatterplot/index.d.ts
@@ -84,7 +84,9 @@ declare module '@nivo/scatterplot' {
         sizes: [number, number]
     }
 
-    export type TooltipProps = { node: Node };
+    export interface TooltipProps {
+        node: Node
+    }
     export type CustomTooltip = (props: TooltipProps) => React.ReactNode
 
     type Scale = (value: Value) => number

--- a/packages/scatterplot/index.d.ts
+++ b/packages/scatterplot/index.d.ts
@@ -84,7 +84,8 @@ declare module '@nivo/scatterplot' {
         sizes: [number, number]
     }
 
-    export type CustomTooltip = ({ node: Node }) => React.ReactNode
+    export type TooltipProps = { node: Node };
+    export type CustomTooltip = (props: TooltipProps) => React.ReactNode
 
     type Scale = (value: Value) => number
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "sourceMap": true,
     "jsx": "react",
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noImplicitAny": true
   },
   "include": ["./packages/*/index.d.ts"]
 }


### PR DESCRIPTION
Fix for #856.

The `CustomTooltip` typing from scatterplot was creating an error in Typescript projects with the `noImplicitAny` compiler optoin enabled. This error was because the argument to the `CustomTooltip` lambda wasn't being typed:

```ts
export type CustomTooltip = ({ node: Node }: /* NEEDS TYPING */) => React.ReactNode
```

So the fix is to create a specific `TooltipProps` for the argument and enable `noImplicitAny` across the project to prevent regressions.