### PR TITLE
feat(generators): add network data generation

### DIFF
--- a/packages/generators/src/index.js
+++ b/packages/generators/src/index.js
@@ -262,6 +262,7 @@ export const generateWinesTastes = ({ randMin = 20, randMax = 120 } = {}) => {
 
 export * from './bullet'
 export * from './chord'
+export * from './network'
 export * from './parallelCoordinates'
 export * from './sankey'
 export * from './swarmplot'

--- a/packages/generators/src/network.js
+++ b/packages/generators/src/network.js
@@ -8,7 +8,7 @@
  */
 import random from 'lodash/random'
 
-export const generateData = ({
+export const generateNetworkData = ({
     rootNodeRadius = 12,
     minMidNodes = 6,
     maxMidNodes = 16,

--- a/packages/network/stories/network.stories.js
+++ b/packages/network/stories/network.stories.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { NetworkDefaultProps } from '../src/props'
-import { generateData } from '../../../website/src/data/components/network/generator'
+import { generateNetworkData } from '@nivo/generators'
 import { Network } from '../src'
 
-const data = generateData()
+const data = generateNetworkData()
 
 const commonProperties = {
     ...NetworkDefaultProps,

--- a/website/src/pages/network/canvas.js
+++ b/website/src/pages/network/canvas.js
@@ -11,7 +11,7 @@ import { ResponsiveNetworkCanvas, NetworkCanvasDefaultProps } from '@nivo/networ
 import ComponentTemplate from '../../components/components/ComponentTemplate'
 import meta from '../../data/components/network/meta.yml'
 import { groups } from '../../data/components/network/props'
-import { generateData } from '../../data/components/network/generator'
+import { generateNetworkData } from '@nivo/generators'
 
 const initialProperties = Object.freeze({
     pixelRatio:
@@ -37,6 +37,8 @@ const initialProperties = Object.freeze({
 
     isInteractive: true,
 })
+
+const generateData = () => generateNetworkData()
 
 const NetworkCanvas = () => {
     return (

--- a/website/src/pages/network/index.js
+++ b/website/src/pages/network/index.js
@@ -11,7 +11,7 @@ import { ResponsiveNetwork, NetworkDefaultProps } from '@nivo/network'
 import ComponentTemplate from '../../components/components/ComponentTemplate'
 import meta from '../../data/components/network/meta.yml'
 import { groups } from '../../data/components/network/props'
-import { generateData } from '../../data/components/network/generator'
+import { generateNetworkData } from '@nivo/generators'
 
 const initialProperties = Object.freeze({
     margin: {
@@ -41,6 +41,8 @@ const initialProperties = Object.freeze({
     motionStiffness: 160,
     motionDamping: 12,
 })
+
+const generateData = () => generateNetworkData()
 
 const Network = () => {
     return (


### PR DESCRIPTION
Moves this from the website workspace so it can be shared with storybook.