### PR TITLE
add repository field to every package.json

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/annotations"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/axes"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/bar"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/bullet"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/bump"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/calendar"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/chord"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/circle-packing"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/colors"
+  },
   "main": "./dist/nivo-colors.cjs.js",
   "module": "./dist/nivo-colors.es.js",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/core"
+  },
   "main": "./dist/nivo-core.cjs.js",
   "module": "./dist/nivo-core.es.js",
   "files": [

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/funnel"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -12,6 +12,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/generators"
+  },
   "main": "./dist/nivo-generators.cjs.js",
   "module": "./dist/nivo-generators.es.js",
   "files": [

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/geo"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/heatmap"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/legends/package.json
+++ b/packages/legends/package.json
@@ -7,6 +7,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/legends"
+  },
   "main": "./dist/nivo-legends.cjs.js",
   "module": "./dist/nivo-legends.es.js",
   "typings": "./index.d.ts",

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/line"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/network"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/parallel-coordinates"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/pie/package.json
+++ b/packages/pie/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/pie"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/radar"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/sankey"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/scales/package.json
+++ b/packages/scales/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/scales"
+  },
   "main": "./dist/nivo-scales.cjs.js",
   "module": "./dist/nivo-scales.es.js",
   "files": [

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/scatterplot"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/stream"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/sunburst/package.json
+++ b/packages/sunburst/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/sunburst"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -6,6 +6,11 @@
         "name": "Raphaël Benitte",
         "url": "https://github.com/plouc"
     },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/plouc/nivo.git",
+      "directory": "packages/swarmplot"
+    },
     "keywords": [
         "nivo",
         "dataviz",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/tooltip"
+  },
   "main": "./dist/nivo-tooltip.cjs.js",
   "module": "./dist/nivo-tooltip.es.js",
   "files": [

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/treemap"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/voronoi/package.json
+++ b/packages/voronoi/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/voronoi"
+  },
   "keywords": [
     "nivo",
     "dataviz",

--- a/packages/waffle/package.json
+++ b/packages/waffle/package.json
@@ -6,6 +6,11 @@
     "name": "Raphaël Benitte",
     "url": "https://github.com/plouc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/waffle"
+  },
   "keywords": [
     "nivo",
     "dataviz",


### PR DESCRIPTION
motivation:
- on npmjs.org you can click a link in the sidebar to go to the repo (compare [@nivo/bar](https://npm.im/@nivo/bar) with [react](https://npm.im/react))
- dependency upgrade tools like renovate and dependabot can link to the repo
-  dependency upgrade tools like renovate and dependabot can find the CHANGELOG file from the source repo and show include the relevant section in the PR