### PR TITLE
fix(scatterplot): fix serieId typing

### DIFF
--- a/packages/scatterplot/index.d.ts
+++ b/packages/scatterplot/index.d.ts
@@ -41,7 +41,6 @@ declare module '@nivo/scatterplot' {
     export interface Node {
         index: number
         id: string
-        serieId: string
         x: number
         y: number
         size: number
@@ -49,6 +48,7 @@ declare module '@nivo/scatterplot' {
             color: string
         }
         data: {
+            serieId: string
             x: Value
             formattedX: string | number
             y: Value


### PR DESCRIPTION
serieId is a property on `Node.data` not `Node` itself:
From compute.js
```js 
export const computePoints = ({ series, formatX, formatY }) => {
    return series.reduce(
        (agg, serie) => [
            ...,
            ...serie.data.map((d, i) => ({
               ...,
                data: {
                    ...,
                    serieId: serie.id
                },
            })),
        ],
        []
    )
}
```