### PR TITLE
fix(types): improve typings for onMouseLeave/Enter in Bar/Pie

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -48,9 +48,10 @@ declare module '@nivo/bar' {
 
     export type ValueFormatter = (value: number) => string | number
 
-    export type BarClickHandler = (
+
+    export type BarMouseEventHandler<T = HTMLCanvasElement> = (
         datum: BarExtendedDatum,
-        event: React.MouseEvent<HTMLCanvasElement>
+        event: React.MouseEvent<T>
     ) => void
 
     export type TooltipProp = React.StatelessComponent<BarExtendedDatum>
@@ -72,7 +73,9 @@ declare module '@nivo/bar' {
         label: string
         shouldRenderLabel: boolean
         labelColor: string
-        onClick: BarClickHandler
+        onClick: BarMouseEventHandler
+        onMouseEnter: BarMouseEventHandler
+        onMouseLeave: BarMouseEventHandler
         tooltipFormat: string | ValueFormatter
         tooltip: TooltipProp
         showTooltip: (tooltip: React.ReactNode, event: React.MouseEvent<HTMLCanvasElement>) => void
@@ -156,7 +159,9 @@ declare module '@nivo/bar' {
         SvgDefsAndFill<BarDatum> &
         Partial<{
             layers: Layer[]
-            onClick: (datum: BarExtendedDatum, event: React.MouseEvent<SVGRectElement>) => void
+            onClick: BarMouseEventHandler<SVGRectElement>
+            onMouseEnter: BarMouseEventHandler<SVGRectElement>
+            onMouseLeave: BarMouseEventHandler<SVGRectElement>
         }>
 
     export class Bar extends React.Component<BarSvgProps & Dimensions> {}
@@ -165,7 +170,9 @@ declare module '@nivo/bar' {
     export type BarCanvasProps = Data &
         BarProps &
         Partial<{
-            onClick: BarClickHandler
+            onClick: BarMouseEventHandler
+            onMouseEnter: BarMouseEventHandler
+            onMouseLeave: BarMouseEventHandler
             pixelRatio: number
         }>
 

--- a/packages/pie/index.d.ts
+++ b/packages/pie/index.d.ts
@@ -18,6 +18,11 @@ declare module '@nivo/pie' {
 
     export type ValueFormatter = (value: number) => string | number
 
+    export type PieMouseEventHandler<T = HTMLCanvasElement> = (
+        datum: PieDatum,
+        event: React.MouseEvent<T>
+    ) => void
+
     export interface Data {
         data: PieDatum[]
     }
@@ -60,14 +65,20 @@ declare module '@nivo/pie' {
 
             // interactivity
             isInteractive: boolean
-            onClick: (datum: PieDatum, event: React.MouseEvent<SVGPathElement>) => void
             tooltipFormat: string | ValueFormatter
             tooltip: React.StatelessComponent<PieDatumWithColor>
 
             legends: LegendProps[]
         }>
 
-    export type PieSvgProps = Data & CommonPieProps & SvgDefsAndFill<PieDatum>
+    export type PieSvgProps = Data &
+        CommonPieProps &
+        SvgDefsAndFill<PieDatum> &
+        Partial<{
+            onClick: PieMouseEventHandler<SVGPathElement>
+            onMouseEnter: PieMouseEventHandler<SVGPathElement>
+            onMouseLeave: PieMouseEventHandler<SVGPathElement>
+        }>
 
     export class Pie extends React.Component<PieSvgProps & Dimensions> {}
     export class ResponsivePie extends React.Component<PieSvgProps> {}
@@ -76,6 +87,9 @@ declare module '@nivo/pie' {
         CommonPieProps &
         Partial<{
             pixelRatio: number
+            onClick: PieMouseEventHandler
+            onMouseEnter: PieMouseEventHandler
+            onMouseLeave: PieMouseEventHandler
         }>
 
     export class PieCanvas extends React.Component<PieCanvasProps & Dimensions> {}


### PR DESCRIPTION
Supersedes https://github.com/plouc/nivo/pull/868, covers for some of https://github.com/plouc/nivo/pull/280 (Bar & Pie, not ScatterPlot)