### PR TITLE
fix(bump): add missing @nivo/axes module to dependencies

### DIFF
--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -25,6 +25,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@nivo/axes": "0.63.0",
     "@nivo/colors": "0.63.0",
     "@nivo/legends": "0.63.1",
     "@nivo/tooltip": "0.63.0",


### PR DESCRIPTION
fix https://github.com/plouc/nivo/issues/1198