### PR TITLE
Show entries in legend for 0 value data

### DIFF
--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -104,6 +104,7 @@ const Bar = props => {
         onMouseLeave,
 
         legends,
+        showLegendForZeroedValues,
 
         animate,
         motionStiffness,
@@ -122,6 +123,7 @@ const Bar = props => {
         getColor,
         padding,
         innerPadding,
+        showLegendForZeroedValues,
     }
     const result =
         groupMode === 'grouped' ? generateGroupedBars(options) : generateStackedBars(options)

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -67,6 +67,7 @@ export const generateVerticalGroupedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    showLegendForZeroedValues,
 }) => {
     const xScale = getIndexedScale(data, getIndex, [0, width], padding)
     const yRange = reverse ? [0, height] : [height, 0]
@@ -90,7 +91,7 @@ export const generateVerticalGroupedBars = ({
                 const y = getY(data[index][key])
                 const barHeight = getHeight(data[index][key], y)
 
-                if (barWidth > 0 && barHeight > 0) {
+                if (showLegendForZeroedValues || (barWidth > 0 && barHeight > 0)) {
                     const barData = {
                         id: key,
                         value: data[index][key],
@@ -144,6 +145,7 @@ export const generateHorizontalGroupedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    showLegendForZeroedValues,
 }) => {
     const xRange = reverse ? [width, 0] : [0, width]
     const xScale = getGroupedScale(data, keys, minValue, maxValue, xRange)
@@ -167,7 +169,7 @@ export const generateHorizontalGroupedBars = ({
                 const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
                 const barWidth = getWidth(data[index][key], x)
 
-                if (barWidth > 0) {
+                if (showLegendForZeroedValues || barWidth > 0) {
                     const barData = {
                         id: key,
                         value: data[index][key],

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -66,6 +66,7 @@ export const generateVerticalStackedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    showLegendForZeroedValues,
 }) => {
     const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(data)
 
@@ -96,7 +97,7 @@ export const generateVerticalStackedBars = ({
                     barHeight -= innerPadding
                 }
 
-                if (barHeight > 0) {
+                if (showLegendForZeroedValues || barHeight > 0) {
                     const barData = {
                         id: stackedDataItem.key,
                         value: d.data[stackedDataItem.key],
@@ -150,6 +151,7 @@ export const generateHorizontalStackedBars = ({
     getColor,
     padding = 0,
     innerPadding = 0,
+    showLegendForZeroedValues,
 }) => {
     const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(data)
 
@@ -188,7 +190,7 @@ export const generateHorizontalStackedBars = ({
                     barWidth -= innerPadding
                 }
 
-                if (barWidth > 0) {
+                if (showLegendForZeroedValues || barWidth > 0) {
                     bars.push({
                         key: `${stackedDataItem.key}.${index}`,
                         data: barData,

--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -90,6 +90,7 @@ export const BarPropTypes = {
             ...LegendPropShape,
         })
     ).isRequired,
+    showLegendForZeroedValues: PropTypes.func.isRequired,
 
     pixelRatio: PropTypes.number.isRequired,
 }
@@ -136,6 +137,7 @@ export const BarDefaultProps = {
     onMouseLeave: noop,
 
     legends: [],
+    showLegendForZeroedValues: false,
 
     annotations: [],
 


### PR DESCRIPTION
Fix #874 
I created a prop to enable and disable the legend for 0 value data, it's disabled by default, so it doesn't give unwanted behavior.
The prop is: `showLegendForZeroedValues`