### PR TITLE
Fix react-spring handling animating paths

### DIFF
--- a/packages/annotations/src/AnnotationLink.js
+++ b/packages/annotations/src/AnnotationLink.js
@@ -8,23 +8,15 @@
  */
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
-import { useSpring, animated } from 'react-spring'
-import { useTheme, useMotionConfig } from '@nivo/core'
+import { animated } from 'react-spring'
+import { useAnimatedPath, useTheme } from '@nivo/core'
 
-const AnnotationLink = memo(({ points, isOutline }) => {
+const AnnotationLink = memo(({ isOutline, ...props }) => {
     const theme = useTheme()
+    const [point, ...points] = props.points
 
-    let path = `M${points[0][0]},${points[0][1]}`
-    points.slice(1).forEach(point => {
-        path = `${path} L${point[0]},${point[1]}`
-    })
-
-    const { animate, config: springConfig } = useMotionConfig()
-    const animatedProps = useSpring({
-        path,
-        config: springConfig,
-        immediate: !animate,
-    })
+    const path = points.reduce((acc, [x, y]) => `${acc} L${x},${y}`, `M${point[0]},${point[1]}`)
+    const animatedPath = useAnimatedPath(path)
 
     if (isOutline && theme.annotations.link.outlineWidth <= 0) {
         return null
@@ -38,7 +30,7 @@ const AnnotationLink = memo(({ points, isOutline }) => {
         style.stroke = theme.annotations.link.outlineColor
     }
 
-    return <animated.path fill="none" d={animatedProps.path} style={style} />
+    return <animated.path fill="none" d={animatedPath} style={style} />
 })
 
 AnnotationLink.displayName = 'AnnotationLink'

--- a/packages/bump/src/area-bump/Area.js
+++ b/packages/bump/src/area-bump/Area.js
@@ -9,7 +9,7 @@
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { useSpring, animated } from 'react-spring'
-import { useMotionConfig, blendModePropType } from '@nivo/core'
+import { useAnimatedPath, useMotionConfig, blendModePropType } from '@nivo/core'
 import { useSerieHandlers } from './hooks'
 
 const Area = ({
@@ -37,8 +37,8 @@ const Area = ({
 
     const { animate, config: springConfig } = useMotionConfig()
 
+    const animatedPath = useAnimatedPath(areaGenerator(serie.areaPoints))
     const animatedProps = useSpring({
-        path: areaGenerator(serie.areaPoints),
         color: serie.color,
         fillOpacity: serie.style.fillOpacity,
         stroke: serie.style.borderColor,
@@ -49,7 +49,7 @@ const Area = ({
 
     return (
         <animated.path
-            d={animatedProps.path}
+            d={animatedPath}
             fill={serie.fill ? serie.fill : animatedProps.color}
             fillOpacity={animatedProps.fillOpacity}
             stroke={animatedProps.stroke}

--- a/packages/bump/src/bump/Line.js
+++ b/packages/bump/src/bump/Line.js
@@ -9,7 +9,7 @@
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { useSpring, animated } from 'react-spring'
-import { useMotionConfig } from '@nivo/core'
+import { useAnimatedPath, useMotionConfig } from '@nivo/core'
 import { useSerieHandlers } from './hooks'
 
 const Line = ({
@@ -39,8 +39,8 @@ const Line = ({
 
     const linePath = lineGenerator(serie.linePoints)
 
+    const animatedPath = useAnimatedPath(linePath)
     const animatedProps = useSpring({
-        path: linePath,
         color: serie.color,
         opacity: serie.style.opacity,
         lineWidth: serie.style.lineWidth,
@@ -52,7 +52,7 @@ const Line = ({
         <>
             <animated.path
                 fill="none"
-                d={animatedProps.path}
+                d={animatedPath}
                 stroke={animatedProps.color}
                 strokeWidth={animatedProps.lineWidth}
                 strokeLinecap="round"

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { OpaqueInterpolation } from 'react-spring'
 
 declare module '@nivo/core' {
     export type DatumValue = string | number | Date
@@ -152,6 +153,7 @@ declare module '@nivo/core' {
 
     export type DataFormatter = (value: DatumValue) => string | number
 
+    export function useAnimatedPath(path: string): OpaqueInterpolation<string>
     export function useValueFormatter(formatter?: DataFormatter | string): DataFormatter
 
     export type LinearGradientDef = {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "d3-color": "^1.2.3",
     "d3-format": "^1.4.4",
     "d3-hierarchy": "^1.1.8",
+    "d3-interpolate": "^2.0.1",
     "d3-scale": "^3.0.0",
     "d3-scale-chromatic": "^1.3.3",
     "d3-shape": "^1.3.5",

--- a/packages/core/src/hooks/index.js
+++ b/packages/core/src/hooks/index.js
@@ -6,6 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+export * from './useAnimatedPath'
 export * from './useCurveInterpolation'
 export * from './useDimensions'
 export * from './useMeasure'

--- a/packages/core/src/hooks/useAnimatedPath.js
+++ b/packages/core/src/hooks/useAnimatedPath.js
@@ -1,0 +1,31 @@
+import { interpolateString } from 'd3-interpolate'
+import { useEffect, useMemo, useRef } from 'react'
+import { useMotionConfig } from '../motion'
+import { useSpring } from 'react-spring'
+
+const usePrevious = value => {
+    const ref = useRef()
+
+    useEffect(() => {
+        ref.current = value
+    }, [value])
+
+    return ref.current
+}
+
+export const useAnimatedPath = path => {
+    const { animate, config: springConfig } = useMotionConfig()
+
+    const previousPath = usePrevious(path)
+    const interpolator = useMemo(() => interpolateString(previousPath, path), [previousPath, path])
+
+    const { value } = useSpring({
+        from: { value: 0 },
+        to: { value: 1 },
+        reset: true,
+        config: springConfig,
+        immediate: !animate,
+    })
+
+    return value.interpolate(interpolator)
+}

--- a/packages/funnel/src/Part.js
+++ b/packages/funnel/src/Part.js
@@ -9,15 +9,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { useSpring, animated } from 'react-spring'
-import { useMotionConfig } from '@nivo/core'
+import { useAnimatedPath, useMotionConfig } from '@nivo/core'
 
 export const Part = ({ part, areaGenerator, borderGenerator }) => {
     const { animate, config: motionConfig } = useMotionConfig()
 
+    const animatedAreaPath = useAnimatedPath(areaGenerator(part.areaPoints))
+    const animatedBorderPath = useAnimatedPath(borderGenerator(part.borderPoints))
     const animatedProps = useSpring({
-        areaPath: areaGenerator(part.areaPoints),
         areaColor: part.color,
-        borderPath: borderGenerator(part.borderPoints),
         borderWidth: part.borderWidth,
         borderColor: part.borderColor,
         config: motionConfig,
@@ -28,7 +28,7 @@ export const Part = ({ part, areaGenerator, borderGenerator }) => {
         <>
             {part.borderWidth > 0 && (
                 <animated.path
-                    d={animatedProps.borderPath}
+                    d={animatedBorderPath}
                     stroke={animatedProps.borderColor}
                     strokeWidth={animatedProps.borderWidth}
                     strokeOpacity={part.borderOpacity}
@@ -36,7 +36,7 @@ export const Part = ({ part, areaGenerator, borderGenerator }) => {
                 />
             )}
             <animated.path
-                d={animatedProps.areaPath}
+                d={animatedAreaPath}
                 fill={animatedProps.areaColor}
                 fillOpacity={part.fillOpacity}
                 onMouseEnter={part.onMouseEnter}

--- a/packages/line/src/LinesItem.js
+++ b/packages/line/src/LinesItem.js
@@ -6,23 +6,16 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import React, { memo } from 'react'
+import React, { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { useSpring, animated } from 'react-spring'
-import { useMotionConfig } from '@nivo/core'
+import { animated } from 'react-spring'
+import { useAnimatedPath } from '@nivo/core'
 
 const LinesItem = ({ lineGenerator, points, color, thickness }) => {
-    const { animate, config: springConfig } = useMotionConfig()
+    const path = useMemo(() => lineGenerator(points), [lineGenerator, points])
+    const animatedPath = useAnimatedPath(path)
 
-    const animatedProps = useSpring({
-        path: lineGenerator(points),
-        config: springConfig,
-        immediate: !animate,
-    })
-
-    return (
-        <animated.path d={animatedProps.path} fill="none" strokeWidth={thickness} stroke={color} />
-    )
+    return <animated.path d={animatedPath} fill="none" strokeWidth={thickness} stroke={color} />
 }
 
 LinesItem.propTypes = {

--- a/packages/parallel-coordinates/src/ParallelCoordinatesAxisDensityPoly.js
+++ b/packages/parallel-coordinates/src/ParallelCoordinatesAxisDensityPoly.js
@@ -9,8 +9,8 @@
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { line } from 'd3-shape'
-import { useSpring, animated } from 'react-spring'
-import { curveFromProp, useMotionConfig } from '@nivo/core'
+import { animated } from 'react-spring'
+import { curveFromProp, useAnimatedPath } from '@nivo/core'
 
 const lineGenerator = line()
     .x(d => d.x)
@@ -52,18 +52,13 @@ const ParallelCoordinatesAxisDensityPoly = ({ axis, variable, variablesScale }) 
         })
     })
 
-    const { animate, config: springConfig } = useMotionConfig()
-    const animatedProps = useSpring({
-        path: lineGenerator(points),
-        config: springConfig,
-        immediate: !animate,
-    })
+    const animatedPath = useAnimatedPath(lineGenerator(points))
 
     if (variable.densityBins.length === 0) return null
 
     return (
         <animated.path
-            d={animatedProps.path}
+            d={animatedPath}
             fill="rgba(0,0,0,.06)"
             stroke="rgba(0,0,0,.3)"
             strokeWidth={1}

--- a/packages/parallel-coordinates/src/ParallelCoordinatesLine.js
+++ b/packages/parallel-coordinates/src/ParallelCoordinatesLine.js
@@ -9,7 +9,7 @@
 import React, { memo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useSpring, animated } from 'react-spring'
-import { useMotionConfig } from '@nivo/core'
+import { useAnimatedPath, useMotionConfig } from '@nivo/core'
 import { useTooltip } from '@nivo/tooltip'
 import ParallelCoordinatesLineTooltip from './ParallelCoordinatesLineTooltip'
 
@@ -34,8 +34,8 @@ const ParallelCoordinatesLine = ({
     )
 
     const { animate, config: springConfig } = useMotionConfig()
+    const animatedPath = useAnimatedPath(lineGenerator(points))
     const animatedProps = useSpring({
-        path: lineGenerator(points),
         color,
         opacity,
         config: springConfig,
@@ -44,7 +44,7 @@ const ParallelCoordinatesLine = ({
 
     return (
         <animated.path
-            d={animatedProps.path}
+            d={animatedPath}
             stroke={animatedProps.color}
             strokeWidth={strokeWidth}
             strokeLinecap="round"

--- a/packages/radar/src/Radar.js
+++ b/packages/radar/src/Radar.js
@@ -122,18 +122,23 @@ const Radar = memo(
                         label={gridLabel}
                         labelOffset={gridLabelOffset}
                     />
-                    <RadarShapes
-                        data={data}
-                        keys={keys}
-                        colorByKey={colorByKey}
-                        radiusScale={radiusScale}
-                        angleStep={angleStep}
-                        curveInterpolator={curveInterpolator}
-                        borderWidth={borderWidth}
-                        borderColor={borderColor}
-                        fillOpacity={fillOpacity}
-                        blendMode={blendMode}
-                    />
+                    {keys.map(key => (
+                        <RadarShapes
+                            key={key}
+                            {...{
+                                data,
+                                item: key,
+                                colorByKey,
+                                radiusScale,
+                                angleStep,
+                                curveInterpolator,
+                                borderWidth,
+                                borderColor,
+                                fillOpacity,
+                                blendMode,
+                            }}
+                        />
+                    ))}
                     {isInteractive && (
                         <RadarTooltip
                             data={data}

--- a/packages/radar/src/RadarGrid.js
+++ b/packages/radar/src/RadarGrid.js
@@ -38,12 +38,15 @@ const RadarGrid = memo(({ indices, levels, shape, radius, angleStep, label, labe
                     />
                 )
             })}
-            <RadarGridLevels
-                shape={shape}
-                radii={radii}
-                angleStep={angleStep}
-                dataLength={indices.length}
-            />
+            {radii.map((radius, i) => (
+                <RadarGridLevels
+                    key={`level.${i}`}
+                    shape={shape}
+                    radius={radius}
+                    angleStep={angleStep}
+                    dataLength={indices.length}
+                />
+            ))}
             <RadialGridLabels
                 radius={radius}
                 angles={angles}

--- a/packages/radar/src/RadarShapes.js
+++ b/packages/radar/src/RadarShapes.js
@@ -8,15 +8,15 @@
  */
 import React, { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { useSprings, animated } from 'react-spring'
+import { useSpring, animated } from 'react-spring'
 import { lineRadial } from 'd3-shape'
-import { useMotionConfig, useTheme, blendModePropType } from '@nivo/core'
+import { useMotionConfig, useTheme, useAnimatedPath, blendModePropType } from '@nivo/core'
 import { useInheritedColor, inheritedColorPropType } from '@nivo/colors'
 
 const RadarShapes = memo(
     ({
         data,
-        keys,
+        item: key,
         colorByKey,
         radiusScale,
         angleStep,
@@ -37,39 +37,32 @@ const RadarShapes = memo(
         }, [radiusScale, angleStep, curveInterpolator])
 
         const { animate, config: springConfig } = useMotionConfig()
-        const springs = useSprings(
-            keys.length,
-            keys.map(key => ({
-                path: lineGenerator(data.map(d => d[key])),
-                fill: colorByKey[key],
-                stroke: getBorderColor({ key, color: colorByKey[key] }),
-                config: springConfig,
-                immediate: !animate,
-            }))
-        )
-
-        return springs.map((animatedProps, index) => {
-            const key = keys[index]
-
-            return (
-                <animated.path
-                    key={key}
-                    d={animatedProps.path}
-                    fill={animatedProps.fill}
-                    fillOpacity={fillOpacity}
-                    stroke={animatedProps.stroke}
-                    strokeWidth={borderWidth}
-                    style={{ mixBlendMode: blendMode }}
-                />
-            )
+        const animatedPath = useAnimatedPath(lineGenerator(data.map(d => d[key])))
+        const animatedProps = useSpring({
+            fill: colorByKey[key],
+            stroke: getBorderColor({ key, color: colorByKey[key] }),
+            config: springConfig,
+            immediate: !animate,
         })
+
+        return (
+            <animated.path
+                key={key}
+                d={animatedPath}
+                fill={animatedProps.fill}
+                fillOpacity={fillOpacity}
+                stroke={animatedProps.stroke}
+                strokeWidth={borderWidth}
+                style={{ mixBlendMode: blendMode }}
+            />
+        )
     }
 )
 
 RadarShapes.displayName = 'RadarShapes'
 RadarShapes.propTypes = {
     data: PropTypes.arrayOf(PropTypes.object).isRequired,
-    keys: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+    item: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     colorByKey: PropTypes.object.isRequired,
 
     radiusScale: PropTypes.func.isRequired,

--- a/packages/sankey/src/SankeyLinksItem.js
+++ b/packages/sankey/src/SankeyLinksItem.js
@@ -9,7 +9,7 @@
 import React, { memo, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { useSpring, animated } from 'react-spring'
-import { blendModePropType, useMotionConfig } from '@nivo/core'
+import { blendModePropType, useAnimatedPath, useMotionConfig } from '@nivo/core'
 import { BasicTooltip, Chip, useTooltip } from '@nivo/tooltip'
 import SankeyLinkGradient from './SankeyLinkGradient'
 
@@ -73,8 +73,8 @@ const SankeyLinksItem = ({
     const linkId = `${link.source.id}.${link.target.id}`
 
     const { animate, config: springConfig } = useMotionConfig()
+    const animatedPath = useAnimatedPath(path)
     const animatedProps = useSpring({
-        path,
         color,
         opacity,
         config: springConfig,
@@ -130,7 +130,7 @@ const SankeyLinksItem = ({
             )}
             <animated.path
                 fill={enableGradient ? `url("#${encodeURI(linkId)}")` : animatedProps.color}
-                d={animatedProps.path}
+                d={animatedPath}
                 fillOpacity={animatedProps.opacity}
                 onMouseEnter={isInteractive ? handleMouseEnter : undefined}
                 onMouseMove={isInteractive ? handleMouseMove : undefined}

--- a/packages/stream/src/StreamLayer.js
+++ b/packages/stream/src/StreamLayer.js
@@ -9,7 +9,7 @@
 import React, { memo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useSpring, animated } from 'react-spring'
-import { useMotionConfig } from '@nivo/core'
+import { useAnimatedPath, useMotionConfig } from '@nivo/core'
 import { BasicTooltip, useTooltip } from '@nivo/tooltip'
 
 const StreamLayer = ({
@@ -33,8 +33,8 @@ const StreamLayer = ({
     )
 
     const { animate, config: springConfig } = useMotionConfig()
+    const animatedPath = useAnimatedPath(layer.path)
     const animatedProps = useSpring({
-        path: layer.path,
         color: layer.color,
         config: springConfig,
         immediate: !animate,
@@ -42,7 +42,7 @@ const StreamLayer = ({
 
     return (
         <animated.path
-            d={animatedProps.path}
+            d={animatedPath}
             fill={layer.fill ? layer.fill : animatedProps.color}
             fillOpacity={fillOpacity}
             stroke={getBorderColor(layer)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5017,6 +5017,18 @@
   resolved "https://registry.yarnpkg.com/@types/configstore/-/configstore-2.1.1.tgz#cd1e8553633ad3185c3f2f239ecff5d2643e92b6"
   integrity sha1-zR6FU2M60xhcPy8jns/10mQ+krY=
 
+"@types/d3-path@^1":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
+  integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
+
+"@types/d3-shape@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-2.0.0.tgz#61aa065726f3c2641aedc59c3603475ab11aeb2f"
+  integrity sha512-NLzD02m5PiD1KLEDjLN+MtqEcFYn4ZL9+Rqc9ZwARK1cpKZXd91zBETbe6wpBB6Ia0D0VZbpmbW3+BsGPGnCpA==
+  dependencies:
+    "@types/d3-path" "^1"
+
 "@types/debug@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.29.tgz#a1e514adfbd92f03a224ba54d693111dbf1f3754"
@@ -9096,6 +9108,11 @@ d3-color@1, d3-color@^1.2.3:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.3.tgz#6c67bb2af6df3cc8d79efcc4d3a3e83e28c8048f"
   integrity sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw==
 
+"d3-color@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
+  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
+
 d3-delaunay@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-5.1.1.tgz#fa2313f5fff1c6007f7d814276fc6914f370d63c"
@@ -9145,6 +9162,13 @@ d3-interpolate@1:
   integrity sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==
   dependencies:
     d3-color "1"
+
+d3-interpolate@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-2.0.1.tgz#98be499cfb8a3b94d4ff616900501a64abc91163"
+  integrity sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==
+  dependencies:
+    d3-color "1 - 2"
 
 d3-path@1:
   version "1.0.7"


### PR DESCRIPTION
Animating paths don't work well with `react-spring` as they did previous with `react-motion`. I've created a custom hook that can be used to animate the paths properly.

This might be charts that support animating `curve` prop that crash, others might work correctly. The when trying to animate a curve, `react-spring` receives different size paths and tries to split strings and crashes because the lengths don't match.

I've added a list of charts below that contain `animated.path` component and will check each individually and either push fixes or check the box to ensure it is working properly.

Close #1170 
Close #1171

------

TODO:

- [x] annotations
- [x] bump
- [x] funnel
- [x] line
- [x] parallel-coordinates
- [x] radar
- [x] sankey
- [x] stream