### PR TITLE
Add support for annotations on scatterplots

### DIFF
--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -23,6 +23,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@nivo/annotations": "0.61.0",
     "@nivo/axes": "0.61.0",
     "@nivo/colors": "0.61.0",
     "@nivo/core": "0.61.0",

--- a/packages/scatterplot/src/ScatterPlot.js
+++ b/packages/scatterplot/src/ScatterPlot.js
@@ -20,6 +20,7 @@ import { BoxLegendSvg } from '@nivo/legends'
 import { useScatterPlot } from './hooks'
 import { ScatterPlotPropTypes, ScatterPlotDefaultProps } from './props'
 import AnimatedNodes from './AnimatedNodes'
+import ScatterPlotAnnotations from './ScatterPlotAnnotations'
 import StaticNodes from './StaticNodes'
 import Mesh from './Mesh'
 
@@ -51,6 +52,8 @@ const ScatterPlot = props => {
         axisRight,
         axisBottom,
         axisLeft,
+
+        annotations,
 
         isInteractive,
         useMesh,
@@ -152,6 +155,16 @@ const ScatterPlot = props => {
             />
         ),
         mesh: null,
+        annotations: (
+            <ScatterPlotAnnotations
+                key="annotations"
+                nodes={nodes}
+                annotations={annotations}
+                innerWidth={innerWidth}
+                innerHeight={innerHeight}
+                animate={animate}
+            />
+        ),
         legends: legends.map((legend, i) => (
             <BoxLegendSvg
                 key={i}

--- a/packages/scatterplot/src/ScatterPlotAnnotations.js
+++ b/packages/scatterplot/src/ScatterPlotAnnotations.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Annotation } from '@nivo/annotations'
+import { useScatterPlotAnnotations } from './hooks'
+
+const ScatterPlotAnnotations = ({ nodes, annotations, innerWidth, innerHeight }) => {
+    const boundAnnotations = useScatterPlotAnnotations(nodes, annotations)
+
+    return boundAnnotations.map((annotation, i) => (
+        <Annotation
+            key={i}
+            {...annotation}
+            containerWidth={innerWidth}
+            containerHeight={innerHeight}
+        />
+    ))
+}
+
+ScatterPlotAnnotations.propTypes = {}
+
+export default ScatterPlotAnnotations

--- a/packages/scatterplot/src/hooks.js
+++ b/packages/scatterplot/src/hooks.js
@@ -10,6 +10,7 @@ import { useMemo } from 'react'
 import { useValueFormatter } from '@nivo/core'
 import { useOrdinalColorScale } from '@nivo/colors'
 import { computeXYScalesForSeries } from '@nivo/scales'
+import { useAnnotations } from '@nivo/annotations'
 import { computePoints, getNodeSizeGenerator } from './compute'
 
 const useNodeSize = size => useMemo(() => getNodeSizeGenerator(size), [size])
@@ -73,3 +74,13 @@ export const useScatterPlot = ({
         legendData,
     }
 }
+
+export const useScatterPlotAnnotations = (items, annotations) =>
+    useAnnotations({
+        items,
+        annotations,
+        getDimensions: (node, offset) => {
+            const size = node.size + offset * 2
+            return { size, width: size, height: size }
+        },
+    })

--- a/packages/scatterplot/src/props.js
+++ b/packages/scatterplot/src/props.js
@@ -12,6 +12,7 @@ import { ordinalColorsPropType } from '@nivo/colors'
 import { axisPropType } from '@nivo/axes'
 import { LegendPropShape } from '@nivo/legends'
 import { scalePropType } from '@nivo/scales'
+import { annotationSpecPropType } from '@nivo/annotations'
 import Node from './Node'
 import Tooltip from './Tooltip'
 
@@ -54,6 +55,8 @@ const commonPropTypes = {
     axisBottom: axisPropType,
     axisLeft: axisPropType,
 
+    annotations: PropTypes.arrayOf(annotationSpecPropType).isRequired,
+
     nodeSize: PropTypes.oneOfType([
         PropTypes.number,
         PropTypes.shape({
@@ -86,7 +89,6 @@ const commonPropTypes = {
     ),
 
     legends: PropTypes.arrayOf(PropTypes.shape(LegendPropShape)).isRequired,
-    annotations: [],
 }
 
 export const ScatterPlotPropTypes = {

--- a/packages/scatterplot/src/props.js
+++ b/packages/scatterplot/src/props.js
@@ -42,7 +42,7 @@ const commonPropTypes = {
 
     layers: PropTypes.arrayOf(
         PropTypes.oneOfType([
-            PropTypes.oneOf(['grid', 'axes', 'nodes', 'markers', 'mesh', 'legends']),
+            PropTypes.oneOf(['grid', 'axes', 'nodes', 'markers', 'mesh', 'legends', 'annotations']),
             PropTypes.func,
         ])
     ).isRequired,
@@ -86,6 +86,7 @@ const commonPropTypes = {
     ),
 
     legends: PropTypes.arrayOf(PropTypes.shape(LegendPropShape)).isRequired,
+    annotations: [],
 }
 
 export const ScatterPlotPropTypes = {
@@ -130,11 +131,13 @@ const commonDefaultProps = {
     markers: [],
 
     legends: [],
+
+    annotations: [],
 }
 
 export const ScatterPlotDefaultProps = {
     ...commonDefaultProps,
-    layers: ['grid', 'axes', 'nodes', 'markers', 'mesh', 'legends'],
+    layers: ['grid', 'axes', 'nodes', 'markers', 'mesh', 'legends', 'annotations'],
     useMesh: true,
     animate: true,
     motionStiffness: 90,
@@ -143,7 +146,7 @@ export const ScatterPlotDefaultProps = {
 
 export const ScatterPlotCanvasDefaultProps = {
     ...commonDefaultProps,
-    layers: ['grid', 'axes', 'nodes', 'mesh', 'legends'],
+    layers: ['grid', 'axes', 'nodes', 'mesh', 'legends', 'annotations'],
     pixelRatio:
         global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
 }

--- a/packages/scatterplot/stories/ScatterPlot.stories.js
+++ b/packages/scatterplot/stories/ScatterPlot.stories.js
@@ -529,7 +529,28 @@ stories.add(
                 max: 10,
             }}
             legends={[]}
-            layers={['grid', 'axes', AreaLayer, 'nodes', 'markers', 'mesh', 'legends']}
+            layers={[
+                'grid',
+                'axes',
+                AreaLayer,
+                'nodes',
+                'markers',
+                'mesh',
+                'legends',
+                'annotations',
+            ]}
+            annotations={[
+                {
+                    type: 'circle',
+                    match: { index: 10 },
+                    noteX: 50,
+                    noteY: 50,
+                    offset: 3,
+                    noteTextOffset: -3,
+                    noteWidth: 10,
+                    note: 'an annotation',
+                },
+            ]}
         />
     ),
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3116,6 +3116,15 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nivo/babel-preset@0.60.0":
+  version "0.60.0"
+  resolved "https://registry.yarnpkg.com/@nivo/babel-preset/-/babel-preset-0.60.0.tgz#dbb12998b19b05ca59910f5e6ed2f75318d67163"
+  integrity sha512-OJVg0cDXbPCHi7wcKQPraLRftZk6r+8yulkU43z0y6vYQ/GGDryBwRXa2R61XY6jEv6ICNdKfguojoJiIrP28w==
+  dependencies:
+    "@babel/plugin-proposal-class-properties" "^7.4.0"
+    "@babel/preset-env" "^7.4.1"
+    babel-plugin-lodash "^3.3.4"
+
 "@nivo/core@0.59.0":
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/@nivo/core/-/core-0.59.0.tgz#3003fab8659786421fddd2a07a4e8f8572dc1a08"
@@ -3134,6 +3143,16 @@
     react-measure "^2.2.4"
     react-motion "^0.5.2"
     recompose "^0.30.0"
+
+"@nivo/generators@0.60.0":
+  version "0.60.0"
+  resolved "https://registry.yarnpkg.com/@nivo/generators/-/generators-0.60.0.tgz#949ac1e1c8640ba98cb6a81a1c28a3f6eb0c6937"
+  integrity sha512-NwRiIbrSsjQi5Ha121TtDL5LGDwzqa05hYD3nU0wrSLdByT2FKAAWz2Bh+96p1XBzXiGjn1bwqcwMa4UxsyZcQ==
+  dependencies:
+    d3-random "^1.1.2"
+    d3-time "^1.0.10"
+    d3-time-format "^2.1.3"
+    lodash "^4.17.11"
 
 "@nivo/tooltip@0.59.0":
   version "0.59.0"


### PR DESCRIPTION
Adds support for putting annotations over a scatterplot. This was mostly taken from the swarmplot implementation.

![nivo_scatterplot_annotation](https://user-images.githubusercontent.com/960264/75378069-0714bd00-58a1-11ea-94d7-cf7861aa0a99.png)

Connects #125.