### PR TITLE
fix(bump): Add types for defs to AreaBumpSvgProps

### DIFF
--- a/packages/bump/index.d.ts
+++ b/packages/bump/index.d.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 import { Component, MouseEvent } from 'react'
-import { Dimensions, Box, Theme, MotionProps, CssMixBlendMode } from '@nivo/core'
+import { Dimensions, Box, Theme, MotionProps, SvgDefsAndFill, CssMixBlendMode } from '@nivo/core'
 import { OrdinalColorsInstruction, InheritedColorProp } from '@nivo/colors'
 
 declare module '@nivo/bump' {
@@ -172,7 +172,7 @@ declare module '@nivo/bump' {
         tooltip?: any
     }
 
-    export type AreaBumpSvgProps = AreaBumpProps & MotionProps
+    export type AreaBumpSvgProps = AreaBumpProps & MotionProps & SvgDefsAndFill<BumpInputDatum>
     export class AreaBump extends Component<AreaBumpSvgProps & Dimensions> {}
     export class ResponsiveAreaBump extends Component<AreaBumpSvgProps> {}
 }


### PR DESCRIPTION
It looks like I missed this in #926 sorry - it currently complains about a missing type for `defs`:

```
      Property 'defs' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<ResponsiveAreaBump> & Readonly<AreaBumpSvgProps> & Readonly<...>'.
    69 |             colors={colors}
    70 |             data={data}
  > 71 |             defs={defs}
       |             ^
    72 |             endLabelTextColor={labelColor}
    73 |             fill={fill}
    74 |             startLabelTextColor={labelColor}
```