### PR TITLE
fix(bar): prevent missing values causing bad scales

### DIFF
--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -161,7 +161,9 @@ export const generateGroupedBars = ({
     }
     const clampMin = scaleSpec.min === 'auto' ? clampToZero : value => value
 
-    const values = data.reduce((acc, entry) => [...acc, ...keys.map(k => entry[k])], [])
+    const values = data
+        .reduce((acc, entry) => [...acc, ...keys.map(k => entry[k])], [])
+        .filter(Boolean)
     const min = clampMin(Math.min(...values))
     const max = Math.max(...values)
 


### PR DESCRIPTION
Close #1255
