### PR TITLE
feat(calendar): add monthSpacing prop

### DIFF
--- a/packages/calendar/index.d.ts
+++ b/packages/calendar/index.d.ts
@@ -46,6 +46,7 @@ declare module '@nivo/calendar' {
         yearLegendOffset: number
 
         monthLegend: (year: number, month: number, date: Date) => string | number
+        monthSpacing: number
         monthBorderWidth: number
         monthBorderColor: string
         monthLegendOffset: number

--- a/packages/calendar/src/compute.js
+++ b/packages/calendar/src/compute.js
@@ -37,6 +37,7 @@ export const computeDomain = (data, minSpec, maxSpec) => {
  * @param {number} direction
  * @param {array}  yearRange
  * @param {number} yearSpacing
+ * @param {number} monthSpacing
  * @param {number} daySpacing
  * @param {number} maxWeeks
  * @returns {number}
@@ -47,6 +48,7 @@ const computeCellSize = ({
     direction,
     yearRange,
     yearSpacing,
+    monthSpacing,
     daySpacing,
     maxWeeks,
 }) => {
@@ -54,7 +56,7 @@ const computeCellSize = ({
     let vCellSize
 
     if (direction === 'horizontal') {
-        hCellSize = (width - daySpacing * maxWeeks) / maxWeeks
+        hCellSize = (width - monthSpacing * 12 - daySpacing * maxWeeks) / maxWeeks
         vCellSize =
             (height - (yearRange.length - 1) * yearSpacing - yearRange.length * (8 * daySpacing)) /
             (yearRange.length * 7)
@@ -62,7 +64,7 @@ const computeCellSize = ({
         hCellSize =
             (width - (yearRange.length - 1) * yearSpacing - yearRange.length * (8 * daySpacing)) /
             (yearRange.length * 7)
-        vCellSize = (height - daySpacing * maxWeeks) / maxWeeks
+        vCellSize = (height - monthSpacing * 12 - daySpacing * maxWeeks) / maxWeeks
     }
 
     return Math.min(hCellSize, vCellSize)
@@ -75,6 +77,7 @@ const computeCellSize = ({
  * @param {number} cellSize
  * @param {number} yearIndex
  * @param {number} yearSpacing
+ * @param {number} monthSpacing
  * @param {number} daySpacing
  * @param {string} direction
  * @param {number} originX
@@ -86,6 +89,7 @@ const monthPathAndBBox = ({
     cellSize,
     yearIndex,
     yearSpacing,
+    monthSpacing,
     daySpacing,
     direction,
     originX,
@@ -100,13 +104,16 @@ const monthPathAndBBox = ({
     const firstDay = date.getDay()
     const lastDay = t1.getDay()
 
-    // offset according to year index
+    // offset according to year index and month
     let xO = originX
     let yO = originY
     const yearOffset = yearIndex * (7 * (cellSize + daySpacing) + yearSpacing)
+    const monthOffset = date.getMonth() * monthSpacing
     if (direction === 'horizontal') {
         yO += yearOffset
+        xO += monthOffset
     } else {
+        yO += monthOffset
         xO += yearOffset
     }
 
@@ -150,8 +157,18 @@ const monthPathAndBBox = ({
  */
 const memoMonthPathAndBBox = memoize(
     monthPathAndBBox,
-    ({ date, cellSize, yearIndex, yearSpacing, daySpacing, direction, originX, originY }) => {
-        return `${date.toString()}.${cellSize}.${yearIndex}.${yearSpacing}.${daySpacing}.${direction}.${originX}.${originY}`
+    ({
+        date,
+        cellSize,
+        yearIndex,
+        yearSpacing,
+        monthSpacing,
+        daySpacing,
+        direction,
+        originX,
+        originY,
+    }) => {
+        return `${date.toString()}.${cellSize}.${yearIndex}.${yearSpacing}.${monthSpacing}.${daySpacing}.${direction}.${originX}.${originY}`
     }
 )
 
@@ -160,15 +177,20 @@ const memoMonthPathAndBBox = memoize(
  *
  * @param {number} cellSize
  * @param {number} yearSpacing
+ * @param {number} monthSpacing
  * @param {number} daySpacing
  * @returns { function(): { x: number, y: number } }
  */
-const cellPositionHorizontal = (cellSize, yearSpacing, daySpacing) => {
+const cellPositionHorizontal = (cellSize, yearSpacing, monthSpacing, daySpacing) => {
     return (originX, originY, d, yearIndex) => {
         const weekOfYear = timeWeek.count(timeYear(d), d)
 
         return {
-            x: originX + weekOfYear * (cellSize + daySpacing) + daySpacing / 2,
+            x:
+                originX +
+                weekOfYear * (cellSize + daySpacing) +
+                daySpacing / 2 +
+                d.getMonth() * monthSpacing,
             y:
                 originY +
                 d.getDay() * (cellSize + daySpacing) +
@@ -183,10 +205,11 @@ const cellPositionHorizontal = (cellSize, yearSpacing, daySpacing) => {
  *
  * @param {number} cellSize
  * @param {number} yearSpacing
+ * @param {number} monthSpacing
  * @param {number} daySpacing
  * @returns { function(): { x: number, y: number } }
  */
-const cellPositionVertical = (cellSize, yearSpacing, daySpacing) => {
+const cellPositionVertical = (cellSize, yearSpacing, monthSpacing, daySpacing) => {
     return (originX, originY, d, yearIndex) => {
         const weekOfYear = timeWeek.count(timeYear(d), d)
 
@@ -196,7 +219,11 @@ const cellPositionVertical = (cellSize, yearSpacing, daySpacing) => {
                 d.getDay() * (cellSize + daySpacing) +
                 daySpacing / 2 +
                 yearIndex * (yearSpacing + 7 * (cellSize + daySpacing)),
-            y: originY + weekOfYear * (cellSize + daySpacing) + daySpacing / 2,
+            y:
+                originY +
+                weekOfYear * (cellSize + daySpacing) +
+                daySpacing / 2 +
+                d.getMonth() * monthSpacing,
         }
     }
 }
@@ -213,6 +240,7 @@ const dayFormat = timeFormat('%Y-%m-%d')
  * @param {string|Date} to
  * @param {string}      direction
  * @param {number}      yearSpacing
+ * @param {number}      monthSpacing
  * @param {number}      daySpacing
  * @param {string}      align
  * @returns {object}
@@ -224,6 +252,7 @@ export const computeLayout = ({
     to,
     direction,
     yearSpacing,
+    monthSpacing,
     daySpacing,
     align,
 }) => {
@@ -244,11 +273,12 @@ export const computeLayout = ({
         direction,
         yearRange,
         yearSpacing,
+        monthSpacing,
         daySpacing,
         maxWeeks,
     })
 
-    const monthsSize = cellSize * maxWeeks + daySpacing * maxWeeks
+    const monthsSize = cellSize * maxWeeks + daySpacing * maxWeeks + monthSpacing * 12
     const yearsSize =
         (cellSize + daySpacing) * 7 * yearRange.length + yearSpacing * (yearRange.length - 1)
 
@@ -272,9 +302,9 @@ export const computeLayout = ({
 
     let cellPosition
     if (direction === 'horizontal') {
-        cellPosition = cellPositionHorizontal(cellSize, yearSpacing, daySpacing)
+        cellPosition = cellPositionHorizontal(cellSize, yearSpacing, monthSpacing, daySpacing)
     } else {
-        cellPosition = cellPositionVertical(cellSize, yearSpacing, daySpacing)
+        cellPosition = cellPositionVertical(cellSize, yearSpacing, monthSpacing, daySpacing)
     }
 
     let years = []
@@ -307,6 +337,7 @@ export const computeLayout = ({
                 direction,
                 yearIndex: i,
                 yearSpacing,
+                monthSpacing,
                 daySpacing,
                 cellSize,
             }),

--- a/packages/calendar/src/enhance.js
+++ b/packages/calendar/src/enhance.js
@@ -35,8 +35,18 @@ const commonEnhancers = [
         }
     ),
     withPropsOnChange(
-        ['width', 'height', 'from', 'to', 'direction', 'yearSpacing', 'daySpacing', 'align'],
-        ({ width, height, from, to, direction, yearSpacing, daySpacing, align }) => {
+        [
+            'width',
+            'height',
+            'from',
+            'to',
+            'direction',
+            'yearSpacing',
+            'monthSpacing',
+            'daySpacing',
+            'align',
+        ],
+        ({ width, height, from, to, direction, yearSpacing, monthSpacing, daySpacing, align }) => {
             return computeLayout({
                 width,
                 height,
@@ -44,6 +54,7 @@ const commonEnhancers = [
                 to,
                 direction,
                 yearSpacing,
+                monthSpacing,
                 daySpacing,
                 align,
             })

--- a/packages/calendar/src/props.js
+++ b/packages/calendar/src/props.js
@@ -46,6 +46,7 @@ const commonPropTypes = {
     monthBorderWidth: PropTypes.number.isRequired,
     monthBorderColor: PropTypes.string.isRequired,
     monthLegend: PropTypes.func.isRequired,
+    monthSpacing: PropTypes.number.isRequired,
     monthLegendPosition: PropTypes.oneOf(['before', 'after']).isRequired,
     monthLegendOffset: PropTypes.number.isRequired,
 
@@ -90,6 +91,7 @@ const commonDefaultProps = {
 
     monthBorderWidth: 2,
     monthBorderColor: '#000',
+    monthSpacing: 0,
     monthLegend: (year, month, date) => monthLabelFormat(date),
     monthLegendPosition: 'before',
     monthLegendOffset: 10,

--- a/packages/calendar/stories/calendar.stories.js
+++ b/packages/calendar/stories/calendar.stories.js
@@ -68,3 +68,5 @@ stories.add('custom tooltip', () => (
         {...commonProps}
     />
 ))
+
+stories.add('month spacing', () => <Calendar {...commonProps} monthSpacing={25} />)

--- a/website/src/data/components/calendar/props.js
+++ b/website/src/data/components/calendar/props.js
@@ -253,6 +253,21 @@ const props = [
     },
     // Months
     {
+        key: 'monthSpacing',
+        help: 'define spacing between each month row/column depending on the direction.',
+        type: 'number',
+        required: false,
+        defaultValue: defaults.monthSpacing,
+        controlType: 'range',
+        group: 'Months',
+        controlOptions: {
+            unit: 'px',
+            min: 0,
+            max: 160,
+            step: 5,
+        },
+    },
+    {
         key: 'monthBorderWidth',
         flavors: ['svg', 'api'],
         help: 'width of month borders.',

--- a/website/src/pages/calendar/canvas.js
+++ b/website/src/pages/calendar/canvas.js
@@ -47,6 +47,7 @@ const initialProperties = {
     yearLegendPosition: 'before',
     yearLegendOffset: 10,
 
+    monthSpacing: 0,
     monthBorderWidth: 2,
     monthBorderColor: '#ffffff',
     monthLegendPosition: 'before',

--- a/website/src/pages/calendar/index.js
+++ b/website/src/pages/calendar/index.js
@@ -44,6 +44,7 @@ const initialProperties = {
     yearLegendPosition: 'before',
     yearLegendOffset: 10,
 
+    monthSpacing: 0,
     monthBorderWidth: 2,
     monthBorderColor: '#ffffff',
     monthLegendPosition: 'before',


### PR DESCRIPTION
This PR adds the prop `monthSpacing` to `@nivo/calendar` as an option to add spacing between months in the rendered output.
![image](https://user-images.githubusercontent.com/2495155/82329975-13a93d00-99da-11ea-8cbb-dd59e1538392.png)
