### PR TITLE
feat(scales): Add support for symlog scale

### DIFF
--- a/packages/line/stories/line.stories.js
+++ b/packages/line/stories/line.stories.js
@@ -226,6 +226,41 @@ stories.add('logarithmic scale', () => (
     />
 ))
 
+stories.add('symmetric logarithmic scale', () => (
+    <Line
+        {...commonProperties}
+        data={[
+            {
+                id: 'fake corp. A',
+                data: [
+                    { x: 1, y: -12 },
+                    { x: 2, y: 123 },
+                    { x: 3, y: 870 },
+                    { x: 4, y: 210 },
+                    { x: 7, y: 400 },
+                    { x: 9, y: 100 },
+                    { x: 16, y: 1000 },
+                ],
+            },
+        ]}
+        xScale={{
+            type: 'linear',
+            max: 'auto',
+        }}
+        yScale={{
+            type: 'symlog',
+            max: 'auto',
+        }}
+        axisLeft={{
+            tickValues: [0, 100, 250, 500, 1000],
+            legend: 'symmetric logarithmic scale',
+            legendOffset: 12,
+        }}
+        useMesh={true}
+        enableSlices={false}
+    />
+))
+
 class RealTimeChart extends Component {
     constructor(props) {
         super(props)

--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -45,6 +45,7 @@ declare module '@nivo/scales' {
 
     export interface SymlogScale {
         type: 'symlog'
+        constant?: number
         min?: 'auto' | number
         max?: 'auto' | number
     }

--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -43,7 +43,19 @@ declare module '@nivo/scales' {
         max?: 'auto' | number
     }
 
-    export type Scale = LinearScale | PointScale | TimeScale | TimeScaleFormatted | LogScale
+    export interface SymlogScale {
+        type: 'symlog'
+        min?: 'auto' | number
+        max?: 'auto' | number
+    }
+
+    export type Scale =
+        | LinearScale
+        | PointScale
+        | TimeScale
+        | TimeScaleFormatted
+        | LogScale
+        | SymlogScale
 
     export type ScaleFunc = (value: string | number | Date) => number
 }

--- a/packages/scales/src/compute.js
+++ b/packages/scales/src/compute.js
@@ -13,6 +13,7 @@ import last from 'lodash/last'
 import isDate from 'lodash/isDate'
 import { linearScale } from './linearScale'
 import { logScale } from './logScale'
+import { symlogScale } from './symlogScale'
 import { pointScale } from './pointScale'
 import { timeScale } from './timeScale'
 import { createDateNormalizer } from './timeHelpers'
@@ -75,6 +76,7 @@ export const computeScale = (spec, xy, width, height) => {
     else if (spec.type === 'point') return pointScale(spec, xy, width, height)
     else if (spec.type === 'time') return timeScale(spec, xy, width, height)
     else if (spec.type === 'log') return logScale(spec, xy, width, height)
+    else if (spec.type === 'symlog') return symlogScale(spec, xy, width, height)
 }
 
 export const generateSeriesXY = (series, xScaleSpec, yScaleSpec) => ({

--- a/packages/scales/src/index.js
+++ b/packages/scales/src/index.js
@@ -9,6 +9,7 @@
 import PropTypes from 'prop-types'
 import { linearScalePropTypes } from './linearScale'
 import { logScalePropTypes } from './logScale'
+import { symLogScalePropTypes } from './symlogScale'
 import { pointScalePropTypes } from './pointScale'
 import { timeScalePropTypes } from './timeScale'
 
@@ -23,4 +24,5 @@ export const scalePropType = PropTypes.oneOfType([
     PropTypes.shape(pointScalePropTypes),
     PropTypes.shape(timeScalePropTypes),
     PropTypes.shape(logScalePropTypes),
+    PropTypes.shape(symLogScalePropTypes),
 ])

--- a/packages/scales/src/symlogScale.js
+++ b/packages/scales/src/symlogScale.js
@@ -40,7 +40,7 @@ export const symlogScale = (
 }
 
 export const symLogScalePropTypes = {
-    type: PropTypes.oneOf(['symLog']).isRequired,
+    type: PropTypes.oneOf(['symlog']).isRequired,
     constant: PropTypes.number,
     min: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]),
     max: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]),

--- a/packages/scales/src/symlogScale.js
+++ b/packages/scales/src/symlogScale.js
@@ -28,7 +28,7 @@ export const symlogScale = ({ axis, min = 'auto', max = 'auto' }, xy, width, hei
         .rangeRound(axis === 'x' ? [0, size] : [size, 0])
         .nice()
 
-    scale.type = 'log'
+    scale.type = 'symlog'
 
     return scale
 }

--- a/packages/scales/src/symlogScale.js
+++ b/packages/scales/src/symlogScale.js
@@ -9,7 +9,12 @@
 import { scaleSymlog } from 'd3-scale'
 import PropTypes from 'prop-types'
 
-export const symlogScale = ({ axis, min = 'auto', max = 'auto' }, xy, width, height) => {
+export const symlogScale = (
+    { axis, constant = 1, min = 'auto', max = 'auto' },
+    xy,
+    width,
+    height
+) => {
     const values = xy[axis]
     const size = axis === 'x' ? width : height
 
@@ -25,6 +30,7 @@ export const symlogScale = ({ axis, min = 'auto', max = 'auto' }, xy, width, hei
 
     const scale = scaleSymlog()
         .domain([minValue, maxValue])
+        .constant(constant)
         .rangeRound(axis === 'x' ? [0, size] : [size, 0])
         .nice()
 
@@ -35,6 +41,7 @@ export const symlogScale = ({ axis, min = 'auto', max = 'auto' }, xy, width, hei
 
 export const symLogScalePropTypes = {
     type: PropTypes.oneOf(['symLog']).isRequired,
+    constant: PropTypes.number,
     min: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]),
     max: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]),
 }

--- a/packages/scales/src/symlogScale.js
+++ b/packages/scales/src/symlogScale.js
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import { scaleSymlog } from 'd3-scale'
+import PropTypes from 'prop-types'
+
+export const symlogScale = ({ axis, min = 'auto', max = 'auto' }, xy, width, height) => {
+    const values = xy[axis]
+    const size = axis === 'x' ? width : height
+
+    let minValue = min
+    if (min === 'auto') {
+        minValue = values.min
+    }
+
+    let maxValue = max
+    if (max === 'auto') {
+        maxValue = values.max
+    }
+
+    const scale = scaleSymlog()
+        .domain([minValue, maxValue])
+        .rangeRound(axis === 'x' ? [0, size] : [size, 0])
+        .nice()
+
+    scale.type = 'log'
+
+    return scale
+}
+
+export const symLogScalePropTypes = {
+    type: PropTypes.oneOf(['symLog']).isRequired,
+    min: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]),
+    max: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]),
+}

--- a/packages/scatterplot/stories/ScatterPlot.stories.js
+++ b/packages/scatterplot/stories/ScatterPlot.stories.js
@@ -238,6 +238,36 @@ stories.add('using logarithmic scales', () => (
     />
 ))
 
+stories.add('using symmetric logarithmic scales', () => (
+    <ScatterPlot
+        {...commonProps}
+        data={[
+            {
+                id: 'apples',
+                data: [
+                    { x: 1, y: 1 },
+                    { x: 2, y: 3 },
+                    { x: 4, y: 32 },
+                    { x: 5, y: 8 },
+                    { x: 2, y: 38 },
+                    { x: 3, y: 45 },
+                ],
+            },
+        ]}
+        xScale={{
+            type: 'linear',
+        }}
+        xFormat={undefined}
+        yScale={{
+            type: 'symlog',
+        }}
+        yFormat={undefined}
+        axisBottom={{
+            tickValues: [0, 1, 2, 3, 4, 5],
+        }}
+    />
+))
+
 stories.add('node size', () => <ScatterPlot {...commonProps} nodeSize={24} />)
 
 stories.add('varying node size', () => (

--- a/packages/scatterplot/stories/ScatterPlotCanvas.stories.js
+++ b/packages/scatterplot/stories/ScatterPlotCanvas.stories.js
@@ -231,6 +231,36 @@ stories.add('using logarithmic scales', () => (
     />
 ))
 
+stories.add('using symmetric logarithmic scales', () => (
+    <ScatterPlotCanvas
+        {...commonProps}
+        data={[
+            {
+                id: 'apples',
+                data: [
+                    { x: 1, y: 1 },
+                    { x: 2, y: 3 },
+                    { x: 4, y: 32 },
+                    { x: 5, y: 8 },
+                    { x: 2, y: 38 },
+                    { x: 3, y: 45 },
+                ],
+            },
+        ]}
+        xScale={{
+            type: 'linear',
+        }}
+        xFormat={undefined}
+        yScale={{
+            type: 'symlog',
+        }}
+        yFormat={undefined}
+        axisBottom={{
+            tickValues: [0, 1, 2, 3, 4, 5],
+        }}
+    />
+))
+
 stories.add('symbol size', () => <ScatterPlotCanvas {...commonProps} nodeSize={24} />)
 
 stories.add('varying symbol size', () => (


### PR DESCRIPTION
Thank you for the great library!

Lately we needed to render some graphs using logarithmic scale, but found out that `d3-scale`'s logarithmic scale is not very well suited for data having a wider range. For those use cases one can use symlog scale which "offers a bi-symmetric log transformation, suitable ‘for wide-range data’. Its domain can span several orders of magnitude, with negative as well as positive values." `d3-scale` has also API for that.

Add support for [symlog scale](https://github.com/d3/d3-scale#symlog-scales). The code is heavily inspired by a PR adding the support for logarithmic scale: https://github.com/plouc/nivo/pull/378

Compared to logarithmic scale PR, no safe-guarding for zero or negative values is needed since the scale accepts both.

I added relevant stories to storybook but did not include links to website as I thought it's rather similar to logarithmic scale. Users browsing the storybook should find it easily though.

Here is a screenshot of a scatterplot using symlog scale:

![image](https://user-images.githubusercontent.com/520104/89789629-833a4e80-db29-11ea-9b51-1329f276ff83.png)

Thank you in advance, and let me know if you have any suggestions for improvement.