### PR TITLE
feat(line): add option to enable tooltip when hovering over points with holes in data

### DIFF
--- a/packages/line/src/Line.js
+++ b/packages/line/src/Line.js
@@ -88,6 +88,7 @@ const Line = props => {
         tooltip,
 
         enableSlices,
+        enableTooltipOnNullValues,
         debugSlices,
         sliceTooltip,
 
@@ -115,6 +116,7 @@ const Line = props => {
         pointColor,
         pointBorderColor,
         enableSlices,
+        enableTooltipOnNullValues,
     })
 
     const theme = useTheme()

--- a/packages/line/src/hooks.js
+++ b/packages/line/src/hooks.js
@@ -36,19 +36,33 @@ export const useAreaGenerator = ({ curve, yScale, areaBaselineValue }) => {
     }, [curve, yScale, areaBaselineValue])
 }
 
-const usePoints = ({ series, getPointColor, getPointBorderColor, formatX, formatY }) => {
+const usePoints = ({
+    series,
+    getPointColor,
+    getPointBorderColor,
+    formatX,
+    formatY,
+    enableTooltipOnNullValues,
+}) => {
     return useMemo(() => {
         return series.reduce((acc, serie) => {
             return [
                 ...acc,
                 ...serie.data
-                    .filter(datum => datum.position.x !== null && datum.position.y !== null)
+                    .filter(datum =>
+                        enableTooltipOnNullValues
+                            ? true
+                            : datum.position.x !== null && datum.position.y !== null
+                    )
                     .map((datum, i) => {
                         const point = {
                             id: `${serie.id}.${i}`,
                             index: acc.length + i,
                             serieId: serie.id,
-                            serieColor: serie.color,
+                            serieColor:
+                                datum.position.x !== null && datum.position.y !== null
+                                    ? serie.color
+                                    : 'transparent',
                             x: datum.position.x,
                             y: datum.position.y,
                         }
@@ -67,14 +81,15 @@ const usePoints = ({ series, getPointColor, getPointBorderColor, formatX, format
     }, [series, getPointColor, getPointBorderColor, formatX, formatY])
 }
 
-export const useSlices = ({ enableSlices, points, width, height }) => {
+export const useSlices = ({ enableSlices, enableTooltipOnNullValues, points, width, height }) => {
     return useMemo(() => {
         if (enableSlices === false) return []
 
         if (enableSlices === 'x') {
             const map = new Map()
             points.forEach(point => {
-                if (point.data.x === null || point.data.y === null) return
+                if (!enableTooltipOnNullValues && (point.data.x === null || point.data.y === null))
+                    return
                 if (!map.has(point.x)) map.set(point.x, [point])
                 else map.get(point.x).push(point)
             })
@@ -153,6 +168,7 @@ export const useLine = ({
     pointColor = LineDefaultProps.pointColor,
     pointBorderColor = LineDefaultProps.pointBorderColor,
     enableSlices = LineDefaultProps.enableSlicesTooltip,
+    enableTooltipOnNullValues = LineDefaultProps.enableTooltipOnNullValues,
 }) => {
     const formatX = useValueFormatter(xFormat)
     const formatY = useValueFormatter(yFormat)
@@ -181,10 +197,12 @@ export const useLine = ({
         getPointBorderColor,
         formatX,
         formatY,
+        enableTooltipOnNullValues,
     })
 
     const slices = useSlices({
         enableSlices,
+        enableTooltipOnNullValues,
         points,
         width,
         height,

--- a/packages/line/src/props.js
+++ b/packages/line/src/props.js
@@ -134,6 +134,7 @@ export const LinePropTypes = {
     ...commonPropTypes,
     enablePointLabel: PropTypes.bool.isRequired,
     useMesh: PropTypes.bool.isRequired,
+    enableTooltipOnNullValues: PropTypes.bool,
     ...motionPropTypes,
     ...defsPropTypes,
 }
@@ -207,6 +208,7 @@ export const LineDefaultProps = {
     motionConfig: 'gentle',
     defs: [],
     fill: [],
+    enableTooltipOnNullValues: false,
 }
 
 export const LineCanvasDefaultProps = {

--- a/packages/line/stories/line.stories.js
+++ b/packages/line/stories/line.stories.js
@@ -468,6 +468,7 @@ stories.add(
             pointSize={8}
             pointBorderColor="#fff"
             pointBorderWidth={2}
+            enableTooltipOnNullValues={boolean('enableTooltipOnNullValues', false)}
         />
     ),
     {


### PR DESCRIPTION
This Pull Request closes #975.

- feat(line): add option to enable tooltip when hovering over points with null values

![Screenshot 2020-07-21 at 10 51 14 AM](https://user-images.githubusercontent.com/29735224/88008227-5efadb80-cb42-11ea-8272-b9bd62a8dafc.png)
