### PR TITLE
feat(bar): pass showTooltip and hideTooltip functions to custom layers

### DIFF
--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -318,7 +318,11 @@ const Bar = props => {
                     >
                         {layers.map((layer, i) => {
                             if (typeof layer === 'function') {
-                                return <Fragment key={i}>{layer({ ...props, ...result })}</Fragment>
+                                return (
+                                    <Fragment key={i}>
+                                        {layer({ ...props, ...result, showTooltip, hideTooltip })}
+                                    </Fragment>
+                                )
                             }
                             return layerById[layer]
                         })}


### PR DESCRIPTION
In the same vein as #425, expose `showTooltip`/`hideTooltip` functions to custom layers in the bar chart.

Resolves #914