### PR TITLE
Radar inner grid

### DIFF
--- a/packages/core/src/theming/defaultTheme.js
+++ b/packages/core/src/theming/defaultTheme.js
@@ -82,6 +82,12 @@ export const defaultTheme = {
             strokeOpacity: 0.75,
             strokeDasharray: '6 6',
         },
+        staticLine: {
+            stroke: '#dddddd',
+            strokeWidth: 1,
+            strokeOpacity: 0.75,
+            strokeDasharray: '6 6',
+        },
     },
     annotations: {
         text: {

--- a/packages/radar/src/Radar.js
+++ b/packages/radar/src/Radar.js
@@ -23,6 +23,7 @@ import RadarGrid from './RadarGrid'
 import RadarTooltip from './RadarTooltip'
 import RadarDots from './RadarDots'
 import { RadarDefaultProps, RadarPropTypes } from './props'
+import RadarInnerGrid from './RadarInnerGrid'
 
 const Radar = memo(
     ({
@@ -56,6 +57,7 @@ const Radar = memo(
         isInteractive,
         tooltipFormat,
         legends,
+        displayInnerGrid,
     }) => {
         const getIndex = useMemo(() => getAccessorFor(indexBy), [indexBy])
         const indices = useMemo(() => data.map(getIndex), [data, getIndex])
@@ -129,6 +131,17 @@ const Radar = memo(
                         fillOpacity={fillOpacity}
                         blendMode={blendMode}
                     />
+                    {displayInnerGrid && (
+                        <RadarInnerGrid
+                            data={data}
+                            keys={keys}
+                            getIndex={getIndex}
+                            colorByKey={colorByKey}
+                            radius={radius}
+                            angleStep={angleStep}
+                            tooltipFormat={tooltipFormat}
+                        />
+                    )}
                     {isInteractive && (
                         <RadarTooltip
                             data={data}

--- a/packages/radar/src/Radar.js
+++ b/packages/radar/src/Radar.js
@@ -134,12 +134,9 @@ const Radar = memo(
                     {displayInnerGrid && (
                         <RadarInnerGrid
                             data={data}
-                            keys={keys}
                             getIndex={getIndex}
-                            colorByKey={colorByKey}
                             radius={radius}
                             angleStep={angleStep}
-                            tooltipFormat={tooltipFormat}
                         />
                     )}
                     {isInteractive && (

--- a/packages/radar/src/RadarInnerGrid.js
+++ b/packages/radar/src/RadarInnerGrid.js
@@ -1,0 +1,57 @@
+import React, { memo } from 'react'
+import PropTypes from 'prop-types'
+import { arc as d3Arc } from 'd3-shape'
+import RadarInnerGridItem from './RadarInnerGridItem'
+
+const RadarInnerGrid = memo(
+    ({ data, keys, getIndex, colorByKey, radius, angleStep, tooltipFormat }) => {
+        const arc = d3Arc()
+            .outerRadius(radius)
+            .innerRadius(0)
+
+        const halfAngleStep = angleStep * 0.5
+        let rootStartAngle = -halfAngleStep
+
+        return (
+            <g>
+                {data.map(d => {
+                    const index = getIndex(d)
+                    const startAngle = rootStartAngle
+                    const endAngle = startAngle + angleStep
+
+                    rootStartAngle += angleStep
+
+                    return (
+                        <RadarInnerGridItem
+                            key={index}
+                            datum={d}
+                            keys={keys}
+                            index={index}
+                            colorByKey={colorByKey}
+                            startAngle={startAngle}
+                            endAngle={endAngle}
+                            radius={radius}
+                            arcGenerator={arc}
+                            tooltipFormat={tooltipFormat}
+                        />
+                    )
+                })}
+            </g>
+        )
+    }
+)
+
+RadarInnerGrid.displayName = 'RadarTooltip'
+RadarInnerGrid.propTypes = {
+    data: PropTypes.array.isRequired,
+    keys: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+    getIndex: PropTypes.func.isRequired,
+    colorByKey: PropTypes.object.isRequired,
+
+    radius: PropTypes.number.isRequired,
+    angleStep: PropTypes.number.isRequired,
+
+    tooltipFormat: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+}
+
+export default RadarInnerGrid

--- a/packages/radar/src/RadarInnerGrid.js
+++ b/packages/radar/src/RadarInnerGrid.js
@@ -3,50 +3,41 @@ import PropTypes from 'prop-types'
 import { arc as d3Arc } from 'd3-shape'
 import RadarInnerGridItem from './RadarInnerGridItem'
 
-const RadarInnerGrid = memo(
-    ({ data, keys, getIndex, colorByKey, radius, angleStep, tooltipFormat }) => {
-        const arc = d3Arc()
-            .outerRadius(radius)
-            .innerRadius(0)
+const RadarInnerGrid = memo(({ data, getIndex, radius, angleStep }) => {
+    const arc = d3Arc()
+        .outerRadius(radius)
+        .innerRadius(0)
 
-        const halfAngleStep = angleStep * 0.5
-        let rootStartAngle = -halfAngleStep
+    const halfAngleStep = angleStep * 0.5
+    let rootStartAngle = -halfAngleStep
 
-        return (
-            <g>
-                {data.map(d => {
-                    const index = getIndex(d)
-                    const startAngle = rootStartAngle
-                    const endAngle = startAngle + angleStep
+    return (
+        <g>
+            {data.map(d => {
+                const index = getIndex(d)
+                const startAngle = rootStartAngle
+                const endAngle = startAngle + angleStep
 
-                    rootStartAngle += angleStep
+                rootStartAngle += angleStep
 
-                    return (
-                        <RadarInnerGridItem
-                            key={index}
-                            datum={d}
-                            keys={keys}
-                            index={index}
-                            colorByKey={colorByKey}
-                            startAngle={startAngle}
-                            endAngle={endAngle}
-                            radius={radius}
-                            arcGenerator={arc}
-                            tooltipFormat={tooltipFormat}
-                        />
-                    )
-                })}
-            </g>
-        )
-    }
-)
+                return (
+                    <RadarInnerGridItem
+                        key={index}
+                        startAngle={startAngle}
+                        endAngle={endAngle}
+                        radius={radius}
+                        arcGenerator={arc}
+                    />
+                )
+            })}
+        </g>
+    )
+})
 
-RadarInnerGrid.displayName = 'RadarTooltip'
+RadarInnerGrid.displayName = 'RadarInnerGrid'
 RadarInnerGrid.propTypes = {
     data: PropTypes.array.isRequired,
-    keys: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
     getIndex: PropTypes.func.isRequired,
-    colorByKey: PropTypes.object.isRequired,
 
     radius: PropTypes.number.isRequired,
     angleStep: PropTypes.number.isRequired,

--- a/packages/radar/src/RadarInnerGridItem.js
+++ b/packages/radar/src/RadarInnerGridItem.js
@@ -6,97 +6,38 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import React, { memo, useMemo, useState, useCallback } from 'react'
+import React, { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
-import sortBy from 'lodash/sortBy'
-import { format as d3Format } from 'd3-format'
 import { positionFromAngle, useTheme } from '@nivo/core'
-import { TableTooltip, Chip, useTooltip } from '@nivo/tooltip'
 
-const RadarInnerGridItem = memo(
-    ({
-        datum,
-        keys,
-        index,
-        colorByKey,
-        radius,
-        startAngle,
-        endAngle,
-        arcGenerator,
-        tooltipFormat,
-    }) => {
-        const [isHover, setIsHover] = useState(false)
-        const theme = useTheme()
-        const { showTooltipFromEvent, hideTooltip } = useTooltip()
-
-        const tooltip = useMemo(() => {
-            const format =
-                !tooltipFormat || typeof tooltipFormat === 'function'
-                    ? tooltipFormat
-                    : d3Format(tooltipFormat)
-
-            return (
-                <TableTooltip
-                    title={<strong>{index}</strong>}
-                    rows={sortBy(
-                        keys.map(key => [
-                            <Chip key={key} color={colorByKey[key]} />,
-                            key,
-                            format ? format(datum[key], key) : datum[key],
-                        ]),
-                        '2'
-                    ).reverse()}
-                    theme={theme}
-                />
-            )
-        }, [datum, keys, index, colorByKey, theme, tooltipFormat])
-        const showItemTooltip = useCallback(
-            event => {
-                setIsHover(true)
-                showTooltipFromEvent(tooltip, event)
-            },
-            [showTooltipFromEvent, tooltip]
+const RadarInnerGridItem = memo(({ radius, startAngle, endAngle, arcGenerator }) => {
+    const theme = useTheme()
+    const { tipX, tipY } = useMemo(() => {
+        const position = positionFromAngle(
+            startAngle + (endAngle - startAngle) * 0.5 - Math.PI / 2,
+            radius
         )
-        const hideItemTooltip = useCallback(() => {
-            setIsHover(false)
-            hideTooltip()
-        }, [hideTooltip, setIsHover])
 
-        const { path, tipX, tipY } = useMemo(() => {
-            const position = positionFromAngle(
-                startAngle + (endAngle - startAngle) * 0.5 - Math.PI / 2,
-                radius
-            )
+        return {
+            tipX: position.x,
+            tipY: position.y,
+        }
+    }, [startAngle, endAngle, radius, arcGenerator])
 
-            return {
-                path: arcGenerator({ startAngle, endAngle }),
-                tipX: position.x,
-                tipY: position.y,
-            }
-        }, [startAngle, endAngle, radius, arcGenerator])
+    return (
+        <>
+            <line x1={0} y1={0} x2={tipX} y2={tipY} style={theme.crosshair.staticLine} />
+        </>
+    )
+})
 
-        return (
-            <>
-                <line x1={0} y1={0} x2={tipX} y2={tipY} style={theme.crosshair.staticLine} />
-            </>
-        )
-    }
-)
-
-RadarInnerGridItem.displayName = 'RadarTooltipItem'
+RadarInnerGridItem.displayName = 'RadarInnerGridItem'
 RadarInnerGridItem.propTypes = {
-    datum: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
-    keys: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
-    index: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    colorByKey: PropTypes.object.isRequired,
-
     startAngle: PropTypes.number.isRequired,
     endAngle: PropTypes.number.isRequired,
     radius: PropTypes.number.isRequired,
 
     arcGenerator: PropTypes.func.isRequired,
-
-    tooltipFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 }
 
 export default RadarInnerGridItem

--- a/packages/radar/src/RadarInnerGridItem.js
+++ b/packages/radar/src/RadarInnerGridItem.js
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import React, { memo, useMemo, useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import sortBy from 'lodash/sortBy'
+import { format as d3Format } from 'd3-format'
+import { positionFromAngle, useTheme } from '@nivo/core'
+import { TableTooltip, Chip, useTooltip } from '@nivo/tooltip'
+
+const RadarInnerGridItem = memo(
+    ({
+        datum,
+        keys,
+        index,
+        colorByKey,
+        radius,
+        startAngle,
+        endAngle,
+        arcGenerator,
+        tooltipFormat,
+    }) => {
+        const [isHover, setIsHover] = useState(false)
+        const theme = useTheme()
+        const { showTooltipFromEvent, hideTooltip } = useTooltip()
+
+        const tooltip = useMemo(() => {
+            const format =
+                !tooltipFormat || typeof tooltipFormat === 'function'
+                    ? tooltipFormat
+                    : d3Format(tooltipFormat)
+
+            return (
+                <TableTooltip
+                    title={<strong>{index}</strong>}
+                    rows={sortBy(
+                        keys.map(key => [
+                            <Chip key={key} color={colorByKey[key]} />,
+                            key,
+                            format ? format(datum[key], key) : datum[key],
+                        ]),
+                        '2'
+                    ).reverse()}
+                    theme={theme}
+                />
+            )
+        }, [datum, keys, index, colorByKey, theme, tooltipFormat])
+        const showItemTooltip = useCallback(
+            event => {
+                setIsHover(true)
+                showTooltipFromEvent(tooltip, event)
+            },
+            [showTooltipFromEvent, tooltip]
+        )
+        const hideItemTooltip = useCallback(() => {
+            setIsHover(false)
+            hideTooltip()
+        }, [hideTooltip, setIsHover])
+
+        const { path, tipX, tipY } = useMemo(() => {
+            const position = positionFromAngle(
+                startAngle + (endAngle - startAngle) * 0.5 - Math.PI / 2,
+                radius
+            )
+
+            return {
+                path: arcGenerator({ startAngle, endAngle }),
+                tipX: position.x,
+                tipY: position.y,
+            }
+        }, [startAngle, endAngle, radius, arcGenerator])
+
+        return (
+            <>
+                <line x1={0} y1={0} x2={tipX} y2={tipY} style={theme.crosshair.staticLine} />
+            </>
+        )
+    }
+)
+
+RadarInnerGridItem.displayName = 'RadarTooltipItem'
+RadarInnerGridItem.propTypes = {
+    datum: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+    keys: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+    index: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    colorByKey: PropTypes.object.isRequired,
+
+    startAngle: PropTypes.number.isRequired,
+    endAngle: PropTypes.number.isRequired,
+    radius: PropTypes.number.isRequired,
+
+    arcGenerator: PropTypes.func.isRequired,
+
+    tooltipFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+}
+
+export default RadarInnerGridItem

--- a/packages/radar/src/props.js
+++ b/packages/radar/src/props.js
@@ -43,6 +43,7 @@ export const RadarPropTypes = {
     blendMode: blendModePropType.isRequired,
 
     isInteractive: PropTypes.bool.isRequired,
+    displayInnerGrid: PropTypes.bool,
     tooltipFormat: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 
     legends: PropTypes.arrayOf(PropTypes.shape(LegendPropShape)).isRequired,
@@ -69,6 +70,7 @@ export const RadarDefaultProps = {
     blendMode: 'normal',
 
     isInteractive: true,
+    displayInnerGrid: false,
 
     legends: [],
 

--- a/packages/radar/stories/radar.stories.js
+++ b/packages/radar/stories/radar.stories.js
@@ -126,3 +126,28 @@ const LabelComponent = ({ id, anchor }) => (
 stories.add('custom label component', () => (
     <Radar {...commonProperties} gridLabel={LabelComponent} />
 ))
+
+const theme = {
+    grid: {
+        line: {
+            stroke: 'rgba(0,212,255,.3)',
+            strokeWidth: 2,
+        },
+    },
+    crosshair: {
+        line: {
+            stroke: 'rgba(0,212,255,1)',
+            strokeWidth: 2,
+            strokeDasharray: '0',
+        },
+        staticLine: {
+            stroke: 'rgba(0,212,255,.3)',
+            strokeWidth: 2,
+            strokeDasharray: '0',
+        },
+    },
+}
+
+stories.add('display inner grid', () => (
+    <Radar {...commonProperties} theme={theme} displayInnerGrid={true} />
+))


### PR DESCRIPTION
On `<Radar />` component using a new property `displayInnerGrid` it shows the inner grid at all times. By overriding the theme property crosshair, can control the color of the static line and the line in hover.
```javascript
 crosshair: {
      line: {
        stroke: "rgba(0,212,255,1)",
        strokeWidth: 2,
        // strokeOpacity: 0.75,
        strokeDasharray: "0"
      },
      staticLine: {
        stroke: "rgba(0,212,255,.3)",
        strokeWidth: 2,
        // strokeOpacity: 0.75,
        strokeDasharray: "0"
      }
    }
```