### PR TITLE
feat(a11y): add ability to set `role` prop on all charts

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -132,8 +132,6 @@ declare module '@nivo/bar' {
         legends: ({ dataFrom: 'indexes' | 'keys' } & LegendProps)[]
 
         markers: CartesianMarkerProps[]
-
-        role: string
     }>
 
     export enum BarLayerType {
@@ -155,6 +153,7 @@ declare module '@nivo/bar' {
             onClick: BarMouseEventHandler<SVGRectElement>
             onMouseEnter: BarMouseEventHandler<SVGRectElement>
             onMouseLeave: BarMouseEventHandler<SVGRectElement>
+            role: string
         }>
 
     export class Bar extends React.Component<BarSvgProps & Dimensions> {}

--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -14,7 +14,7 @@ import { BoxLegendSvg } from '@nivo/legends'
 import { generateGroupedBars, generateStackedBars, getLegendData } from './compute'
 import setDisplayName from 'recompose/setDisplayName'
 import enhance from './enhance'
-import { BarPropTypes } from './props'
+import { BarSvgDefaultProps, BarSvgPropTypes } from './props'
 import BarAnnotations from './BarAnnotations'
 
 const barWillEnterHorizontal = ({ style }) => ({
@@ -336,6 +336,7 @@ const Bar = props => {
     )
 }
 
-Bar.propTypes = BarPropTypes
+Bar.propTypes = BarSvgPropTypes
+Bar.defaultProps = BarSvgDefaultProps
 
 export default setDisplayName('Bar')(enhance(Bar))

--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -92,8 +92,11 @@ export const BarPropTypes = {
     ).isRequired,
 
     pixelRatio: PropTypes.number.isRequired,
+}
 
-    role: PropTypes.string,
+export const BarSvgPropTypes = {
+    ...BarPropTypes,
+    role: PropTypes.string.isRequired,
 }
 
 export const BarDefaultProps = {
@@ -143,6 +146,9 @@ export const BarDefaultProps = {
 
     pixelRatio:
         global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+}
 
+export const BarSvgDefaultProps = {
+    ...BarDefaultProps,
     role: 'img',
 }

--- a/packages/bullet/src/Bullet.js
+++ b/packages/bullet/src/Bullet.js
@@ -59,6 +59,8 @@ export class Bullet extends Component {
             onRangeClick,
             onMeasureClick,
             onMarkerClick,
+
+            role,
         } = this.props
 
         let itemHeight
@@ -105,6 +107,7 @@ export class Bullet extends Component {
                         height={outerHeight}
                         margin={margin}
                         theme={theme}
+                        role={role}
                     >
                         {enhancedData.map((d, i) => (
                             <BulletItem

--- a/packages/bullet/src/props.js
+++ b/packages/bullet/src/props.js
@@ -70,6 +70,7 @@ const commonPropTypes = {
 
 export const BulletPropTypes = {
     ...commonPropTypes,
+    role: PropTypes.string.isRequired,
 }
 
 const commonDefaultProps = {
@@ -98,4 +99,5 @@ const commonDefaultProps = {
 
 export const BulletDefaultProps = {
     ...commonDefaultProps,
+    role: 'img',
 }

--- a/packages/bump/index.d.ts
+++ b/packages/bump/index.d.ts
@@ -73,6 +73,7 @@ declare module '@nivo/bump' {
         onMouseLeave?: BumpMouseHandler
         onClick?: BumpMouseHandler
         tooltip?: any
+        role?: string
     }
 
     export type BumpSvgProps = BumpProps & MotionProps
@@ -170,6 +171,7 @@ declare module '@nivo/bump' {
         onMouseLeave?: AreaBumpMouseHandler
         onClick?: AreaBumpMouseHandler
         tooltip?: any
+        role?: string
     }
 
     export type AreaBumpSvgProps = AreaBumpProps & MotionProps & SvgDefsAndFill<BumpInputDatum>

--- a/packages/bump/src/area-bump/AreaBump.js
+++ b/packages/bump/src/area-bump/AreaBump.js
@@ -61,6 +61,7 @@ const AreaBump = props => {
         onMouseLeave,
         onClick,
         tooltip,
+        role,
     } = props
 
     const [currentSerie, setCurrentSerie] = useState(null)
@@ -160,7 +161,13 @@ const AreaBump = props => {
     }
 
     return (
-        <SvgWrapper defs={boundDefs} width={outerWidth} height={outerHeight} margin={margin}>
+        <SvgWrapper
+            defs={boundDefs}
+            width={outerWidth}
+            height={outerHeight}
+            margin={margin}
+            role={role}
+        >
             {layers.map((layer, i) => {
                 if (typeof layer === 'function') {
                     return (

--- a/packages/bump/src/area-bump/props.js
+++ b/packages/bump/src/area-bump/props.js
@@ -84,6 +84,7 @@ const commonPropTypes = {
 export const AreaBumpPropTypes = {
     ...commonPropTypes,
     ...motionPropTypes,
+    role: PropTypes.string.isRequired,
 }
 
 const commonDefaultProps = {
@@ -129,4 +130,5 @@ export const AreaBumpDefaultProps = {
     ...commonDefaultProps,
     animate: true,
     motionConfig: 'gentle',
+    role: 'img',
 }

--- a/packages/bump/src/bump/Bump.js
+++ b/packages/bump/src/bump/Bump.js
@@ -68,6 +68,7 @@ const Bump = props => {
         onMouseLeave,
         onClick,
         tooltip,
+        role,
     } = props
 
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
@@ -181,7 +182,7 @@ const Bump = props => {
     }
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin}>
+        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} role={role}>
             {layers.map((layer, i) => {
                 if (typeof layer === 'function') {
                     return (

--- a/packages/bump/src/bump/props.js
+++ b/packages/bump/src/bump/props.js
@@ -83,6 +83,7 @@ const commonPropTypes = {
 export const BumpPropTypes = {
     ...commonPropTypes,
     ...motionPropTypes,
+    role: PropTypes.string.isRequired,
 }
 
 const commonDefaultProps = {
@@ -132,4 +133,5 @@ export const BumpDefaultProps = {
     pointComponent: Point,
     animate: true,
     motionConfig: 'gentle',
+    role: 'img',
 }

--- a/packages/calendar/index.d.ts
+++ b/packages/calendar/index.d.ts
@@ -99,6 +99,7 @@ declare module '@nivo/calendar' {
         CalendarCommonProps &
         Partial<{
             onClick: (datum: CalendarDayData, event: React.MouseEvent<SVGRectElement>) => void
+            role: string
         }>
 
     export class Calendar extends React.Component<CalendarSvgProps & Dimensions> {}

--- a/packages/calendar/src/Calendar.js
+++ b/packages/calendar/src/Calendar.js
@@ -58,6 +58,7 @@ const Calendar = ({
     onMouseMove,
 
     legends,
+    role,
 }) => {
     const theme = useTheme()
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
@@ -89,7 +90,13 @@ const Calendar = ({
     const formatValue = useValueFormatter(valueFormat)
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+        <SvgWrapper
+            width={outerWidth}
+            height={outerHeight}
+            margin={margin}
+            theme={theme}
+            role={role}
+        >
             {days.map(d => (
                 <CalendarDay
                     key={d.date.toString()}

--- a/packages/calendar/src/props.js
+++ b/packages/calendar/src/props.js
@@ -67,7 +67,10 @@ const commonPropTypes = {
     ).isRequired,
 }
 
-export const CalendarPropTypes = commonPropTypes
+export const CalendarPropTypes = {
+    ...commonPropTypes,
+    role: PropTypes.string.isRequired,
+}
 
 export const CalendarCanvasPropTypes = {
     ...commonPropTypes,
@@ -107,7 +110,10 @@ const commonDefaultProps = {
     tooltip: CalendarTooltip,
 }
 
-export const CalendarDefaultProps = commonDefaultProps
+export const CalendarDefaultProps = {
+    ...commonDefaultProps,
+    role: 'img',
+}
 
 export const CalendarCanvasDefaultProps = {
     ...commonDefaultProps,

--- a/packages/chord/index.d.ts
+++ b/packages/chord/index.d.ts
@@ -90,6 +90,7 @@ declare module '@nivo/chord' {
             onRibbonMouseLeave?: ChordRibbonMouseHandler
             onRibbonClick?: ChordRibbonMouseHandler
             ribbonTooltip?: any
+            role?: string
         }
 
     export class Chord extends Component<ChordProps & Dimensions> {}

--- a/packages/chord/src/Chord.js
+++ b/packages/chord/src/Chord.js
@@ -64,6 +64,7 @@ const Chord = ({
     onRibbonClick,
 
     legends,
+    role,
 }) => {
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
@@ -186,7 +187,13 @@ const Chord = ({
     }
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+        <SvgWrapper
+            width={outerWidth}
+            height={outerHeight}
+            margin={margin}
+            theme={theme}
+            role={role}
+        >
             {layers.map((layer, i) => {
                 if (layerById[layer] !== undefined) {
                     return layerById[layer]

--- a/packages/chord/src/props.js
+++ b/packages/chord/src/props.js
@@ -68,6 +68,7 @@ const commonPropTypes = {
 export const ChordPropTypes = {
     ...commonPropTypes,
     ...motionPropTypes,
+    role: PropTypes.string.isRequired,
 }
 
 export const ChordCanvasPropTypes = {
@@ -124,6 +125,7 @@ export const ChordDefaultProps = {
     animate: true,
     motionStiffness: 90,
     motionDamping: 15,
+    role: 'img',
 }
 
 export const ChordCanvasDefaultProps = {

--- a/packages/circle-packing/src/Bubble.js
+++ b/packages/circle-packing/src/Bubble.js
@@ -41,6 +41,7 @@ const Bubble = ({
     tooltip,
     isZoomable,
     zoomToNode,
+    role,
 }) => {
     const springConfig = {
         stiffness: motionStiffness,
@@ -75,6 +76,7 @@ const Bubble = ({
                     margin={margin}
                     defs={defs}
                     theme={theme}
+                    role={role}
                 >
                     {!animate && (
                         <g>

--- a/packages/circle-packing/src/props.js
+++ b/packages/circle-packing/src/props.js
@@ -49,6 +49,7 @@ const commonPropTypes = {
 export const BubblePropTypes = {
     ...commonPropTypes,
     nodeComponent: PropTypes.func.isRequired,
+    role: PropTypes.string.isRequired,
     ...defsPropTypes,
 }
 
@@ -89,6 +90,7 @@ const commonDefaultProps = {
 export const BubbleDefaultProps = {
     ...commonDefaultProps,
     nodeComponent: BubbleNode,
+    role: 'img',
     defs: [],
     fill: [],
 }

--- a/packages/funnel/index.d.ts
+++ b/packages/funnel/index.d.ts
@@ -118,7 +118,9 @@ declare module '@nivo/funnel' {
         animate?: boolean
     }
 
-    export interface FunnelSvgProps extends FunnelProps, MotionProps {}
+    export interface FunnelSvgProps extends FunnelProps, MotionProps {
+        role?: string
+    }
 
     export class Funnel extends React.Component<FunnelSvgProps & Dimensions> {}
     export class ResponsiveFunnel extends React.Component<FunnelSvgProps> {}

--- a/packages/funnel/src/Funnel.js
+++ b/packages/funnel/src/Funnel.js
@@ -48,6 +48,7 @@ const Funnel = props => {
         onMouseMove,
         onMouseLeave,
         onClick,
+        role,
     } = props
 
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
@@ -127,7 +128,7 @@ const Funnel = props => {
     }
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin}>
+        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} role={role}>
             {layers.map((layer, i) => {
                 if (typeof layer === 'function') {
                     return <Fragment key={i}>{layer(customLayerProps)}</Fragment>

--- a/packages/funnel/src/props.js
+++ b/packages/funnel/src/props.js
@@ -59,6 +59,8 @@ export const FunnelPropTypes = {
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
 
+    role: PropTypes.string.isRequired,
+
     ...motionPropTypes,
 }
 
@@ -91,6 +93,8 @@ export const FunnelDefaultProps = {
 
     isInteractive: true,
     currentPartSizeExtension: 0,
+
+    role: 'img',
 
     animate: MotionConfigProvider.defaultProps.animate,
     motionConfig: MotionConfigProvider.defaultProps.config,

--- a/packages/geo/index.d.ts
+++ b/packages/geo/index.d.ts
@@ -62,7 +62,9 @@ declare module '@nivo/geo' {
         tooltip?: GeoMapTooltip
     }
 
-    export interface GeoMapProps extends GeoMapCommonProps {}
+    export interface GeoMapProps extends GeoMapCommonProps {
+        role?: string
+    }
     export interface GeoMapCanvasProps extends GeoMapCommonProps {
         pixelRatio?: number
     }
@@ -118,7 +120,9 @@ declare module '@nivo/geo' {
         onClick?: ChoroplethEventHandler
     }
 
-    export interface ChoroplethProps extends ChoroplethCommonProps {}
+    export interface ChoroplethProps extends ChoroplethCommonProps {
+        role?: string
+    }
     export interface ChoroplethCanvasProps extends ChoroplethCommonProps {
         pixelRatio?: number
     }

--- a/packages/geo/src/Choropleth.js
+++ b/packages/geo/src/Choropleth.js
@@ -43,6 +43,7 @@ const Choropleth = memo(
         isInteractive,
         onClick,
         tooltip: Tooltip,
+        role,
     }) => {
         const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
         const { graticule, path, getBorderWidth, getBorderColor } = useGeoMap({
@@ -95,7 +96,13 @@ const Choropleth = memo(
         ])
 
         return (
-            <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+            <SvgWrapper
+                width={outerWidth}
+                height={outerHeight}
+                margin={margin}
+                theme={theme}
+                role={role}
+            >
                 {layers.map((layer, i) => {
                     if (layer === 'graticule') {
                         if (enableGraticule !== true) return null

--- a/packages/geo/src/GeoMap.js
+++ b/packages/geo/src/GeoMap.js
@@ -34,6 +34,7 @@ const GeoMap = memo(props => {
         isInteractive,
         onClick,
         tooltip: Tooltip,
+        role,
     } = props
     const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
     const { graticule, path, getFillColor, getBorderWidth, getBorderColor } = useGeoMap({
@@ -71,7 +72,13 @@ const GeoMap = memo(props => {
     ])
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+        <SvgWrapper
+            width={outerWidth}
+            height={outerHeight}
+            margin={margin}
+            theme={theme}
+            role={role}
+        >
             {layers.map((layer, i) => {
                 if (layer === 'graticule') {
                     if (enableGraticule !== true) return null

--- a/packages/geo/src/props.js
+++ b/packages/geo/src/props.js
@@ -49,6 +49,7 @@ const commonPropTypes = {
 
 export const GeoMapPropTypes = {
     ...commonPropTypes,
+    role: PropTypes.string.isRequired,
 }
 
 export const GeoMapCanvasPropTypes = {
@@ -73,6 +74,7 @@ const commonChoroplethPropTypes = {
 export const ChoroplethPropTypes = {
     ...GeoMapPropTypes,
     ...commonChoroplethPropTypes,
+    role: PropTypes.string.isRequired,
 }
 
 export const ChoroplethCanvasPropTypes = {
@@ -106,6 +108,7 @@ const commonDefaultProps = {
 
 export const GeoMapDefaultProps = {
     ...commonDefaultProps,
+    role: 'img',
 }
 
 export const GeoMapCanvasDefaultProps = {
@@ -127,6 +130,7 @@ const commonChoroplethDefaultProps = {
 export const ChoroplethDefaultProps = {
     ...GeoMapDefaultProps,
     ...commonChoroplethDefaultProps,
+    role: 'img',
 }
 
 export const ChoroplethCanvasDefaultProps = {

--- a/packages/heatmap/index.d.ts
+++ b/packages/heatmap/index.d.ts
@@ -85,6 +85,7 @@ declare module '@nivo/heatmap' {
         Partial<{
             onClick: (datum: NodeData, event: React.MouseEvent<HTMLCanvasElement>) => void
             pixelRatio: number
+            role: string
         }>
 
     export class HeatMapCanvas extends React.Component<HeatMapCanvasProps & Dimensions> {}

--- a/packages/heatmap/src/HeatMap.js
+++ b/packages/heatmap/src/HeatMap.js
@@ -10,7 +10,7 @@ import React, { useCallback } from 'react'
 import { SvgWrapper, withContainer, useDimensions } from '@nivo/core'
 import { Axes, Grid } from '@nivo/axes'
 import { useTooltip } from '@nivo/tooltip'
-import { HeatMapPropTypes, HeatMapDefaultProps } from './props'
+import { HeatMapSvgPropTypes, HeatMapSvgDefaultProps } from './props'
 import { useHeatMap } from './hooks'
 import HeatMapCells from './HeatMapCells'
 import HeatMapCellRect from './HeatMapCellRect'
@@ -50,6 +50,7 @@ const HeatMap = ({
     cellHoverOthersOpacity,
     tooltipFormat,
     tooltip,
+    role,
 }) => {
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
@@ -122,6 +123,7 @@ const HeatMap = ({
                 top: margin.top + offsetY,
                 left: margin.left + offsetX,
             })}
+            role={role}
         >
             <Grid
                 width={innerWidth - offsetX * 2}
@@ -154,9 +156,9 @@ const HeatMap = ({
     )
 }
 
-HeatMap.propTypes = HeatMapPropTypes
+HeatMap.propTypes = HeatMapSvgPropTypes
 
 const WrappedHeatMap = withContainer(HeatMap)
-WrappedHeatMap.defaultProps = HeatMapDefaultProps
+WrappedHeatMap.defaultProps = HeatMapSvgDefaultProps
 
 export default WrappedHeatMap

--- a/packages/heatmap/src/props.js
+++ b/packages/heatmap/src/props.js
@@ -54,6 +54,11 @@ export const HeatMapPropTypes = {
     pixelRatio: PropTypes.number.isRequired,
 }
 
+export const HeatMapSvgPropTypes = {
+    ...HeatMapPropTypes,
+    role: PropTypes.string.isRequired,
+}
+
 export const HeatMapDefaultProps = {
     indexBy: 'id',
 
@@ -94,4 +99,9 @@ export const HeatMapDefaultProps = {
     // canvas specific
     pixelRatio:
         global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+}
+
+export const HeatMapSvgDefaultProps = {
+    ...HeatMapDefaultProps,
+    role: 'img',
 }

--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -206,6 +206,7 @@ declare module '@nivo/line' {
         pointLabel?: string | AccessorFunc
         pointLabelYOffset?: number
         areaBlendMode?: string
+        role?: string
         useMesh?: boolean
     }
 

--- a/packages/line/src/Line.js
+++ b/packages/line/src/Line.js
@@ -93,6 +93,8 @@ const Line = props => {
 
         enableCrosshair,
         crosshairType,
+
+        role,
     } = props
 
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
@@ -288,7 +290,13 @@ const Line = props => {
     }
 
     return (
-        <SvgWrapper defs={boundDefs} width={outerWidth} height={outerHeight} margin={margin}>
+        <SvgWrapper
+            defs={boundDefs}
+            width={outerWidth}
+            height={outerHeight}
+            margin={margin}
+            role={role}
+        >
             {layers.map((layer, i) => {
                 if (typeof layer === 'function') {
                     return (

--- a/packages/line/src/props.js
+++ b/packages/line/src/props.js
@@ -133,6 +133,7 @@ const commonPropTypes = {
 export const LinePropTypes = {
     ...commonPropTypes,
     enablePointLabel: PropTypes.bool.isRequired,
+    role: PropTypes.string.isRequired,
     useMesh: PropTypes.bool.isRequired,
     ...motionPropTypes,
     ...defsPropTypes,
@@ -207,6 +208,7 @@ export const LineDefaultProps = {
     motionConfig: 'gentle',
     defs: [],
     fill: [],
+    role: 'img',
 }
 
 export const LineCanvasDefaultProps = {

--- a/packages/network/index.d.ts
+++ b/packages/network/index.d.ts
@@ -77,7 +77,9 @@ declare module '@nivo/network' {
         isInteractive?: boolean
     }
 
-    export interface NetworkSvgProps extends NetworkProps, MotionProps {}
+    export interface NetworkSvgProps extends NetworkProps, MotionProps {
+        role?: string
+    }
 
     export class Network extends React.Component<NetworkSvgProps & Dimensions> {}
     export class ResponsiveNetwork extends React.Component<NetworkSvgProps> {}

--- a/packages/network/src/Network.js
+++ b/packages/network/src/Network.js
@@ -43,6 +43,7 @@ const Network = props => {
         linkColor,
         tooltip,
         isInteractive,
+        role,
     } = props
 
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
@@ -101,7 +102,7 @@ const Network = props => {
     }
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin}>
+        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} role={role}>
             {layers.map((layer, i) => {
                 if (typeof layer === 'function') {
                     return (

--- a/packages/network/src/props.js
+++ b/packages/network/src/props.js
@@ -46,6 +46,7 @@ const commonPropTypes = {
 
 export const NetworkPropTypes = {
     ...commonPropTypes,
+    role: PropTypes.string.isRequired,
     ...motionPropTypes,
 }
 
@@ -77,6 +78,7 @@ export const NetworkDefaultProps = {
     animate: true,
     motionStiffness: 90,
     motionDamping: 15,
+    role: 'img',
 }
 
 export const NetworkCanvasDefaultProps = {

--- a/packages/parallel-coordinates/src/ParallelCoordinates.js
+++ b/packages/parallel-coordinates/src/ParallelCoordinates.js
@@ -9,7 +9,7 @@
 import React from 'react'
 import { SvgWrapper, useDimensions, withContainer } from '@nivo/core'
 import { Axis } from '@nivo/axes'
-import { commonPropTypes, commonDefaultProps } from './props'
+import { svgPropTypes, svgDefaultProps } from './props'
 import { useParallelCoordinates } from './hooks'
 import ParallelCoordinatesLine from './ParallelCoordinatesLine'
 
@@ -26,6 +26,7 @@ const ParallelCoordinates = ({
     lineOpacity,
     curve,
     colors,
+    role,
 }) => {
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
@@ -70,7 +71,7 @@ const ParallelCoordinates = ({
     ))
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin}>
+        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} role={role}>
             {axesPlan === 'background' && axes}
             {dataWithPoints.map(datum => (
                 <ParallelCoordinatesLine
@@ -89,9 +90,9 @@ const ParallelCoordinates = ({
     )
 }
 
-ParallelCoordinates.propTypes = commonPropTypes
+ParallelCoordinates.propTypes = svgPropTypes
 
 const WrappedParallelCoordinates = withContainer(ParallelCoordinates)
-WrappedParallelCoordinates.defaultProps = commonDefaultProps
+WrappedParallelCoordinates.defaultProps = svgDefaultProps
 
 export default WrappedParallelCoordinates

--- a/packages/parallel-coordinates/src/props.js
+++ b/packages/parallel-coordinates/src/props.js
@@ -59,6 +59,11 @@ export const commonPropTypes = {
     colors: ordinalColorsPropType.isRequired,
 }
 
+export const svgPropTypes = {
+    ...commonPropTypes,
+    role: PropTypes.string.isRequired,
+}
+
 export const commonDefaultProps = {
     layout: 'horizontal',
     curve: 'linear',
@@ -69,4 +74,9 @@ export const commonDefaultProps = {
     axesTicksPosition: 'after',
     animate: true,
     motionConfig: 'gentle',
+}
+
+export const svgDefaultProps = {
+    ...commonDefaultProps,
+    role: 'img',
 }

--- a/packages/pie/index.d.ts
+++ b/packages/pie/index.d.ts
@@ -82,6 +82,7 @@ declare module '@nivo/pie' {
             onClick: PieMouseEventHandler<SVGPathElement>
             onMouseEnter: PieMouseEventHandler<SVGPathElement>
             onMouseLeave: PieMouseEventHandler<SVGPathElement>
+            role: string
         }>
 
     export class Pie extends React.Component<PieSvgProps & Dimensions> {}

--- a/packages/pie/src/Pie.js
+++ b/packages/pie/src/Pie.js
@@ -21,16 +21,15 @@ import {
     bindDefs,
 } from '@nivo/core'
 import { getInheritedColorGenerator } from '@nivo/colors'
-import { PieDefaultProps } from './props'
+import { PieSvgDefaultProps, PieSvgPropTypes } from './props'
 import PieSlice from './PieSlice'
 import PieRadialLabels from './PieRadialLabels'
 import PieSlicesLabels from './PieSlicesLabels'
-import { PiePropTypes } from './props'
 import PieLayout from './PieLayout'
 import PieLegends from './PieLegends'
 
 class Pie extends Component {
-    static propTypes = PiePropTypes
+    static propTypes = PieSvgPropTypes
 
     render() {
         const {
@@ -90,6 +89,7 @@ class Pie extends Component {
             tooltip,
 
             legends,
+            role,
         } = this.props
 
         const borderColor = getInheritedColorGenerator(_borderColor, theme)
@@ -123,6 +123,7 @@ class Pie extends Component {
                                     margin={margin}
                                     defs={boundDefs}
                                     theme={theme}
+                                    role={role}
                                 >
                                     <g transform={`translate(${centerX},${centerY})`}>
                                         {arcs.map(arc => (
@@ -202,7 +203,7 @@ class Pie extends Component {
 
 const enhance = Component =>
     compose(
-        defaultProps(PieDefaultProps),
+        defaultProps(PieSvgDefaultProps),
         withTheme(),
         withDimensions(),
         withPropsOnChange(['radialLabel'], ({ radialLabel }) => ({

--- a/packages/pie/src/props.js
+++ b/packages/pie/src/props.js
@@ -101,6 +101,11 @@ export const PiePropTypes = {
     */
 }
 
+export const PieSvgPropTypes = {
+    ...PiePropTypes,
+    role: PropTypes.string.isRequired,
+}
+
 export const PieDefaultProps = {
     sortByValue: false,
     innerRadius: 0,
@@ -146,4 +151,9 @@ export const PieDefaultProps = {
 
     // legends
     legends: [],
+}
+
+export const PieSvgDefaultProps = {
+    ...PieDefaultProps,
+    role: 'img',
 }

--- a/packages/radar/index.d.ts
+++ b/packages/radar/index.d.ts
@@ -56,6 +56,7 @@ declare module '@nivo/radar' {
         tooltipFormat?: string | CustomFormatter
 
         legends: LegendProps[]
+        role?: string
     }
 
     export type RadarProps = CommonRadarProps & MotionProps

--- a/packages/radar/src/Radar.js
+++ b/packages/radar/src/Radar.js
@@ -56,6 +56,7 @@ const Radar = memo(
         isInteractive,
         tooltipFormat,
         legends,
+        role,
     }) => {
         const getIndex = useMemo(() => getAccessorFor(indexBy), [indexBy])
         const indices = useMemo(() => data.map(getIndex), [data, getIndex])
@@ -104,7 +105,13 @@ const Radar = memo(
         const curveInterpolator = useCurveInterpolation(curve)
 
         return (
-            <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+            <SvgWrapper
+                width={outerWidth}
+                height={outerHeight}
+                margin={margin}
+                theme={theme}
+                role={role}
+            >
                 <g transform={`translate(${centerX}, ${centerY})`}>
                     <RadarGrid
                         levels={gridLevels}

--- a/packages/radar/src/props.js
+++ b/packages/radar/src/props.js
@@ -46,6 +46,7 @@ export const RadarPropTypes = {
     tooltipFormat: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 
     legends: PropTypes.arrayOf(PropTypes.shape(LegendPropShape)).isRequired,
+    role: PropTypes.string.isRequired,
 
     ...motionPropTypes,
 }
@@ -71,6 +72,7 @@ export const RadarDefaultProps = {
     isInteractive: true,
 
     legends: [],
+    role: 'img',
 
     animate: true,
     motionDamping: 13,

--- a/packages/sankey/index.d.ts
+++ b/packages/sankey/index.d.ts
@@ -119,5 +119,6 @@ declare module '@nivo/sankey' {
         theme: Theme
 
         legends: LegendProps[]
+        role: string
     }>
 }

--- a/packages/sankey/src/Sankey.js
+++ b/packages/sankey/src/Sankey.js
@@ -53,6 +53,7 @@ const Sankey = ({
     tooltipFormat,
     legends,
     layers,
+    role,
 }) => {
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
@@ -193,7 +194,7 @@ const Sankey = ({
     }
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin}>
+        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} role={role}>
             {layers.map((layer, i) => {
                 if (typeof layer === 'function') {
                     return <Fragment key={i}>{layer(layerProps)}</Fragment>

--- a/packages/sankey/src/props.js
+++ b/packages/sankey/src/props.js
@@ -89,6 +89,8 @@ export const SankeyPropTypes = {
         ])
     ).isRequired,
 
+    role: PropTypes.string.isRequired,
+
     ...motionPropTypes,
 }
 
@@ -128,6 +130,8 @@ export const SankeyDefaultProps = {
     legends: [],
 
     layers: ['links', 'nodes', 'labels', 'legends'],
+
+    role: 'img',
 
     animate: true,
     motionConfig: 'gentle',

--- a/packages/scatterplot/index.d.ts
+++ b/packages/scatterplot/index.d.ts
@@ -155,6 +155,7 @@ declare module '@nivo/scatterplot' {
         layers?: (CustomLayerId | CustomSvgLayer)[]
         renderNode?: NodeComponent
         markers?: CartesianMarkerProps[]
+        role?: string
     }
 
     export class ScatterPlot extends React.Component<ScatterPlotSvgProps & Dimensions> {}

--- a/packages/scatterplot/src/ScatterPlot.js
+++ b/packages/scatterplot/src/ScatterPlot.js
@@ -67,6 +67,7 @@ const ScatterPlot = props => {
         markers,
 
         legends,
+        role,
     } = props
 
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
@@ -195,7 +196,13 @@ const ScatterPlot = props => {
     }
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+        <SvgWrapper
+            width={outerWidth}
+            height={outerHeight}
+            margin={margin}
+            theme={theme}
+            role={role}
+        >
             {layers.map((layer, i) => {
                 if (layerById[layer] !== undefined) {
                     return layerById[layer]

--- a/packages/scatterplot/src/props.js
+++ b/packages/scatterplot/src/props.js
@@ -93,6 +93,7 @@ const commonPropTypes = {
 
 export const ScatterPlotPropTypes = {
     ...commonPropTypes,
+    role: PropTypes.string.isRequired,
     useMesh: PropTypes.bool.isRequired,
     ...motionPropTypes,
 }
@@ -140,6 +141,7 @@ const commonDefaultProps = {
 export const ScatterPlotDefaultProps = {
     ...commonDefaultProps,
     layers: ['grid', 'axes', 'nodes', 'markers', 'mesh', 'legends', 'annotations'],
+    role: 'img',
     useMesh: true,
     animate: true,
     motionStiffness: 90,

--- a/packages/stream/index.d.ts
+++ b/packages/stream/index.d.ts
@@ -84,6 +84,7 @@ declare module '@nivo/stream' {
         enableStackTooltip: boolean
 
         theme: Theme
+        role: string
 
         legends: LegendProps[]
     }

--- a/packages/stream/src/Stream.js
+++ b/packages/stream/src/Stream.js
@@ -55,6 +55,7 @@ const Stream = ({
     enableStackTooltip,
 
     legends,
+    role,
 }) => {
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
@@ -95,7 +96,13 @@ const Stream = ({
     const boundDefs = bindDefs(defs, layers, fill)
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} defs={boundDefs}>
+        <SvgWrapper
+            width={outerWidth}
+            height={outerHeight}
+            margin={margin}
+            defs={boundDefs}
+            role={role}
+        >
             <Grid
                 width={innerWidth}
                 height={innerHeight}

--- a/packages/stream/src/props.js
+++ b/packages/stream/src/props.js
@@ -57,6 +57,7 @@ export const StreamPropTypes = {
     enableStackTooltip: PropTypes.bool.isRequired,
 
     legends: PropTypes.arrayOf(PropTypes.shape(LegendPropShape)).isRequired,
+    role: PropTypes.string.isRequired,
 }
 
 export const StreamDefaultProps = {
@@ -89,6 +90,7 @@ export const StreamDefaultProps = {
     enableStackTooltip: true,
 
     legends: [],
+    role: 'img',
 
     animate: true,
     motionConfig: 'gentle',

--- a/packages/sunburst/index.d.ts
+++ b/packages/sunburst/index.d.ts
@@ -35,6 +35,7 @@ declare module '@nivo/sunburst' {
             margin: Box
 
             isInteractive: boolean
+            role: string
         }> &
         ColorProps<SunburstDataNode> &
         MotionProps

--- a/packages/sunburst/src/Sunburst.js
+++ b/packages/sunburst/src/Sunburst.js
@@ -51,12 +51,20 @@ const Sunburst = ({
 
     theme, // eslint-disable-line react/prop-types
 
+    role,
+
     isInteractive,
 }) => {
     return (
         <Container isInteractive={isInteractive} theme={theme} animate={false}>
             {({ showTooltip, hideTooltip }) => (
-                <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+                <SvgWrapper
+                    width={outerWidth}
+                    height={outerHeight}
+                    margin={margin}
+                    theme={theme}
+                    role={role}
+                >
                     <g transform={`translate(${centerX}, ${centerY})`}>
                         {nodes
                             .filter(node => node.depth > 0)
@@ -107,6 +115,8 @@ Sunburst.propTypes = {
     tooltipFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     tooltip: PropTypes.func,
 
+    role: PropTypes.string.isRequired,
+
     isInteractive: PropTypes.bool,
 }
 
@@ -121,6 +131,7 @@ export const SunburstDefaultProps = {
     borderColor: 'white',
 
     childColor: { from: 'color' },
+    role: 'img',
 
     isInteractive: true,
 }

--- a/packages/swarmplot/index.d.ts
+++ b/packages/swarmplot/index.d.ts
@@ -90,7 +90,7 @@ declare module '@nivo/swarmplot' {
         tooltip?: any
     }
 
-    export type SwarmPlotProps = CommonSwarmPlotProps & MotionProps
+    export type SwarmPlotProps = CommonSwarmPlotProps & MotionProps & { role?: string }
 
     export class SwarmPlot extends Component<SwarmPlotProps & Dimensions> {}
     export class ResponsiveSwarmPlot extends Component<SwarmPlotProps> {}

--- a/packages/swarmplot/src/SwarmPlot.js
+++ b/packages/swarmplot/src/SwarmPlot.js
@@ -66,6 +66,7 @@ const SwarmPlot = memo(
         onMouseLeave,
         onClick,
         tooltip,
+        role,
 
         animate,
         motionStiffness,
@@ -219,7 +220,13 @@ const SwarmPlot = memo(
         }
 
         return (
-            <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} theme={theme}>
+            <SvgWrapper
+                width={outerWidth}
+                height={outerHeight}
+                margin={margin}
+                theme={theme}
+                role={role}
+            >
                 {layers.map((layer, i) => {
                     if (layerById[layer] !== undefined) {
                         return layerById[layer]

--- a/packages/swarmplot/src/props.js
+++ b/packages/swarmplot/src/props.js
@@ -78,6 +78,7 @@ const commonPropTypes = {
 
 export const SwarmPlotPropTypes = {
     ...commonPropTypes,
+    role: PropTypes.string.isRequired,
     ...motionPropTypes,
 }
 
@@ -126,6 +127,7 @@ export const SwarmPlotDefaultProps = {
     animate: true,
     motionStiffness: 90,
     motionDamping: 15,
+    role: 'img',
 }
 
 export const SwarmPlotCanvasDefaultProps = {

--- a/packages/treemap/index.d.ts
+++ b/packages/treemap/index.d.ts
@@ -88,8 +88,12 @@ declare module '@nivo/treemap' {
         onClick?: NodeEventHandler
     }
 
-    export class TreeMap extends React.Component<TreeMapSvgAndHtmlProps & Dimensions> {}
-    export class ResponsiveTreeMap extends React.Component<TreeMapSvgAndHtmlProps> {}
+    export interface TreeMapSvgProps extends TreeMapSvgAndHtmlProps {
+        role?: string
+    }
+
+    export class TreeMap extends React.Component<TreeMapSvgProps & Dimensions> {}
+    export class ResponsiveTreeMap extends React.Component<TreeMapSvgProps> {}
 
     export class TreeMapHtml extends React.Component<TreeMapSvgAndHtmlProps & Dimensions> {}
     export class ResponsiveTreeMapHtml extends React.Component<TreeMapSvgAndHtmlProps> {}

--- a/packages/treemap/src/TreeMap.js
+++ b/packages/treemap/src/TreeMap.js
@@ -49,6 +49,7 @@ const TreeMap = ({
     onMouseLeave,
     onClick,
     tooltip,
+    role,
 }) => {
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
@@ -85,7 +86,13 @@ const TreeMap = ({
     const boundDefs = bindDefs(defs, nodes, fill)
 
     return (
-        <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} defs={boundDefs}>
+        <SvgWrapper
+            width={outerWidth}
+            height={outerHeight}
+            margin={margin}
+            defs={boundDefs}
+            role={role}
+        >
             <TreeMapNodes
                 nodes={nodes}
                 nodeComponent={nodeComponent}

--- a/packages/treemap/src/props.js
+++ b/packages/treemap/src/props.js
@@ -58,6 +58,7 @@ const commonPropTypes = {
 export const TreeMapPropTypes = {
     ...commonPropTypes,
     nodeComponent: PropTypes.elementType.isRequired,
+    role: PropTypes.string.isRequired,
     ...defsPropTypes,
 }
 
@@ -109,6 +110,7 @@ const commonDefaultProps = {
 export const TreeMapDefaultProps = {
     ...commonDefaultProps,
     nodeComponent: TreeMapNode,
+    role: 'img',
     defs: [],
     fill: [],
 }

--- a/packages/waffle/index.d.ts
+++ b/packages/waffle/index.d.ts
@@ -53,7 +53,7 @@ declare module '@nivo/waffle' {
     export type WaffleSvgProps = WaffleBaseProps &
         WaffleCommonProps &
         MotionProps &
-        SvgDefsAndFill<WaffleDatum>
+        SvgDefsAndFill<WaffleDatum> & { role?: string }
 
     export class Waffle extends React.Component<WaffleSvgProps & Dimensions> {}
     export class ResponsiveWaffle extends React.Component<WaffleSvgProps> {}

--- a/packages/waffle/src/Waffle.js
+++ b/packages/waffle/src/Waffle.js
@@ -84,6 +84,7 @@ export class Waffle extends Component {
             legendData,
 
             legends,
+            role,
         } = this.props
 
         cells.forEach(cell => {
@@ -190,6 +191,7 @@ export class Waffle extends Component {
                             margin={margin}
                             defs={defs}
                             theme={theme}
+                            role={role}
                         >
                             <g transform={`translate(${origin.x}, ${origin.y})`}>{cellsRender}</g>
                             {legends.map((legend, i) => (

--- a/packages/waffle/src/props.js
+++ b/packages/waffle/src/props.js
@@ -52,6 +52,7 @@ const commonPropTypes = {
 export const WafflePropTypes = {
     ...commonPropTypes,
     cellComponent: PropTypes.func.isRequired,
+    role: PropTypes.string.isRequired,
     ...defsPropTypes,
     legends: PropTypes.arrayOf(PropTypes.shape(LegendPropShape)).isRequired,
 }
@@ -88,6 +89,7 @@ const commonDefaultProps = {
 export const WaffleDefaultProps = {
     ...commonDefaultProps,
     cellComponent: WaffleCell,
+    role: 'img',
     defs: [],
     fill: [],
     legends: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,7 +2429,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.4":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
   integrity sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==
@@ -12086,11 +12086,6 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-node-dimensions@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz#fb7b4bb57060fb4247dd51c9d690dfbec56b0823"
-  integrity sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ==
-
 get-own-enumerable-property-symbols@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
@@ -18944,16 +18939,6 @@ react-markdown@^4.2.2:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
-react-measure@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-2.2.4.tgz#cec3d96d3c39e22660e958e26d5498e4a342b9e4"
-  integrity sha512-gpZA4J8sKy1TzTfnOXiiTu01GV8B5OyfF9k7Owt38T6Xxlll19PBE13HKTtauEmDdJO5u4o3XcTiGqCw5wpfjw==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    get-node-dimensions "^1.2.1"
-    prop-types "^15.6.2"
-    resize-observer-polyfill "^1.5.0"
-
 react-motion@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
@@ -19811,7 +19796,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==


### PR DESCRIPTION
This is a followup to #1054. This implements the same changes across the rest of the charts that use `SvgWrapper` component.

This should get all the tests passing again as well. I also correct the types and props for `bar` package as it would have allowed this to be set on `BarCanvas` where it wasn't applicable.