### PR TITLE
feat(pie): add radialLabelsNoClip flag, minAngle parameter

### DIFF
--- a/packages/pie/src/Pie.js
+++ b/packages/pie/src/Pie.js
@@ -40,6 +40,7 @@ class Pie extends Component {
             startAngle,
             endAngle,
             padAngle,
+            minAngle,
             fit,
             innerRadius,
             cornerRadius,
@@ -105,6 +106,7 @@ class Pie extends Component {
                 endAngle={endAngle}
                 fit={fit}
                 padAngle={padAngle}
+                minAngle={minAngle}
                 innerRadius={innerRadius}
                 cornerRadius={cornerRadius}
                 colors={colors}

--- a/packages/pie/src/Pie.js
+++ b/packages/pie/src/Pie.js
@@ -154,6 +154,7 @@ class Pie extends Component {
                                                 linkOffset={radialLabelsLinkOffset}
                                                 linkDiagonalLength={radialLabelsLinkDiagonalLength}
                                                 noClip={radialLabelsNoClip}
+                                                margin={margin}
                                                 linkHorizontalLength={
                                                     radialLabelsLinkHorizontalLength
                                                 }

--- a/packages/pie/src/Pie.js
+++ b/packages/pie/src/Pie.js
@@ -69,6 +69,7 @@ class Pie extends Component {
             radialLabelsTextXOffset,
             radialLabelsTextColor,
             radialLabelsLinkColor,
+            radialLabelsNoClip,
 
             // slices labels
             enableSlicesLabels,
@@ -152,6 +153,7 @@ class Pie extends Component {
                                                 skipAngle={radialLabelsSkipAngle}
                                                 linkOffset={radialLabelsLinkOffset}
                                                 linkDiagonalLength={radialLabelsLinkDiagonalLength}
+                                                noClip={radialLabelsNoClip}
                                                 linkHorizontalLength={
                                                     radialLabelsLinkHorizontalLength
                                                 }

--- a/packages/pie/src/PieLayout.js
+++ b/packages/pie/src/PieLayout.js
@@ -32,6 +32,7 @@ class PieLayout extends Component {
         startAngle: PropTypes.number.isRequired,
         endAngle: PropTypes.number.isRequired,
         padAngle: PropTypes.number.isRequired,
+        minAngle: PropTypes.number.isRequired,
         arcs: PropTypes.array.isRequired, // computed
         arcGenerator: PropTypes.func.isRequired, // computed
         centerX: PropTypes.number.isRequired, // computed
@@ -92,6 +93,7 @@ export const PieLayoutDefaultProps = {
     endAngle: 360,
     padAngle: 0,
     cornerRadius: 0,
+    minAngle: 0,
 }
 
 export const enhance = Component =>
@@ -160,10 +162,14 @@ export const enhance = Component =>
             }
         ),
         withPropsOnChange(
-            ['sortByValue', 'padAngle', 'startAngle', 'endAngle'],
-            ({ sortByValue, padAngle, startAngle, endAngle }) => {
+            ['data', 'sortByValue', 'padAngle', 'startAngle', 'endAngle', 'minAngle'],
+            ({ data, sortByValue, padAngle, startAngle, endAngle, minAngle }) => {
+                const minValue = minAngle
+                    ? data.reduce((a, b) => a + b.value, 0) / (360 / minAngle)
+                    : 0
+
                 const pie = d3Pie()
-                    .value(d => d.value)
+                    .value(d => Math.max(d.value, minValue))
                     .padAngle(degreesToRadians(padAngle))
                     .startAngle(degreesToRadians(startAngle))
                     .endAngle(degreesToRadians(endAngle))

--- a/packages/pie/src/PieRadialLabels.js
+++ b/packages/pie/src/PieRadialLabels.js
@@ -34,6 +34,7 @@ export default class PieRadialLabels extends Component {
             axis: axisThemePropType.isRequired,
             labels: labelsThemePropType.isRequired,
         }).isRequired,
+        noClip: PropTypes.bool,
     }
 
     static defaultProps = {

--- a/packages/pie/src/PieRadialLabels.js
+++ b/packages/pie/src/PieRadialLabels.js
@@ -59,6 +59,7 @@ export default class PieRadialLabels extends Component {
             textColor,
             linkColor,
             theme,
+            noClip,
         } = this.props
 
         const labels = computeRadialLabels(arcs, {
@@ -69,6 +70,7 @@ export default class PieRadialLabels extends Component {
             linkDiagonalLength,
             linkHorizontalLength,
             textXOffset,
+            noClip,
         })
 
         return labels.map(label => (

--- a/packages/pie/src/PieRadialLabels.js
+++ b/packages/pie/src/PieRadialLabels.js
@@ -35,6 +35,7 @@ export default class PieRadialLabels extends Component {
             labels: labelsThemePropType.isRequired,
         }).isRequired,
         noClip: PropTypes.bool,
+        margin: PropTypes.object.isRequired,
     }
 
     static defaultProps = {
@@ -61,6 +62,7 @@ export default class PieRadialLabels extends Component {
             linkColor,
             theme,
             noClip,
+            margin,
         } = this.props
 
         const labels = computeRadialLabels(arcs, {
@@ -72,6 +74,7 @@ export default class PieRadialLabels extends Component {
             linkHorizontalLength,
             textXOffset,
             noClip,
+            margin,
         })
 
         return labels.map(label => (

--- a/packages/pie/src/compute.js
+++ b/packages/pie/src/compute.js
@@ -25,21 +25,24 @@ export const computeRadialLabels = (
         linkHorizontalLength,
         textXOffset,
         noClip,
+        margin
     }
 ) => {
-
     return arcs
         .filter(arc => skipAngle === 0 || arc.angleDeg > skipAngle)
         .map(arc => {
             const angle = absoluteAngleRadians(midAngle(arc) - Math.PI / 2)
             const pTest = positionFromAngle(angle, radius + linkOffset + linkDiagonalLength)
-            const vis = !noClip || Math.abs(pTest.y) + 5 < radius
-            const horz = linkHorizontalLength * (vis? 1 : 2)
+            const vis = !noClip || Math.abs(pTest.y) + 5 < radius + (pTest.y < 0 ? margin.top : margin.bottom)
+            const horz = linkHorizontalLength * (vis ? 1 : 2)
 
-            const positionA = positionFromAngle(angle, radius + (vis? linkOffset : -radius / 12))
-            const positionB = positionFromAngle(angle, radius + (vis? linkOffset + linkDiagonalLength : -radius / 12))
-            const positionC = {...positionB}
-            const labelPosition = {...positionB}
+            const positionA = positionFromAngle(angle, radius + (vis ? linkOffset : -radius / 12))
+            const positionB = positionFromAngle(
+                angle,
+                radius + (vis ? linkOffset + linkDiagonalLength : -radius / 12)
+            )
+            const positionC = { ...positionB }
+            const labelPosition = { ...positionB }
 
             let textAlign
             const deg = absoluteAngleDegrees(radiansToDegrees(angle))

--- a/packages/pie/src/compute.js
+++ b/packages/pie/src/compute.js
@@ -25,7 +25,7 @@ export const computeRadialLabels = (
         linkHorizontalLength,
         textXOffset,
         noClip,
-        margin
+        margin,
     }
 ) => {
     return arcs
@@ -33,7 +33,9 @@ export const computeRadialLabels = (
         .map(arc => {
             const angle = absoluteAngleRadians(midAngle(arc) - Math.PI / 2)
             const pTest = positionFromAngle(angle, radius + linkOffset + linkDiagonalLength)
-            const vis = !noClip || Math.abs(pTest.y) + 5 < radius + (pTest.y < 0 ? margin.top : margin.bottom)
+            const vis =
+                !noClip ||
+                Math.abs(pTest.y) + 5 < radius + (pTest.y < 0 ? margin.top : margin.bottom)
             const horz = linkHorizontalLength * (vis ? 1 : 2)
 
             const positionA = positionFromAngle(angle, radius + (vis ? linkOffset : -radius / 12))

--- a/packages/pie/src/compute.js
+++ b/packages/pie/src/compute.js
@@ -24,35 +24,32 @@ export const computeRadialLabels = (
         linkDiagonalLength,
         linkHorizontalLength,
         textXOffset,
+        noClip,
     }
-) =>
-    arcs
+) => {
+
+    return arcs
         .filter(arc => skipAngle === 0 || arc.angleDeg > skipAngle)
         .map(arc => {
             const angle = absoluteAngleRadians(midAngle(arc) - Math.PI / 2)
-            const positionA = positionFromAngle(angle, radius + linkOffset)
-            const positionB = positionFromAngle(angle, radius + linkOffset + linkDiagonalLength)
+            const pTest = positionFromAngle(angle, radius + linkOffset + linkDiagonalLength)
+            const vis = !noClip || Math.abs(pTest.y) + 5 < radius
+            const horz = linkHorizontalLength * (vis? 1 : 2)
 
-            let positionC
-            let labelPosition
+            const positionA = positionFromAngle(angle, radius + (vis? linkOffset : -radius / 12))
+            const positionB = positionFromAngle(angle, radius + (vis? linkOffset + linkDiagonalLength : -radius / 12))
+            const positionC = {...positionB}
+            const labelPosition = {...positionB}
+
             let textAlign
-
-            if (
-                absoluteAngleDegrees(radiansToDegrees(angle)) < 90 ||
-                absoluteAngleDegrees(radiansToDegrees(angle)) >= 270
-            ) {
-                positionC = { x: positionB.x + linkHorizontalLength, y: positionB.y }
-                labelPosition = {
-                    x: positionB.x + linkHorizontalLength + textXOffset,
-                    y: positionB.y,
-                }
+            const deg = absoluteAngleDegrees(radiansToDegrees(angle))
+            if (deg < 90 || deg >= 270) {
+                positionC.x += horz
+                labelPosition.x += horz + textXOffset
                 textAlign = 'left'
             } else {
-                positionC = { x: positionB.x - linkHorizontalLength, y: positionB.y }
-                labelPosition = {
-                    x: positionB.x - linkHorizontalLength - textXOffset,
-                    y: positionB.y,
-                }
+                positionC.x -= horz
+                labelPosition.x -= horz + textXOffset
                 textAlign = 'right'
             }
 
@@ -64,3 +61,4 @@ export const computeRadialLabels = (
                 line: [positionA, positionB, positionC],
             }
         })
+}

--- a/packages/pie/src/props.js
+++ b/packages/pie/src/props.js
@@ -36,6 +36,7 @@ export const PiePropTypes = {
     endAngle: PropTypes.number.isRequired,
     fit: PropTypes.bool.isRequired,
     padAngle: PropTypes.number.isRequired,
+    minAngle: PropTypes.number.isRequired,
     sortByValue: PropTypes.bool.isRequired,
     innerRadius: PropTypes.number.isRequired,
     cornerRadius: PropTypes.number.isRequired,


### PR DESCRIPTION
1. add radialLabelsNoClip flag (default false) to prevent clipping at top or bottom. This flag allows to create a pie with no margins at top and bottom, and re-positions clipped radial labels along sides of the pie.
2. add minAngle parameter (default 0) to set minimum angle of any slice.