### PR TITLE
Fixes #1209 by passing child's node data to getChildColor

### DIFF
--- a/packages/sunburst/src/Sunburst.js
+++ b/packages/sunburst/src/Sunburst.js
@@ -193,7 +193,7 @@ const enhance = compose(
                 if (node.depth === 1 || childColor === 'noinherit') {
                     node.data.color = getColor(node.data)
                 } else if (node.depth > 1) {
-                    node.data.color = getChildColor(node.parent.data)
+                    node.data.color = getChildColor(node.data)
                 }
             })
 


### PR DESCRIPTION
fix #1209 