### PR TITLE
fix(storybook): always pull latest version of generators package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@babel/core": "^7.10.3",
     "@ekino/config": "^0.3.0",
-    "@nivo/generators": "0.62.0",
+    "@nivo/generators": "*",
     "@rollup/plugin-babel": "^5.0.3",
     "@rollup/plugin-node-resolve": "^8.0.1",
     "@storybook/addon-actions": "^5.3.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4243,16 +4243,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nivo/generators@0.62.0":
-  version "0.62.0"
-  resolved "https://registry.yarnpkg.com/@nivo/generators/-/generators-0.62.0.tgz#f70d66ed20aeed0d2f9f5bc8fb87989f8bb67337"
-  integrity sha512-IRlDOyLLfVPR4r4nTOtn2mHH1Z/Uf2o0PIUW3YDPwB0bNfaJDhInx15hp06H0It/4wihYv7GcqsVl3IWKGECNw==
-  dependencies:
-    d3-random "^1.1.2"
-    d3-time "^1.0.10"
-    d3-time-format "^2.1.3"
-    lodash "^4.17.11"
-
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -5016,18 +5006,6 @@
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/configstore/-/configstore-2.1.1.tgz#cd1e8553633ad3185c3f2f239ecff5d2643e92b6"
   integrity sha1-zR6FU2M60xhcPy8jns/10mQ+krY=
-
-"@types/d3-path@^1":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
-  integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
-
-"@types/d3-shape@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-2.0.0.tgz#61aa065726f3c2641aedc59c3603475ab11aeb2f"
-  integrity sha512-NLzD02m5PiD1KLEDjLN+MtqEcFYn4ZL9+Rqc9ZwARK1cpKZXd91zBETbe6wpBB6Ia0D0VZbpmbW3+BsGPGnCpA==
-  dependencies:
-    "@types/d3-path" "^1"
 
 "@types/debug@^0.0.29":
   version "0.0.29"


### PR DESCRIPTION
For some reason I keep having to do this locally, but the deployed version is fine. Better to do this now so we avoid problems in the future
