### PR TITLE
fix(radar): Add return type of GridLabelCustomFunction

### DIFF
--- a/packages/radar/index.d.ts
+++ b/packages/radar/index.d.ts
@@ -13,7 +13,7 @@ import { LegendProps } from '@nivo/legends'
 
 declare module '@nivo/radar' {
     type IndexByCustomFunctiono<D = any> = (datum: D) => string | number
-    type GridLabelCustomFunction = (...args: any[]) => string
+    type GridLabelCustomFunction = (...args: any[]) => string | JSX.Element
     type CustomDotSymbol = (...args: any[]) => React.ReactNode
     type CustomDotLabel = (...args: any[]) => React.ReactNode
     type CustomFormatter = (...args: any[]) => React.ReactNode


### PR DESCRIPTION
I want to use nivo/radar like below link in typescript code.
In that example code, custom label component return react element.
[nivo/rader: custom-label-component](https://nivo.rocks/storybook/?path=/story/radar--custom-label-component)

but, because of Type Declaration, I can't use custom label component for nivo/radar.
So, I fix packages/radar/index.d.ts code. Could you review it?