### PR TITLE
Update exports in Bar package to include the BarItem

### DIFF
--- a/packages/bar/src/index.js
+++ b/packages/bar/src/index.js
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 export { default as Bar } from './Bar'
+export { default as BarItem } from './BarItem'
 export { default as BarCanvas } from './BarCanvas'
 export { default as ResponsiveBar } from './ResponsiveBar'
 export { default as ResponsiveBarCanvas } from './ResponsiveBarCanvas'


### PR DESCRIPTION
#### Description

Add additional export of the default BarItem so that it can be used as a base BarComponent.

#### Use case

The need arose out of wanting to overlay text around the default BarComponent without having to rewrite the whole thing on my own.

Please consider this small change.