### PR TITLE
fix(legends): Respect theme fill color

### DIFF
--- a/packages/legends/src/svg/LegendSvgItem.js
+++ b/packages/legends/src/svg/LegendSvgItem.js
@@ -139,7 +139,7 @@ const LegendSvgItem = ({
                 textAnchor={labelAnchor}
                 style={{
                     ...theme.legends.text,
-                    fill: style.itemTextColor || textColor,
+                    fill: style.itemTextColor || theme.legends.text.fill || textColor,
                     dominantBaseline: labelAlignment,
                     pointerEvents: 'none',
                     userSelect: 'none',


### PR DESCRIPTION
This fixes #814 - or so I hope

The fill color of the legend text is currently not themeable
because the fill from the theme is always overwritten by either
the style from the local component state (my understanding is
that this style is from mouse hover effects) or the value of
the `textColor` prop which defaults to `black`.

This line would still allow the local state to take precendence,
but would then pick the theme's legend text fill color as a backup
and only then resort to the `textColor` props.

Disclaimer: This is the first time ever I look at the Nivo code
so there might be more subtle things that I'm overlooking.