### PR TITLE
fix(bar): add new prop valueScale to BarCanvas

### DIFF
--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -14,7 +14,7 @@ import { renderAxesToCanvas, renderGridLinesToCanvas } from '@nivo/axes'
 import { renderLegendToCanvas } from '@nivo/legends'
 import { BasicTooltip } from '@nivo/tooltip'
 import { generateGroupedBars, generateStackedBars } from './compute'
-import { BarPropTypes } from './props'
+import { BarDefaultProps, BarPropTypes } from './props'
 import enhance from './enhance'
 
 const findNodeUnderCursor = (nodes, margin, x, y) =>
@@ -54,6 +54,8 @@ class BarCanvas extends Component {
             getIndex,
             minValue,
             maxValue,
+
+            valueScale,
 
             width,
             height,
@@ -104,6 +106,7 @@ class BarCanvas extends Component {
             getColor,
             padding,
             innerPadding,
+            valueScale,
         }
 
         const result =
@@ -284,5 +287,6 @@ class BarCanvas extends Component {
 }
 
 BarCanvas.propTypes = BarPropTypes
+BarCanvas.defaultProps = BarDefaultProps
 
 export default setDisplayName('BarCanvas')(enhance(BarCanvas))


### PR DESCRIPTION
`valueScale` prop has been added to the SVG Bar but not to the canvas version. This PR adds the prop and the default values.

This fixes #1273.

CC @wyze 