### PR TITLE
fix(bar): include bars with zero height/width

### DIFF
--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -68,7 +68,7 @@ const generateVerticalGroupedBars = (
                 }
             })
         )
-    ).filter(bar => gt(bar.width, 0) && gt(bar.height, 0))
+    )
 
     return bars
 }
@@ -124,7 +124,7 @@ const generateHorizontalGroupedBars = (
                 }
             })
         )
-    ).filter(bar => gt(bar.width, 0))
+    )
 
     return bars
 }

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -71,7 +71,7 @@ const generateVerticalStackedBars = (
                 }
             })
         )
-    ).filter(bar => bar.height > 0)
+    )
 
     return bars
 }
@@ -127,7 +127,7 @@ const generateHorizontalStackedBars = (
                 }
             })
         )
-    ).filter(bar => bar.width > 0)
+    )
 
     return bars
 }


### PR DESCRIPTION
I know this is a hot topic and I know several other contributors made PRs adding options to change this behavior, but I think we should not be filtering out bars which would otherwise not be rendered.

I've put together a CodeSandbox comparing with 4 other charting libraries which all do not have this behavior: https://codesandbox.io/s/epic-sanne-hf3ef?file=/src/App.js

Also, I'm not sure I see the difference if the bar is not included versus not rendered. The bandwidth will remain the same since it is calculated over the entire data set, before we calculate the individual bars, so I don't see the harm in keeping this in the data.

@plouc would love to hear your thoughts on this.

Close #720 
Close #1061 
Close #1057 
Close #454
Close #591
Close #957
Close #1031
Close #986