### PR TITLE
Sankey: Sort links by input if nodes are sorted by input order

### DIFF
--- a/packages/sankey/src/hooks.js
+++ b/packages/sankey/src/hooks.js
@@ -12,6 +12,7 @@ export const computeNodeAndLinks = ({
     layout,
     alignFunction,
     sortFunction,
+    linkSortMode,
     nodeThickness,
     nodeSpacing,
     nodeInnerPadding,
@@ -24,6 +25,7 @@ export const computeNodeAndLinks = ({
     const sankey = d3Sankey()
         .nodeAlign(alignFunction)
         .nodeSort(sortFunction)
+        .linkSort(linkSortMode)
         .nodeWidth(nodeThickness)
         .nodePadding(nodeSpacing)
         .size(layout === 'horizontal' ? [width, height] : [height, width])
@@ -99,6 +101,10 @@ export const useSankey = ({
         return sort
     }, [sort])
 
+    // If "input" sorting is used, apply this setting to links, too.
+    // (In d3, `null` means input sorting and `undefined` is the default)
+    const linkSortMode = sort === 'input' ? null : undefined
+
     const alignFunction = useMemo(() => sankeyAlignmentFromProp(align), [align])
 
     const theme = useTheme()
@@ -117,6 +123,7 @@ export const useSankey = ({
                 layout,
                 alignFunction,
                 sortFunction,
+                linkSortMode,
                 nodeThickness,
                 nodeSpacing,
                 nodeInnerPadding,
@@ -131,6 +138,7 @@ export const useSankey = ({
             layout,
             alignFunction,
             sortFunction,
+            linkSortMode,
             nodeThickness,
             nodeSpacing,
             nodeInnerPadding,

--- a/packages/sankey/stories/sankey.stories.js
+++ b/packages/sankey/stories/sankey.stories.js
@@ -96,3 +96,30 @@ const minNodeValueOnTop = (nodeA, nodeB) => {
 stories.add('with reverse sort ordering (min node value on top)', () => (
     <Sankey {...commonProperties} sort={minNodeValueOnTop} />
 ))
+
+stories.add('sort links by input', () => (
+    <Sankey
+        {...commonProperties}
+        data={{
+            nodes: [
+                { id: 'foo_left', color: '#ff0000' },
+                { id: 'bar_left', color: '#0000ff' },
+                { id: 'baz_left', color: '#00ff00' },
+                { id: 'foo_right', color: '#ff0000' },
+                { id: 'bar_right', color: '#0000ff' },
+                { id: 'baz_right', color: '#00ff00' },
+            ],
+            links: [
+                { source: 'foo_left', target: 'bar_right', value: 5 },
+                { source: 'foo_left', target: 'baz_right', value: 5 },
+                { source: 'bar_left', target: 'foo_right', value: 5 },
+                { source: 'bar_left', target: 'bar_right', value: 5 },
+                { source: 'bar_left', target: 'baz_right', value: 5 },
+                { source: 'baz_left', target: 'bar_right', value: 5 },
+            ],
+        }}
+        colors={d => d.color ?? ''}
+        sort="input"
+        enableLinkGradient
+    />
+))


### PR DESCRIPTION
When implementing a sankey diagram using nivo, we experienced an issue with the sort order of the diagram's links which this PR fixes.
Our requirement is that nodes are ordered in a specific order (in our case alphabetically by their label), so we went with the `sort="input"` prop.

The following example illustrates the problem and uses the following data:

```js
{
  nodes: [
      { id: 'foo_left', color: '#ff0000' },
      { id: 'bar_left', color: '#0000ff' },
      { id: 'baz_left', color: '#00ff00' },
      { id: 'foo_right', color: '#ff0000' },
      { id: 'bar_right', color: '#0000ff' },
      { id: 'baz_right', color: '#00ff00' },
  ],
  links: [
      { source: 'foo_left', target: 'bar_right', value: 5 },
      // This is commented in after the first screenshot!
      // { source: 'foo_left', target: 'baz_right', value: 5 },
      { source: 'bar_left', target: 'foo_right', value: 5 },
      { source: 'bar_left', target: 'bar_right', value: 5 },
      { source: 'bar_left', target: 'baz_right', value: 5 },
      { source: 'baz_left', target: 'bar_right', value: 5 },
  ],
}
```

When the flows amongst the existing nodes are distributed "symmetrically", everything works well:

![Screen Shot 2020-08-07 at 15 23 04](https://user-images.githubusercontent.com/768764/89651544-64874e00-d8c4-11ea-8d0a-d57f43ebdc29.png)

However, when making the diagram asymmetric by commenting in the flow from `foo_left` to `baz_right`, flows start crossing each other in unnecessary ways. (See the flows `Bar -> Foo` and `Bar -> Bar`, or `Bar -> Foo` and `Bar -> Baz`)

![Screen Shot 2020-08-07 at 15 22 46](https://user-images.githubusercontent.com/768764/89651881-e7100d80-d8c4-11ea-8560-599a7860a0a5.png)

When applying the change of this PR, the result looks like this, respecting the input sorting of the links which avoids unnecessary crossings:

![Screen Shot 2020-08-07 at 15 23 31](https://user-images.githubusercontent.com/768764/89652227-74ebf880-d8c5-11ea-9557-3ba54177cc55.png)

In essence, the change is that d3-sankey's `linkSort` is set to `null` (which means "input order") every time the component's `sort` property is set to `"input"`.

While this is a backwards incompatible change in the sense that is will change how diagrams using `sort="input"` look, I think that it follows the originally intended description of that property more closely than before.
To ensure backwards compatibility, we would need to introduce a second option that is called something like `sortLinks` to enable this behaviour.

What do you think?