### PR TITLE
fix(theme): remove default fill for legends.text theme

### DIFF
--- a/packages/core/src/theming/defaultTheme.js
+++ b/packages/core/src/theming/defaultTheme.js
@@ -38,9 +38,7 @@ export const defaultTheme = {
         },
     },
     legends: {
-        text: {
-            fill: '#333333',
-        },
+        text: {},
     },
     labels: {
         text: {},

--- a/packages/legends/tests/svg/LegendSvgItem.test.js
+++ b/packages/legends/tests/svg/LegendSvgItem.test.js
@@ -6,11 +6,11 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import React, { Component } from 'react'
+import React from 'react'
 import renderer from 'react-test-renderer'
 import { mount } from 'enzyme'
-import { defaultTheme, themeContext } from '@nivo/core'
-import { default as BaseLegendSvgItem } from '../../src/svg/LegendSvgItem'
+import { ThemeProvider } from '@nivo/core'
+import BaseLegendSvgItem from '../../src/svg/LegendSvgItem'
 import * as shapes from '../../src/svg/symbols'
 import {
     DIRECTION_LEFT_TO_RIGHT,
@@ -38,19 +38,11 @@ const directions = [
     DIRECTION_BOTTOM_TO_TOP,
 ]
 
-const withTheme = WrappedComponent => {
-    return class ThemedLegendSvgItem extends Component {
-        render() {
-            return (
-                <themeContext.Provider value={defaultTheme}>
-                    <WrappedComponent {...this.props} />
-                </themeContext.Provider>
-            )
-        }
-    }
-}
-
-const LegendSvgItem = withTheme(BaseLegendSvgItem)
+const LegendSvgItem = props => (
+    <ThemeProvider>
+        <BaseLegendSvgItem {...props} />
+    </ThemeProvider>
+)
 
 directions.forEach(direction => {
     it(`should support ${direction} direction`, () => {

--- a/packages/legends/tests/svg/__snapshots__/LegendSvgItem.test.js.snap
+++ b/packages/legends/tests/svg/__snapshots__/LegendSvgItem.test.js.snap
@@ -41,6 +41,8 @@ exports[`should support bottom-to-top direction 1`] = `
       Object {
         "dominantBaseline": "alphabetic",
         "fill": "#333333",
+        "fontFamily": "sans-serif",
+        "fontSize": 11,
         "pointerEvents": "none",
         "userSelect": "none",
       }
@@ -95,6 +97,8 @@ exports[`should support bottom-to-top direction justified 1`] = `
       Object {
         "dominantBaseline": "text-before-edge",
         "fill": "#333333",
+        "fontFamily": "sans-serif",
+        "fontSize": 11,
         "pointerEvents": "none",
         "userSelect": "none",
       }
@@ -149,6 +153,8 @@ exports[`should support left-to-right direction 1`] = `
       Object {
         "dominantBaseline": "central",
         "fill": "#333333",
+        "fontFamily": "sans-serif",
+        "fontSize": 11,
         "pointerEvents": "none",
         "userSelect": "none",
       }
@@ -203,6 +209,8 @@ exports[`should support left-to-right direction justified 1`] = `
       Object {
         "dominantBaseline": "central",
         "fill": "#333333",
+        "fontFamily": "sans-serif",
+        "fontSize": 11,
         "pointerEvents": "none",
         "userSelect": "none",
       }
@@ -257,6 +265,8 @@ exports[`should support right-to-left direction 1`] = `
       Object {
         "dominantBaseline": "central",
         "fill": "#333333",
+        "fontFamily": "sans-serif",
+        "fontSize": 11,
         "pointerEvents": "none",
         "userSelect": "none",
       }
@@ -311,6 +321,8 @@ exports[`should support right-to-left direction justified 1`] = `
       Object {
         "dominantBaseline": "central",
         "fill": "#333333",
+        "fontFamily": "sans-serif",
+        "fontSize": 11,
         "pointerEvents": "none",
         "userSelect": "none",
       }
@@ -365,6 +377,8 @@ exports[`should support top-to-bottom direction 1`] = `
       Object {
         "dominantBaseline": "text-before-edge",
         "fill": "#333333",
+        "fontFamily": "sans-serif",
+        "fontSize": 11,
         "pointerEvents": "none",
         "userSelect": "none",
       }
@@ -419,6 +433,8 @@ exports[`should support top-to-bottom direction justified 1`] = `
       Object {
         "dominantBaseline": "alphabetic",
         "fill": "#333333",
+        "fontFamily": "sans-serif",
+        "fontSize": 11,
         "pointerEvents": "none",
         "userSelect": "none",
       }


### PR DESCRIPTION
This will still get populated from extendDefaultTheme and will respect when the user provides a theme.textColor property

Close #1179
