### PR TITLE
Passing through the calculated individual bar width and height to layers

### DIFF
--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -113,7 +113,7 @@ export const generateVerticalGroupedBars = ({
         })
     }
 
-    return { xScale, yScale, bars }
+    return { xScale, yScale, bars, barWidth }
 }
 
 /**
@@ -190,7 +190,7 @@ export const generateHorizontalGroupedBars = ({
         })
     }
 
-    return { xScale, yScale, bars }
+    return { xScale, yScale, bars, barHeight }
 }
 
 /**


### PR DESCRIPTION
**Issue:**
I have three keys in my bar chart(['currentYear', 'oneYearAgo', 'twoYearsAgo']), my custom layer renders a different key('goal'). If the user has no currentYear, oneYearAgo or twoYearsAgo data but has goal data, you cannot use the bars prop as there is no data in it. So I tried using the raw data prop but there was no barWidth prop to allow me to position my SVG layers accurately.

**Solution:**
Passing through the calculated bar height or width(depending on the orientation of the bar chart) to custom layers.

This is to allow you to use the data prop instead of the bars prop(Which could be empty depending on the data -> the issue in my case). 