### PR TITLE
Prevent Line drawing outside data area using clip

### DIFF
--- a/packages/line/src/Line.js
+++ b/packages/line/src/Line.js
@@ -176,7 +176,14 @@ const Line = props => {
         ),
         areas: null,
         lines: (
-            <Lines key="lines" lines={series} lineGenerator={lineGenerator} lineWidth={lineWidth} />
+            <Lines 
+                key="lines" 
+                lines={series} 
+                lineGenerator={lineGenerator} 
+                lineWidth={lineWidth} 
+                width={innerWidth} 
+                height={innerHeight}
+            />
         ),
         slices: null,
         points: null,
@@ -236,6 +243,8 @@ const Line = props => {
                 enableLabel={enablePointLabel}
                 label={pointLabel}
                 labelYOffset={pointLabelYOffset}
+                width={innerWidth} 
+                height={innerHeight}
             />
         )
     }

--- a/packages/line/src/Lines.js
+++ b/packages/line/src/Lines.js
@@ -22,15 +22,10 @@ const Lines = ({ lines, lineGenerator, lineWidth, width, height }) => {
         />
     ));
     if ((width !== undefined && height !== undefined)) {
-        const clipId = `nivo-lines-clip-${width}-${height}`;
-        const clip = <defs key="nivo-lines-clip">
-            <clipPath id={clipId}>
-                <rect x="0" y="0" width={width} height={height}></rect>
-            </clipPath>
-        </defs>
-        return [clip, <g key="nivo-lines" clipPath={`url(#${clipId})`}>{linesArray}</g>];
+        return <svg x="0" y="0" width={width} height = {height} overflow="hidden">{linesArray}</svg>
+    } else {
+        return linesArray;
     }
-    return linesArray;
 }
 
 Lines.propTypes = {

--- a/packages/line/src/Lines.js
+++ b/packages/line/src/Lines.js
@@ -10,8 +10,8 @@ import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import LinesItem from './LinesItem'
 
-const Lines = ({ lines, lineGenerator, lineWidth }) => {
-    return lines.map(({ id, data, color }) => (
+const Lines = ({ lines, lineGenerator, lineWidth, width, height }) => {
+    const linesArray = lines.map(({ id, data, color }) => (
         <LinesItem
             key={id}
             id={id}
@@ -20,7 +20,17 @@ const Lines = ({ lines, lineGenerator, lineWidth }) => {
             color={color}
             thickness={lineWidth}
         />
-    ))
+    ));
+    if ((width !== undefined && height !== undefined)) {
+        const clipId = `nivo-lines-clip-${width}-${height}`;
+        const clip = <defs key="nivo-lines-clip">
+            <clipPath id={clipId}>
+                <rect x="0" y="0" width={width} height={height}></rect>
+            </clipPath>
+        </defs>
+        return [clip, <g key="nivo-lines" clipPath={`url(#${clipId})`}>{linesArray}</g>];
+    }
+    return linesArray;
 }
 
 Lines.propTypes = {
@@ -52,6 +62,8 @@ Lines.propTypes = {
     ).isRequired,
     lineWidth: PropTypes.number.isRequired,
     lineGenerator: PropTypes.func.isRequired,
+    width: PropTypes.number,
+    height: PropTypes.number,
 }
 
 export default memo(Lines)

--- a/packages/line/src/Points.js
+++ b/packages/line/src/Points.js
@@ -46,13 +46,7 @@ const Points = ({ points, symbol, size, borderWidth, enableLabel, label, labelYO
     ));
 
     if ((width !== undefined && height !== undefined)) {
-        const clipId = `nivo-points-clip-${width}-${height}`;
-        const clip = <defs key="nivo-points-clip">
-            <clipPath id={clipId}>
-                <rect x="0" y="0" width={width} height={height}></rect>
-            </clipPath>
-        </defs>
-        return [clip, <g key="nivo-points" clipPath={`url(#${clipId})`}>{pointsArray}</g>];
+        return <svg x="0" y="0" width={width} height = {height} overflow="hidden"><g>{pointsArray}</g></svg>
     } else {
         return <g>{pointsArray}</g>;
     }

--- a/packages/line/src/Points.js
+++ b/packages/line/src/Points.js
@@ -10,7 +10,7 @@ import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { getLabelGenerator, DotsItem, useTheme } from '@nivo/core'
 
-const Points = ({ points, symbol, size, borderWidth, enableLabel, label, labelYOffset }) => {
+const Points = ({ points, symbol, size, borderWidth, enableLabel, label, labelYOffset, width, height }) => {
     const theme = useTheme()
     const getLabel = getLabelGenerator(label)
 
@@ -28,26 +28,34 @@ const Points = ({ points, symbol, size, borderWidth, enableLabel, label, labelYO
         return mappedPoint
     })
 
-    return (
-        <g>
-            {mappedPoints.map(point => (
-                <DotsItem
-                    key={point.id}
-                    x={point.x}
-                    y={point.y}
-                    datum={point.datum}
-                    symbol={symbol}
-                    size={size}
-                    color={point.fill}
-                    borderWidth={borderWidth}
-                    borderColor={point.stroke}
-                    label={point.label}
-                    labelYOffset={labelYOffset}
-                    theme={theme}
-                />
-            ))}
-        </g>
-    )
+    const pointsArray = mappedPoints.map(point => (
+        <DotsItem
+            key={point.id}
+            x={point.x}
+            y={point.y}
+            datum={point.datum}
+            symbol={symbol}
+            size={size}
+            color={point.fill}
+            borderWidth={borderWidth}
+            borderColor={point.stroke}
+            label={point.label}
+            labelYOffset={labelYOffset}
+            theme={theme}
+        />
+    ));
+
+    if ((width !== undefined && height !== undefined)) {
+        const clipId = `nivo-points-clip-${width}-${height}`;
+        const clip = <defs key="nivo-points-clip">
+            <clipPath id={clipId}>
+                <rect x="0" y="0" width={width} height={height}></rect>
+            </clipPath>
+        </defs>
+        return [clip, <g key="nivo-points" clipPath={`url(#${clipId})`}>{pointsArray}</g>];
+    } else {
+        return <g>{pointsArray}</g>;
+    }
 }
 
 Points.propTypes = {
@@ -60,6 +68,8 @@ Points.propTypes = {
     enableLabel: PropTypes.bool.isRequired,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
     labelYOffset: PropTypes.number,
+    width: PropTypes.number,
+    height: PropTypes.number,
 }
 
 export default memo(Points)

--- a/packages/line/stories/line.stories.js
+++ b/packages/line/stories/line.stories.js
@@ -48,6 +48,62 @@ const stories = storiesOf('Line', module)
 stories.addDecorator(withKnobs)
 
 stories.add(
+    'zoomed clipped lines',
+    () => (
+        <Line
+            {...commonProperties}
+            data={[
+                {
+                    id: 'fake corp. A',
+                    data: [
+                        { x: 0, y: 7 },
+                        { x: 1, y: 5 },
+                        { x: 2, y: 11 },
+                        { x: 3, y: 9 },
+                        { x: 4, y: 12 },
+                        { x: 7, y: 12.1 },
+                        { x: 9, y: 12.2 },
+                    ],
+                },
+                {
+                    id: 'fake corp. B',
+                    data: [
+                        { x: 0, y: 5 },
+                        { x: 1, y: 5.5 },
+                        { x: 2, y: 6 },
+                        { x: 3, y: 2 },
+                        { x: 4, y: 21 },
+                        { x: 7, y: 12.5 },
+                        { x: 9, y: 12.5 },
+                    ],
+                },
+
+            ]}
+            yScale={{
+                type: 'linear',
+                min: 6,
+                max: 12,
+                stacked: false,
+            }}
+            xScale={{
+                type: 'linear',
+                min: 1, //Causes rect with width -133.5? Not sure what the rect is...
+                max: 7
+            }}
+            curve={select('curve', curveOptions, 'linear')}
+        />
+    ),
+    {
+        info: {
+            text: `
+                You can zoom the y-axis using min and max, and lines will be clipped to data area.
+                Please note that stacking is only supported for linear scales.
+            `,
+        },
+    }
+)
+
+stories.add(
     'stacked lines',
     () => (
         <Line


### PR DESCRIPTION
Fixes #660
Add a clip-path to the container g of lines and points in Lines graph to prevent drawing outside the data area. This requires Lines and Points to accept a width and height - if either one is omitted, clipping is not done.

The implementation is probably not ideal, but shows the general approach.