### PR TITLE
feat(bullet): support ranges that support < 0

### DIFF
--- a/packages/bullet/src/Bullet.js
+++ b/packages/bullet/src/Bullet.js
@@ -75,7 +75,9 @@ export class Bullet extends Component {
 
             const max = Math.max(...all)
 
-            const scale = scaleLinear().domain([0, max])
+            const min = Math.min(...all, 0)
+
+            const scale = scaleLinear().domain([min, max])
 
             if (layout === 'horizontal') {
                 scale.range(reverse === true ? [width, 0] : [0, width])


### PR DESCRIPTION
- Adds support for < 0 values in bullet graphs by including a value < 0 in the range
- First time committing to this repo, not sure if there's anything else I should do, here's an example where this would be useful (using a bullet graph to display standard deviations or z-scores)

<img width="909" alt="Screen Shot 2020-07-15 at 7 03 04 PM" src="https://user-images.githubusercontent.com/704789/87608394-0e582e00-c6bd-11ea-9969-53964af8c738.png">
