### PR TITLE
bug(line): add missing layer 'crosshair' to TypeScript definition

### DIFF
--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -49,6 +49,7 @@ declare module '@nivo/line' {
         | 'markers'
         | 'axes'
         | 'areas'
+        | 'crosshair'
         | 'lines'
         | 'slices'
         | 'points'


### PR DESCRIPTION
Resolves #862 