### PR TITLE
feat(bar): add ability to set scale config via `valueScale` prop

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -18,6 +18,7 @@ import {
 import { AxisProps, GridValues } from '@nivo/axes'
 import { OrdinalColorsInstruction, InheritedColorProp } from '@nivo/colors'
 import { LegendProps } from '@nivo/legends'
+import { Scale } from '@nivo/scales'
 
 declare module '@nivo/bar' {
     export type Value = string | number
@@ -96,6 +97,8 @@ declare module '@nivo/bar' {
         margin: Box
         maxValue: number | 'auto'
         padding: number
+
+        valueScale: Scale
 
         axisBottom: AxisProps | null
         axisLeft: AxisProps | null

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -28,6 +28,7 @@
     "@nivo/colors": "0.63.0",
     "@nivo/core": "0.63.1",
     "@nivo/legends": "0.63.1",
+    "@nivo/scales": "0.63.0",
     "@nivo/tooltip": "0.63.0",
     "d3-scale": "^3.0.0",
     "d3-shape": "^1.2.2",

--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -57,6 +57,8 @@ const Bar = props => {
         minValue,
         maxValue,
 
+        valueScale,
+
         margin,
         width,
         height,
@@ -111,7 +113,8 @@ const Bar = props => {
 
         role,
     } = props
-    const options = {
+    const generateBars = groupMode === 'grouped' ? generateGroupedBars : generateStackedBars
+    const result = generateBars({
         layout,
         reverse,
         data,
@@ -124,9 +127,8 @@ const Bar = props => {
         getColor,
         padding,
         innerPadding,
-    }
-    const result =
-        groupMode === 'grouped' ? generateGroupedBars(options) : generateStackedBars(options)
+        valueScale,
+    })
 
     const motionProps = {
         animate,

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -6,38 +6,16 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import min from 'lodash/min'
-import max from 'lodash/max'
-import range from 'lodash/range'
-import { scaleLinear } from 'd3-scale'
+import { computeScale } from '@nivo/scales'
 import { getIndexedScale } from './common'
 
-/**
- * Generates scale for grouped bar chart.
- *
- * @param {Array.<Object>} data
- * @param {Array.<string>} keys
- * @param {number}         _minValue
- * @param {number|string}  _maxValue
- * @param {Array.<number>} range
- * @returns {Function}
- */
-export const getGroupedScale = (data, keys, _minValue, _maxValue, range) => {
-    const allValues = data.reduce((acc, entry) => [...acc, ...keys.map(k => entry[k])], [])
+const gt = (value, other) => value > other
+const lt = (value, other) => value < other
 
-    let maxValue = _maxValue
-    if (maxValue === 'auto') {
-        maxValue = max(allValues)
-    }
+const flatten = array => [].concat(...array)
+const range = (start, end) => Array.from(' '.repeat(end - start), (_, index) => start + index)
 
-    let minValue = _minValue
-    if (minValue === 'auto') {
-        minValue = min(allValues)
-        if (minValue > 0) minValue = 0
-    }
-
-    return scaleLinear().rangeRound(range).domain([minValue, maxValue])
-}
+const clampToZero = value => (gt(value, 0) ? 0 : value)
 
 /**
  * Generates x/y scales & bars for vertical grouped bar chart.
@@ -55,65 +33,44 @@ export const getGroupedScale = (data, keys, _minValue, _maxValue, range) => {
  * @param {number}         [innerPadding=0]
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
-export const generateVerticalGroupedBars = ({
-    data,
-    getIndex,
-    keys,
-    minValue,
-    maxValue,
+const generateVerticalGroupedBars = (
+    { data, getIndex, keys, getColor, innerPadding, xScale, yScale },
+    barWidth,
     reverse,
-    width,
-    height,
-    getColor,
-    padding = 0,
-    innerPadding = 0,
-}) => {
-    const xScale = getIndexedScale(data, getIndex, [0, width], padding)
-    const yRange = reverse ? [0, height] : [height, 0]
-    const yScale = getGroupedScale(data, keys, minValue, maxValue, yRange)
+    yRef
+) => {
+    const compare = reverse ? lt : gt
+    const getY = d => (compare(d, 0) ? yScale(d) : yRef)
+    const getHeight = (d, y) => (compare(d, 0) ? yRef - y : yScale(d) - yRef)
 
-    const barWidth = (xScale.bandwidth() - innerPadding * (keys.length - 1)) / keys.length
-    const yRef = yScale(0)
-
-    let getY = d => (d > 0 ? yScale(d) : yRef)
-    let getHeight = (d, y) => (d > 0 ? yRef - y : yScale(d) - yRef)
-    if (reverse) {
-        getY = d => (d < 0 ? yScale(d) : yRef)
-        getHeight = (d, y) => (d < 0 ? yRef - y : yScale(d) - yRef)
-    }
-
-    const bars = []
-    if (barWidth > 0) {
-        keys.forEach((key, i) => {
-            range(xScale.domain().length).forEach(index => {
+    const bars = flatten(
+        keys.map((key, i) =>
+            range(0, xScale.domain().length).map(index => {
                 const x = xScale(getIndex(data[index])) + barWidth * i + innerPadding * i
                 const y = getY(data[index][key])
                 const barHeight = getHeight(data[index][key], y)
+                const barData = {
+                    id: key,
+                    value: data[index][key],
+                    index,
+                    indexValue: getIndex(data[index]),
+                    data: data[index],
+                }
 
-                if (barWidth > 0 && barHeight > 0) {
-                    const barData = {
-                        id: key,
-                        value: data[index][key],
-                        index,
-                        indexValue: getIndex(data[index]),
-                        data: data[index],
-                    }
-
-                    bars.push({
-                        key: `${key}.${barData.indexValue}`,
-                        data: barData,
-                        x,
-                        y,
-                        width: barWidth,
-                        height: barHeight,
-                        color: getColor(barData),
-                    })
+                return {
+                    key: `${key}.${barData.indexValue}`,
+                    data: barData,
+                    x,
+                    y,
+                    width: barWidth,
+                    height: barHeight,
+                    color: getColor(barData),
                 }
             })
-        })
-    }
+        )
+    ).filter(bar => gt(bar.width, 0) && gt(bar.height, 0))
 
-    return { xScale, yScale, bars }
+    return bars
 }
 
 /**
@@ -132,65 +89,44 @@ export const generateVerticalGroupedBars = ({
  * @param {number}         [innerPadding=0]
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
-export const generateHorizontalGroupedBars = ({
-    data,
-    getIndex,
-    keys,
-    minValue,
-    maxValue,
+const generateHorizontalGroupedBars = (
+    { data, getIndex, keys, getColor, innerPadding = 0, xScale, yScale },
+    barHeight,
     reverse,
-    width,
-    height,
-    getColor,
-    padding = 0,
-    innerPadding = 0,
-}) => {
-    const xRange = reverse ? [width, 0] : [0, width]
-    const xScale = getGroupedScale(data, keys, minValue, maxValue, xRange)
-    const yScale = getIndexedScale(data, getIndex, [height, 0], padding)
+    xRef
+) => {
+    const compare = reverse ? lt : gt
+    const getX = d => (compare(d, 0) ? xRef : xScale(d))
+    const getWidth = (d, x) => (compare(d, 0) ? xScale(d) - xRef : xRef - x)
 
-    const barHeight = (yScale.bandwidth() - innerPadding * (keys.length - 1)) / keys.length
-    const xRef = xScale(0)
-
-    let getX = d => (d > 0 ? xRef : xScale(d))
-    let getWidth = (d, x) => (d > 0 ? xScale(d) - xRef : xRef - x)
-    if (reverse) {
-        getX = d => (d < 0 ? xRef : xScale(d))
-        getWidth = (d, x) => (d < 0 ? xScale(d) - xRef : xRef - x)
-    }
-
-    const bars = []
-    if (barHeight > 0) {
-        keys.forEach((key, i) => {
-            range(yScale.domain().length).forEach(index => {
+    const bars = flatten(
+        keys.map((key, i) =>
+            range(0, yScale.domain().length).map(index => {
                 const x = getX(data[index][key])
                 const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
                 const barWidth = getWidth(data[index][key], x)
+                const barData = {
+                    id: key,
+                    value: data[index][key],
+                    index,
+                    indexValue: getIndex(data[index]),
+                    data: data[index],
+                }
 
-                if (barWidth > 0) {
-                    const barData = {
-                        id: key,
-                        value: data[index][key],
-                        index,
-                        indexValue: getIndex(data[index]),
-                        data: data[index],
-                    }
-
-                    bars.push({
-                        key: `${key}.${barData.indexValue}`,
-                        data: barData,
-                        x,
-                        y,
-                        width: barWidth,
-                        height: barHeight,
-                        color: getColor(barData),
-                    })
+                return {
+                    key: `${key}.${barData.indexValue}`,
+                    data: barData,
+                    x,
+                    y,
+                    width: barWidth,
+                    height: barHeight,
+                    color: getColor(barData),
                 }
             })
-        })
-    }
+        )
+    ).filter(bar => gt(bar.width, 0))
 
-    return { xScale, yScale, bars }
+    return bars
 }
 
 /**
@@ -199,7 +135,54 @@ export const generateHorizontalGroupedBars = ({
  * @param {Object} options
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
-export const generateGroupedBars = options =>
-    options.layout === 'vertical'
-        ? generateVerticalGroupedBars(options)
-        : generateHorizontalGroupedBars(options)
+export const generateGroupedBars = ({
+    data,
+    layout,
+    keys,
+    minValue,
+    maxValue,
+    reverse,
+    width,
+    height,
+    padding = 0,
+    innerPadding = 0,
+    valueScale,
+    ...props
+}) => {
+    const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
+    const indexedScale = getIndexedScale(data, props.getIndex, range, padding)
+
+    const scaleSpec = {
+        axis,
+        max: maxValue,
+        min: minValue,
+        reverse,
+        ...valueScale,
+    }
+    const clampMin = scaleSpec.min === 'auto' ? clampToZero : value => value
+
+    const values = data.reduce((acc, entry) => [...acc, ...keys.map(k => entry[k])], [])
+    const min = clampMin(Math.min(...values))
+    const max = Math.max(...values)
+
+    const scale = computeScale(scaleSpec, { [axis]: { min, max } }, width, height)
+
+    const [xScale, yScale] = layout === 'vertical' ? [indexedScale, scale] : [scale, indexedScale]
+
+    const bandwidth = (indexedScale.bandwidth() - innerPadding * (keys.length - 1)) / keys.length
+    const params = [
+        { ...props, data, keys, innerPadding, xScale, yScale },
+        bandwidth,
+        scaleSpec.reverse,
+        scale(0),
+    ]
+
+    const bars =
+        bandwidth > 0
+            ? layout === 'vertical'
+                ? generateVerticalGroupedBars(...params)
+                : generateHorizontalGroupedBars(...params)
+            : []
+
+    return { xScale, yScale, bars }
+}

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -6,37 +6,19 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import min from 'lodash/min'
-import max from 'lodash/max'
-import flattenDepth from 'lodash/flattenDepth'
-import { scaleLinear } from 'd3-scale'
+// import flattenDepth from 'lodash/flattenDepth'
+import { computeScale } from '@nivo/scales'
 import { stack, stackOffsetDiverging } from 'd3-shape'
 import { getIndexedScale } from './common'
 
-/**
- * Generates scale for stacked bar chart.
- *
- * @param {Array.<Object>} data
- * @param {number|string}  _minValue
- * @param {number|string}  _maxValue
- * @param {Array.<number>} range
- * @returns {Function}
- */
-export const getStackedScale = (data, _minValue, _maxValue, range) => {
-    const allValues = flattenDepth(data, 2)
-
-    let minValue = _minValue
-    if (minValue === 'auto') {
-        minValue = min(allValues)
-    }
-
-    let maxValue = _maxValue
-    if (maxValue === 'auto') {
-        maxValue = max(allValues)
-    }
-
-    return scaleLinear().rangeRound(range).domain([minValue, maxValue])
-}
+const flattenDeep = (array, depth = 1) =>
+    depth > 0
+        ? array.reduce(
+              (acc, value) =>
+                  acc.concat(Array.isArray(value) ? flattenDeep(value, depth - 1) : value),
+              []
+          )
+        : array.slice()
 
 /**
  * Generates x/y scales & bars for vertical stacked bar chart.
@@ -54,72 +36,44 @@ export const getStackedScale = (data, _minValue, _maxValue, range) => {
  * @param {number}         [innerPadding=0]
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
-export const generateVerticalStackedBars = ({
-    data,
-    getIndex,
-    keys,
-    minValue,
-    maxValue,
-    reverse,
-    width,
-    height,
-    getColor,
-    padding = 0,
-    innerPadding = 0,
-}) => {
-    const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(data)
+const generateVerticalStackedBars = (
+    { getIndex, getColor, innerPadding, stackedData, xScale, yScale },
+    barWidth,
+    reverse
+) => {
+    const getY = d => yScale(d[reverse ? 0 : 1])
+    const getHeight = (d, y) => yScale(d[reverse ? 1 : 0]) - y
 
-    const xScale = getIndexedScale(data, getIndex, [0, width], padding)
-    const yRange = reverse ? [0, height] : [height, 0]
-    const yScale = getStackedScale(stackedData, minValue, maxValue, yRange)
-
-    const bars = []
-    const barWidth = xScale.bandwidth()
-
-    let getY = d => yScale(d[1])
-    let getHeight = (d, y) => yScale(d[0]) - y
-    if (reverse) {
-        getY = d => yScale(d[0])
-        getHeight = (d, y) => yScale(d[1]) - y
-    }
-
-    if (barWidth > 0) {
-        stackedData.forEach(stackedDataItem => {
-            xScale.domain().forEach((index, i) => {
+    const bars = flattenDeep(
+        stackedData.map(stackedDataItem =>
+            xScale.domain().map((index, i) => {
                 const d = stackedDataItem[i]
                 const x = xScale(getIndex(d.data))
+                const y = getY(d) + innerPadding * 0.5
+                const barHeight = getHeight(d, y) - innerPadding
 
-                let y = getY(d)
-                let barHeight = getHeight(d, y)
-                if (innerPadding > 0) {
-                    y += innerPadding * 0.5
-                    barHeight -= innerPadding
+                const barData = {
+                    id: stackedDataItem.key,
+                    value: d.data[stackedDataItem.key],
+                    index: i,
+                    indexValue: index,
+                    data: d.data,
                 }
 
-                if (barHeight > 0) {
-                    const barData = {
-                        id: stackedDataItem.key,
-                        value: d.data[stackedDataItem.key],
-                        index: i,
-                        indexValue: index,
-                        data: d.data,
-                    }
-
-                    bars.push({
-                        key: `${stackedDataItem.key}.${index}`,
-                        data: barData,
-                        x,
-                        y,
-                        width: barWidth,
-                        height: barHeight,
-                        color: getColor(barData),
-                    })
+                return {
+                    key: `${stackedDataItem.key}.${index}`,
+                    data: barData,
+                    x,
+                    y,
+                    width: barWidth,
+                    height: barHeight,
+                    color: getColor(barData),
                 }
             })
-        })
-    }
+        )
+    ).filter(bar => bar.height > 0)
 
-    return { xScale, yScale, bars }
+    return bars
 }
 
 /**
@@ -138,40 +92,21 @@ export const generateVerticalStackedBars = ({
  * @param {number}         [innerPadding=0]
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
-export const generateHorizontalStackedBars = ({
-    data,
-    getIndex,
-    keys,
-    minValue,
-    maxValue,
-    reverse,
-    width,
-    height,
-    getColor,
-    padding = 0,
-    innerPadding = 0,
-}) => {
-    const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(data)
+const generateHorizontalStackedBars = (
+    { getIndex, getColor, innerPadding, stackedData, xScale, yScale },
+    barHeight,
+    reverse
+) => {
+    const getX = d => xScale(d[reverse ? 1 : 0])
+    const getWidth = (d, x) => xScale(d[reverse ? 0 : 1]) - x
 
-    const xRange = reverse ? [width, 0] : [0, width]
-    const xScale = getStackedScale(stackedData, minValue, maxValue, xRange)
-    const yScale = getIndexedScale(data, getIndex, [height, 0], padding)
-
-    const bars = []
-    const barHeight = yScale.bandwidth()
-
-    let getX = d => xScale(d[0])
-    let getWidth = (d, x) => xScale(d[1]) - x
-    if (reverse) {
-        getX = d => xScale(d[1])
-        getWidth = (d, y) => xScale(d[0]) - y
-    }
-
-    if (barHeight > 0) {
-        stackedData.forEach(stackedDataItem => {
-            yScale.domain().forEach((index, i) => {
+    const bars = flattenDeep(
+        stackedData.map(stackedDataItem =>
+            yScale.domain().map((index, i) => {
                 const d = stackedDataItem[i]
                 const y = yScale(getIndex(d.data))
+                const x = getX(d) + innerPadding * 0.5
+                const barWidth = getWidth(d, x) - innerPadding
 
                 const barData = {
                     id: stackedDataItem.key,
@@ -181,29 +116,20 @@ export const generateHorizontalStackedBars = ({
                     data: d.data,
                 }
 
-                let x = getX(d)
-                let barWidth = getWidth(d, x)
-                if (innerPadding > 0) {
-                    x += innerPadding * 0.5
-                    barWidth -= innerPadding
-                }
-
-                if (barWidth > 0) {
-                    bars.push({
-                        key: `${stackedDataItem.key}.${index}`,
-                        data: barData,
-                        x,
-                        y,
-                        width: barWidth,
-                        height: barHeight,
-                        color: getColor(barData),
-                    })
+                return {
+                    key: `${stackedDataItem.key}.${index}`,
+                    data: barData,
+                    x,
+                    y,
+                    width: barWidth,
+                    height: barHeight,
+                    color: getColor(barData),
                 }
             })
-        })
-    }
+        )
+    ).filter(bar => bar.width > 0)
 
-    return { xScale, yScale, bars }
+    return bars
 }
 
 /**
@@ -212,7 +138,54 @@ export const generateHorizontalStackedBars = ({
  * @param {Object} options
  * @return {{ xScale: Function, yScale: Function, bars: Array.<Object> }}
  */
-export const generateStackedBars = options =>
-    options.layout === 'vertical'
-        ? generateVerticalStackedBars(options)
-        : generateHorizontalStackedBars(options)
+export const generateStackedBars = ({
+    data,
+    keys,
+    layout,
+    minValue,
+    maxValue,
+    reverse,
+    width,
+    height,
+    padding = 0,
+    valueScale,
+    ...props
+}) => {
+    const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(data)
+
+    const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
+    const indexedScale = getIndexedScale(data, props.getIndex, range, padding)
+
+    const scaleSpec = {
+        axis,
+        max: maxValue,
+        min: minValue,
+        reverse,
+        ...valueScale,
+    }
+
+    const values = flattenDeep(stackedData, 2)
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+
+    const scale = computeScale(scaleSpec, { [axis]: { min, max } }, width, height)
+
+    const [xScale, yScale] = layout === 'vertical' ? [indexedScale, scale] : [scale, indexedScale]
+
+    const innerPadding = props.innerPadding > 0 ? props.innerPadding : 0
+    const bandwidth = indexedScale.bandwidth()
+    const params = [
+        { ...props, innerPadding, stackedData, xScale, yScale },
+        bandwidth,
+        scaleSpec.reverse,
+    ]
+
+    const bars =
+        bandwidth > 0
+            ? layout === 'vertical'
+                ? generateVerticalStackedBars(...params)
+                : generateHorizontalStackedBars(...params)
+            : []
+
+    return { xScale, yScale, bars }
+}

--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -15,6 +15,7 @@ import {
 } from '@nivo/colors'
 import { axisPropType } from '@nivo/axes'
 import { LegendPropShape } from '@nivo/legends'
+import { scalePropType } from '@nivo/scales'
 import BarItem from './BarItem'
 
 export const BarPropTypes = {
@@ -32,7 +33,7 @@ export const BarPropTypes = {
     groupMode: PropTypes.oneOf(['stacked', 'grouped']).isRequired,
     layout: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
     reverse: PropTypes.bool.isRequired,
-
+    valueScale: scalePropType.isRequired,
     minValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
     maxValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
     padding: PropTypes.number.isRequired,
@@ -110,6 +111,9 @@ export const BarDefaultProps = {
 
     minValue: 'auto',
     maxValue: 'auto',
+
+    valueScale: { type: 'linear' },
+
     padding: 0.1,
     innerPadding: 0,
 

--- a/packages/bar/stories/bar.stories.js
+++ b/packages/bar/stories/bar.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
+import { withKnobs, select } from '@storybook/addon-knobs'
 import { generateCountriesData, sets } from '@nivo/generators'
 import range from 'lodash/range'
 import random from 'lodash/random'
@@ -22,6 +23,8 @@ const commonProps = {
 }
 
 const stories = storiesOf('Bar', module)
+
+stories.addDecorator(withKnobs)
 
 stories.add('stacked', () => <Bar {...commonProps} />)
 
@@ -250,5 +253,18 @@ stories.add('enter/leave (check actions)', () => (
         {...commonProps}
         onMouseEnter={action('onMouseEnter')}
         onMouseLeave={action('onMouseLeave')}
+    />
+))
+
+stories.add('with symlog scale', () => (
+    <Bar
+        {...commonProps}
+        data={[
+            { country: 'A', population: 100 },
+            { country: 'B', population: 50000 },
+            { country: 'C', population: 15000 },
+        ]}
+        keys={['population']}
+        valueScale={{ type: select('scale', ['symlog', 'linear'], 'symlog') }}
     />
 ))

--- a/website/src/data/components/bar/meta.yml
+++ b/website/src/data/components/bar/meta.yml
@@ -26,6 +26,8 @@ Bar:
       link: bar--custom-tooltip
     - label: Custom axis ticks
       link: bar--custom-axis-ticks
+    - label: With symlog scale
+      link: bar--with-symlog-scale
     - label: Race bar chart
       link: bar-race-chart--demo
   description: |

--- a/website/src/data/components/bar/props.js
+++ b/website/src/data/components/bar/props.js
@@ -30,7 +30,7 @@ const props = [
         description: `
             Key to use to index the data,
             this key must exist in each data item.
-            
+
             You can also provide a function which will
             receive the data item and must return the desired index.
         `,
@@ -74,6 +74,31 @@ const props = [
             choices: [
                 { label: 'horizontal', value: 'horizontal' },
                 { label: 'vertical', value: 'vertical' },
+            ],
+        },
+    },
+    {
+        key: 'valueScale',
+        type: 'object',
+        group: 'Base',
+        help: `value scale configuration.`,
+        defaultValue: defaults.valueScale,
+        controlType: 'object',
+        controlOptions: {
+            props: [
+                {
+                    key: 'type',
+                    help: `Scale type.`,
+                    type: 'string',
+                    controlType: 'choices',
+                    controlOptions: {
+                        disabled: true,
+                        choices: ['linear', 'symlog'].map(v => ({
+                            label: v,
+                            value: v,
+                        })),
+                    },
+                },
             ],
         },
     },
@@ -324,12 +349,12 @@ const props = [
         help: 'Define how bar labels are computed.',
         description: `
             Define how bar labels are computed.
-            
+
             By default it will use the bar's value.
             It accepts a string which will be used to access
             a specific bar data property, such as
             \`'value'\` or \`'id'\`.
-            
+
             You can also use a funtion if you want to
             add more logic, this function will receive
             the current bar's data and must return

--- a/website/src/pages/bar/index.js
+++ b/website/src/pages/bar/index.js
@@ -38,6 +38,8 @@ const initialProperties = {
     layout: 'vertical',
     reverse: false,
 
+    valueScale: { type: 'linear' },
+
     colors: { scheme: 'nivo' },
     colorBy: 'id',
     defs: [


### PR DESCRIPTION
- Cleaned up and reduced duplication in compute grouped/stack functions
- Removed mutation in compute code and made it more functional
- Added story with knob to show difference between linear/symlog
- Updated website with valueScale prop
