### PR TITLE
fix(scatterplot): Support DerivedNodeProp for nodeSize prop

### DIFF
--- a/packages/scatterplot/index.d.ts
+++ b/packages/scatterplot/index.d.ts
@@ -137,7 +137,7 @@ declare module '@nivo/scatterplot' {
         axisBottom?: AxisProps | null
         axisLeft?: AxisProps | null
 
-        nodeSize?: number | DerivedDatumProp<number> | DynamicSizeSpec
+        nodeSize?: number | DerivedDatumProp<number> | DynamicSizeSpec | DerivedNodeProp<number>
 
         isInteractive?: boolean
         useMesh?: boolean


### PR DESCRIPTION
Adds support for DerivedNodeProp<number> so when a function is passed to nodeSize the id of the node can be referenced. The current implementation uses only DerivedDatumProp<number> and the Datum type only has x and y fields where as Node also contains its id.

Also, the nivo docs at https://nivo.rocks/scatterplot/ specify "it will receive the current node and must return a number" which is consistent with the proposed type.
