### PR TITLE
chore(docs): Add Testing section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 - [requirements](#requirements)
 - [setup](#setup)
 - [development](#development)
+  - [storybook](#storybook)
+  - [demo/doc website](#demodoc-website)
+  - [testing](#testing)
   - [formatting](#formatting)
   - [linting](#linting)
   - [screenshots](#screenshots)
@@ -61,6 +64,23 @@ You can also build the packages without running a watcher, you have two options:
 
  1. Rebuild all the packages via `make packages-build` or…
  2. Rebuild only a specific package, for example `make package-build-bar` for `@nivo/bar` package
+
+### Testing
+
+To run unit tests on all packages, run the following command:
+
+```
+make packages-test
+```
+
+If you only made modifications on a specific package,
+you can use the scoped form to speed up the process:
+
+```
+make package-test-bar
+```
+
+where `bar` is the name of the targeted nivo package.
 
 ### Formatting
 


### PR DESCRIPTION
Finding out how to launch tests was only a quick look at `Makefile` away, but I think it makes sense to have it in the CONTRIBUTING docs—it also has the benefits of stating that there _are_ tests to check your PR against.