### PR TITLE
fix(pie): tooltip props typing

### DIFF
--- a/packages/pie/index.d.ts
+++ b/packages/pie/index.d.ts
@@ -13,6 +13,10 @@ declare module '@nivo/pie' {
     export type PieDatumWithColor = PieDatum & {
         color: string
     }
+    
+    export type PieTooltip = PieDatumWithColor & {
+        label: string | number
+    }
 
     export type AccessorFunc = (datum: PieDatum) => string
 
@@ -66,7 +70,7 @@ declare module '@nivo/pie' {
             // interactivity
             isInteractive: boolean
             tooltipFormat: string | ValueFormatter
-            tooltip: React.StatelessComponent<PieDatumWithColor>
+            tooltip: React.FC<PieTooltip>
 
             legends: LegendProps[]
         }>

--- a/packages/pie/index.d.ts
+++ b/packages/pie/index.d.ts
@@ -13,7 +13,7 @@ declare module '@nivo/pie' {
     export type PieDatumWithColor = PieDatum & {
         color: string
     }
-    
+
     export type PieTooltip = PieDatumWithColor & {
         label: string | number
     }


### PR DESCRIPTION
Seems like the pie tooltip typing is broken, I replaced `StatelessComponent` with `FunctionComponent`, since `SC` is deprecated, also the label seemed missing, I added its typing according to the docs.

EDIT: typo