### PR TITLE
fix(core / swarmplot): Improve core and swarmplot typedefs

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -184,5 +184,9 @@ declare module '@nivo/core' {
         defs: Def[]
     }
 
+    export function PatternLines(props: Omit<PatternLinesDef, 'type'>): JSX.Element
+    export function PatternSquares(props: Omit<PatternSquaresDef, 'type'>): JSX.Element
+    export function PatternDots(props: Omit<PatternDotsDef, 'type'>): JSX.Element
+
     export function Defs(props: DefsProps): JSX.Element
 }

--- a/packages/swarmplot/index.d.ts
+++ b/packages/swarmplot/index.d.ts
@@ -26,6 +26,22 @@ declare module '@nivo/swarmplot' {
         data: Datum
     }
 
+    export interface LayerProps<Datum> {
+        nodes: ComputedNode<Datum>[]
+        xScale: (input: number) => number
+        yScale: (input: number) => number
+        innerWidth: number
+        innerHeight: number
+        outerWidth: number
+        outerHeight: number
+        margin: number
+        getBorderColor: () => string
+        getBorderWidth: () => number
+        animate: boolean
+        motionStiffness: number
+        motionDamping: number
+    }
+
     type DatumAccessor<Datum, T> = (datum: Datum) => T
     type ComputedNodeAccessor<Datum, T> = (node: ComputedNode<Datum>) => T
 
@@ -40,6 +56,8 @@ declare module '@nivo/swarmplot' {
         event: React.MouseEvent<any>
     ) => void
 
+    export type Layers<Datum> = ((props: LayerProps<Datum>) => JSX.Element) | string
+
     type ValueFormatter<Datum> = (datum: Datum) => string | number
 
     interface CommonSwarmPlotProps<Datum = any> {
@@ -48,7 +66,7 @@ declare module '@nivo/swarmplot' {
         margin?: Box
 
         groups: string[]
-        groupBy?: string
+        groupBy?: string | DatumAccessor<Datum, string>
         identity?: string | DatumAccessor<Datum, string>
         label?: string | DatumAccessor<Datum, string>
         value?: string | DatumAccessor<Datum, number>
@@ -62,7 +80,7 @@ declare module '@nivo/swarmplot' {
         forceStrength?: number
         simulationIterations?: number
 
-        layers: any[]
+        layers?: Layers<Datum>[]
 
         colors?: OrdinalColorsInstruction
         colorBy?: string | ComputedNodeAccessor<Datum, string | number>

--- a/packages/swarmplot/index.d.ts
+++ b/packages/swarmplot/index.d.ts
@@ -42,6 +42,14 @@ declare module '@nivo/swarmplot' {
         motionDamping: number
     }
 
+    export enum SwarmPlotLayerType {
+        Grid = 'grid',
+        Axes = 'axes',
+        Nodes = 'nodes',
+        Mesh = 'mesh',
+        Annotations = 'annotations'
+    }
+
     type DatumAccessor<Datum, T> = (datum: Datum) => T
     type ComputedNodeAccessor<Datum, T> = (node: ComputedNode<Datum>) => T
 
@@ -56,7 +64,8 @@ declare module '@nivo/swarmplot' {
         event: React.MouseEvent<any>
     ) => void
 
-    export type Layers<Datum> = ((props: LayerProps<Datum>) => JSX.Element) | string
+    export type SwarmPlotCustomLayer<Datum> = (props: LayerProps<Datum>) => JSX.Element
+    export type Layers<Datum> = SwarmPlotCustomLayer<Datum> | SwarmPlotLayerType
 
     type ValueFormatter<Datum> = (datum: Datum) => string | number
 


### PR DESCRIPTION
When implementing custom layers I noticed that the Pattern helpers were not being exported in the type def which caused us to have to use `@ts-ignore` in our code base. I also noticed when working with swarmplots the type def also appeared to be slightly off. I propose two changes in this PR, the first being to export the pattern helpers in the type definition of @nivo/core and the second to give layers a real definition instead of `any[]` in `@nivo/swarmplot`. If anything is not correct please let me know and I will be more than happy to fix it. 