### PR TITLE
Add closed bracket in gradients example code

### DIFF
--- a/website/src/components/guides/gradients/GradientsExample.js
+++ b/website/src/components/guides/gradients/GradientsExample.js
@@ -37,7 +37,7 @@ const MyChart = () => (
                     { offset: 0, color: '#faf047' },
                     { offset: 100, color: '#e4b400' },
                 ],
-            ,
+            },
         ]}
         // 2. defining rules to apply those gradients
         fill={[


### PR DESCRIPTION
A Closed bracket was missing at the code block in gradients guide.
Please check out [https://nivo.rocks/guides/gradients](https://nivo.rocks/guides/gradients)