### PR TITLE
fix(tooltip): Show tooltip on first tap for touch devices

### DIFF
--- a/packages/tooltip/src/components/TooltipWrapper.js
+++ b/packages/tooltip/src/components/TooltipWrapper.js
@@ -21,6 +21,8 @@ const tooltipStyle = {
     left: 0,
 }
 
+const translate = (x, y) => `translate(${x}px, ${y}px)`
+
 const TooltipWrapper = ({ position, anchor, children }) => {
     const theme = useTheme()
     const { animate, config: springConfig } = useMotionConfig()
@@ -29,12 +31,12 @@ const TooltipWrapper = ({ position, anchor, children }) => {
 
     let to = undefined
     let immediate = false
-
     const hasDimension = bounds.width > 0 && bounds.height > 0
-    if (hasDimension) {
-        let x = Math.round(position[0])
-        let y = Math.round(position[1])
 
+    let x = Math.round(position[0])
+    let y = Math.round(position[1])
+
+    if (hasDimension) {
         if (anchor === 'top') {
             x -= bounds.width / 2
             y -= bounds.height + TOOLTIP_OFFSET
@@ -53,7 +55,7 @@ const TooltipWrapper = ({ position, anchor, children }) => {
         }
 
         to = {
-            transform: `translate(${x}px, ${y}px)`,
+            transform: translate(x, y),
         }
         if (!previousPosition.current) {
             immediate = true
@@ -71,8 +73,7 @@ const TooltipWrapper = ({ position, anchor, children }) => {
     const style = {
         ...tooltipStyle,
         ...theme.tooltip,
-        transform: animatedProps.transform,
-        opacity: animatedProps.transform ? 1 : 0,
+        transform: animatedProps.transform ?? translate(x, y),
     }
 
     return (


### PR DESCRIPTION
This closes #1184 - tooltips not being shown the first time a data point is tapped on a touch device.

The issue seemed to stem from how the code was setting the transform values. On the first event, `hasDimension` was false so the transform value wasn't being set. This change sets the transform value the first time the event is fired so it displays correctly. I also got rid of the opacity property since I didn't see a scenario where it should be set to 0 after this change, but let me know if I missed anything and I can add that back.

I did go through every chart type in the storybook and all of the tooltips seemed to render and hide themselves appropriately.