### PR TITLE
feat: add ref to access the underlying canvas

### DIFF
--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -257,7 +257,7 @@ class BarCanvas extends Component {
     }
 
     render() {
-        const { outerWidth, outerHeight, pixelRatio, isInteractive, theme } = this.props
+        const { outerWidth, outerHeight, pixelRatio, isInteractive, theme, ref } = this.props
 
         return (
             <Container isInteractive={isInteractive} theme={theme} animate={false}>
@@ -265,6 +265,7 @@ class BarCanvas extends Component {
                     <canvas
                         ref={surface => {
                             this.surface = surface
+                            if (ref) ref.current = surface
                         }}
                         width={outerWidth * pixelRatio}
                         height={outerHeight * pixelRatio}

--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -14,7 +14,7 @@ import { renderAxesToCanvas, renderGridLinesToCanvas } from '@nivo/axes'
 import { renderLegendToCanvas } from '@nivo/legends'
 import { BasicTooltip } from '@nivo/tooltip'
 import { generateGroupedBars, generateStackedBars } from './compute'
-import { BarPropTypes } from './props'
+import { BarDefaultProps, BarPropTypes } from './props'
 import enhance from './enhance'
 
 const findNodeUnderCursor = (nodes, margin, x, y) =>
@@ -54,6 +54,8 @@ class BarCanvas extends Component {
             getIndex,
             minValue,
             maxValue,
+
+            valueScale,
 
             width,
             height,
@@ -104,6 +106,7 @@ class BarCanvas extends Component {
             getColor,
             padding,
             innerPadding,
+            valueScale,
         }
 
         const result =
@@ -285,5 +288,6 @@ class BarCanvas extends Component {
 }
 
 BarCanvas.propTypes = BarPropTypes
+BarCanvas.defaultProps = BarDefaultProps
 
 export default setDisplayName('BarCanvas')(enhance(BarCanvas))

--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -260,7 +260,7 @@ class BarCanvas extends Component {
     }
 
     render() {
-        const { outerWidth, outerHeight, pixelRatio, isInteractive, theme, ref } = this.props
+        const { outerWidth, outerHeight, pixelRatio, isInteractive, theme, canvasRef } = this.props
 
         return (
             <Container isInteractive={isInteractive} theme={theme} animate={false}>
@@ -268,7 +268,7 @@ class BarCanvas extends Component {
                     <canvas
                         ref={surface => {
                             this.surface = surface
-                            if (ref) ref.current = surface
+                            if (canvasRef) canvasRef.current = surface
                         }}
                         width={outerWidth * pixelRatio}
                         height={outerHeight * pixelRatio}
@@ -290,4 +290,5 @@ class BarCanvas extends Component {
 BarCanvas.propTypes = BarPropTypes
 BarCanvas.defaultProps = BarDefaultProps
 
-export default setDisplayName('BarCanvas')(enhance(BarCanvas))
+const EnhancedBarCanvas = setDisplayName('BarCanvas')(enhance(BarCanvas))
+export default React.forwardRef((props, ref) => <EnhancedBarCanvas {...props} canvasRef={ref} />)

--- a/packages/bar/src/ResponsiveBarCanvas.js
+++ b/packages/bar/src/ResponsiveBarCanvas.js
@@ -6,14 +6,14 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { ResponsiveWrapper } from '@nivo/core'
 import BarCanvas from './BarCanvas'
 
-const ResponsiveBarCanvas = props => (
+const ResponsiveBarCanvas = (props, ref) => (
     <ResponsiveWrapper>
-        {({ width, height }) => <BarCanvas width={width} height={height} {...props} />}
+        {({ width, height }) => <BarCanvas width={width} height={height} {...props} ref={ref} />}
     </ResponsiveWrapper>
 )
 
-export default ResponsiveBarCanvas
+export default forwardRef(ResponsiveBarCanvas)

--- a/packages/bar/src/ResponsiveBarCanvas.js
+++ b/packages/bar/src/ResponsiveBarCanvas.js
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import React, { forwardRef } from 'react'
+import React from 'react'
 import { ResponsiveWrapper } from '@nivo/core'
 import BarCanvas from './BarCanvas'
 
@@ -16,4 +16,4 @@ const ResponsiveBarCanvas = (props, ref) => (
     </ResponsiveWrapper>
 )
 
-export default forwardRef(ResponsiveBarCanvas)
+export default React.forwardRef(ResponsiveBarCanvas)

--- a/packages/bar/stories/responsivBarCanvas.stories.js
+++ b/packages/bar/stories/responsivBarCanvas.stories.js
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 import { storiesOf } from '@storybook/react'
 import { generateCountriesData } from '@nivo/generators'
-import { BarCanvas } from '../src'
+import { ResponsiveBarCanvas } from '../src'
 import { button } from '@storybook/addon-knobs'
 
 const keys = ['hot dogs', 'burgers', 'sandwich', 'kebab', 'fries', 'donut']
@@ -18,24 +18,28 @@ const commonProps = {
     labelSkipHeight: 16,
 }
 
-const stories = storiesOf('BarCanvas', module)
+const stories = storiesOf('ResponsiveBarCanvas', module)
+
+const Wrapper = props => <div {...props} style={{ height: '300px', width: '600px' }} />
 
 stories.add('custom tooltip', () => (
-    <BarCanvas
-        {...commonProps}
-        tooltip={({ id, value, color }) => (
-            <strong style={{ color }}>
-                {id}: {value}
-            </strong>
-        )}
-        theme={{
-            tooltip: {
-                container: {
-                    background: '#333',
+    <Wrapper>
+        <ResponsiveBarCanvas
+            {...commonProps}
+            tooltip={({ id, value, color }) => (
+                <strong style={{ color }}>
+                    {id}: {value}
+                </strong>
+            )}
+            theme={{
+                tooltip: {
+                    container: {
+                        background: '#333',
+                    },
                 },
-            },
-        }}
-    />
+            }}
+        />
+    </Wrapper>
 ))
 
 stories.add('Get canvas - download the chart', () => {
@@ -49,5 +53,9 @@ stories.add('Get canvas - download the chart', () => {
         link.click()
     })
 
-    return <BarCanvas {...commonProps} ref={ref} />
+    return (
+        <Wrapper>
+            <ResponsiveBarCanvas {...commonProps} ref={ref} />
+        </Wrapper>
+    )
 })

--- a/packages/line/src/LineCanvas.js
+++ b/packages/line/src/LineCanvas.js
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import React, { useRef, useEffect, useState, useCallback } from 'react'
+import React, { useRef, useEffect, useState, useCallback, forwardRef } from 'react'
 import {
     withContainer,
     useDimensions,
@@ -67,6 +67,8 @@ const LineCanvas = ({
     onMouseLeave,
     onClick,
     tooltip,
+
+    canvasRef,
 }) => {
     const canvasEl = useRef(null)
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
@@ -100,6 +102,10 @@ const LineCanvas = ({
     })
 
     useEffect(() => {
+        if (canvasRef) {
+            canvasRef.current = canvasEl.current
+        }
+
         canvasEl.current.width = outerWidth * pixelRatio
         canvasEl.current.height = outerHeight * pixelRatio
 
@@ -326,4 +332,6 @@ const LineCanvas = ({
 LineCanvas.propTypes = LineCanvasPropTypes
 LineCanvas.defaultProps = LineCanvasDefaultProps
 
-export default withContainer(LineCanvas)
+const LineCanvasWithContainer = withContainer(LineCanvas)
+
+export default forwardRef((props, ref) => <LineCanvasWithContainer {...props} canvasRef={ref} />)

--- a/packages/line/src/ResponsiveLineCanvas.js
+++ b/packages/line/src/ResponsiveLineCanvas.js
@@ -6,14 +6,14 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { ResponsiveWrapper } from '@nivo/core'
 import LineCanvas from './LineCanvas'
 
-const ResponsiveLineCanvas = props => (
+const ResponsiveLineCanvas = (props, ref) => (
     <ResponsiveWrapper>
-        {({ width, height }) => <LineCanvas width={width} height={height} {...props} />}
+        {({ width, height }) => <LineCanvas width={width} height={height} {...props} ref={ref} />}
     </ResponsiveWrapper>
 )
 
-export default ResponsiveLineCanvas
+export default forwardRef(ResponsiveLineCanvas)

--- a/packages/line/stories/LineCanvas.stories.js
+++ b/packages/line/stories/LineCanvas.stories.js
@@ -6,9 +6,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import React from 'react'
+import React, { useRef } from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, boolean } from '@storybook/addon-knobs'
+import { withKnobs, boolean, button } from '@storybook/addon-knobs'
 import { generateDrinkStats } from '@nivo/generators'
 import { LineCanvas } from '../src'
 
@@ -209,3 +209,17 @@ stories.add('custom line style', () => (
         ]}
     />
 ))
+
+stories.add('Get canvas - download the chart', () => {
+    const ref = useRef(undefined)
+
+    button('Download image', () => {
+        const canvas = ref.current
+        const link = document.createElement('a')
+        link.download = 'chart.png'
+        link.href = canvas.toDataURL('image/png')
+        link.click()
+    })
+
+    return <LineCanvas {...commonProperties} ref={ref} />
+})

--- a/packages/line/stories/ResponsiveLineCanvas.stories.js
+++ b/packages/line/stories/ResponsiveLineCanvas.stories.js
@@ -1,0 +1,244 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import React, { useRef } from 'react'
+import { storiesOf } from '@storybook/react'
+import { withKnobs, boolean, button } from '@storybook/addon-knobs'
+import { generateDrinkStats } from '@nivo/generators'
+import { ResponsiveLineCanvas } from '../src'
+
+const data = generateDrinkStats(32)
+const commonProperties = {
+    margin: { top: 20, right: 20, bottom: 60, left: 80 },
+    data,
+    pointSize: 8,
+    pointColor: { theme: 'background' },
+    pointBorderWidth: 2,
+    pointBorderColor: { theme: 'background' },
+}
+
+const Wrapper = props => <div {...props} style={{ height: '300px', width: '600px' }} />
+
+const stories = storiesOf('ResponsiveLineCanvas', module)
+
+stories.addDecorator(withKnobs)
+
+stories.add('default', () => (
+    <Wrapper>
+        <ResponsiveLineCanvas {...commonProperties} />
+    </Wrapper>
+))
+
+stories.add(
+    'holes in data',
+    () => (
+        <Wrapper>
+            <ResponsiveLineCanvas
+                {...commonProperties}
+                data={[
+                    {
+                        id: 'fake corp. A',
+                        data: [4, 8, 5, null, 2, 1, 4, null, 8, 9, 5].map((y, i) => ({
+                            x: `#${i}`,
+                            y,
+                        })),
+                    },
+                    {
+                        id: 'fake corp. B',
+                        data: [5, 9, 8, 6, 3, 1, 2, null, 5, 8, 4].map((y, i) => ({
+                            x: `#${i}`,
+                            y,
+                        })),
+                    },
+                ]}
+                yScale={{
+                    type: 'linear',
+                    stacked: boolean('stacked', false),
+                }}
+                curve="monotoneX"
+            />
+        </Wrapper>
+    ),
+    {
+        info: {
+            text: `You can skip portions of the lines by setting y value to \`null\`.`,
+        },
+    }
+)
+
+stories.add(
+    'different series lengths',
+    () => (
+        <Wrapper>
+            <ResponsiveLineCanvas
+                {...commonProperties}
+                data={[
+                    {
+                        id: 'fake corp. A',
+                        data: [
+                            { x: 0, y: 7 },
+                            { x: 1, y: 5 },
+                            { x: 2, y: 11 },
+                            { x: 3, y: 12 },
+                            { x: 4, y: 13 },
+                            { x: 5, y: null },
+                            { x: 6, y: 18 },
+                            { x: 7, y: 16 },
+                            { x: 8, y: 8 },
+                            { x: 9, y: 10 },
+                            { x: 10, y: 9 },
+                        ],
+                    },
+                    {
+                        id: 'fake corp. B',
+                        data: [
+                            { x: 3, y: 14 },
+                            { x: 4, y: 16 },
+                            { x: 5, y: 19 },
+                            { x: 6, y: 20 },
+                            { x: 7, y: 18 },
+                        ],
+                    },
+                ]}
+                xScale={{
+                    type: 'linear',
+                    min: 0,
+                    max: 'auto',
+                }}
+                yScale={{
+                    type: 'linear',
+                    stacked: false,
+                }}
+                curve="monotoneX"
+                enableArea={true}
+            />
+        </Wrapper>
+    ),
+    {
+        info: {
+            text: `
+                Please note that when using stacked y scale with variable length/data holes,
+                if one of the y value is \`null\` all subsequent values will be skipped
+                as we cannot properly compute the sum. 
+            `,
+        },
+    }
+)
+
+stories.add('time scale', () => (
+    <Wrapper>
+        <ResponsiveLineCanvas
+            {...commonProperties}
+            data={[
+                {
+                    id: 'fake corp. A',
+                    data: [
+                        { x: '2018-01-01', y: 7 },
+                        { x: '2018-01-02', y: 5 },
+                        { x: '2018-01-03', y: 11 },
+                        { x: '2018-01-04', y: 9 },
+                        { x: '2018-01-05', y: 12 },
+                        { x: '2018-01-06', y: 16 },
+                        { x: '2018-01-07', y: 13 },
+                        { x: '2018-01-08', y: 13 },
+                    ],
+                },
+                {
+                    id: 'fake corp. B',
+                    data: [
+                        { x: '2018-01-04', y: 14 },
+                        { x: '2018-01-05', y: 14 },
+                        { x: '2018-01-06', y: 15 },
+                        { x: '2018-01-07', y: 11 },
+                        { x: '2018-01-08', y: 10 },
+                        { x: '2018-01-09', y: 12 },
+                        { x: '2018-01-10', y: 9 },
+                        { x: '2018-01-11', y: 7 },
+                    ],
+                },
+            ]}
+            xScale={{
+                type: 'time',
+                format: '%Y-%m-%d',
+                precision: 'day',
+            }}
+            xFormat="time:%Y-%m-%d"
+            yScale={{
+                type: 'linear',
+                stacked: boolean('stacked', false),
+            }}
+            axisLeft={{
+                legend: 'linear scale',
+                legendOffset: 12,
+            }}
+            axisBottom={{
+                format: '%b %d',
+                tickValues: 'every 2 days',
+                legend: 'time scale',
+                legendOffset: -12,
+            }}
+            enablePointLabel={true}
+            pointSize={16}
+            pointBorderWidth={1}
+            pointBorderColor={{
+                from: 'color',
+                modifiers: [['darker', 0.3]],
+            }}
+            useMesh={true}
+            enableSlices={false}
+        />
+    </Wrapper>
+))
+
+stories.add('custom line style', () => (
+    <Wrapper>
+        <ResponsiveLineCanvas
+            {...commonProperties}
+            layers={[
+                'grid',
+                'markers',
+                'areas',
+                ({ lineGenerator, series, ctx, lineWidth, innerWidth }) => {
+                    lineGenerator.context(ctx)
+                    series.forEach(serie => {
+                        const gradient = ctx.createLinearGradient(0, 0, innerWidth, 0)
+                        gradient.addColorStop('0', 'white')
+                        gradient.addColorStop('0.5', serie.color)
+                        gradient.addColorStop('1.0', 'black')
+                        ctx.strokeStyle = gradient
+                        ctx.lineWidth = lineWidth
+                        ctx.beginPath()
+                        lineGenerator(serie.data.map(d => d.position))
+                        ctx.stroke()
+                    })
+                },
+                'points',
+                'mesh',
+                'legends',
+            ]}
+        />
+    </Wrapper>
+))
+
+stories.add('Get canvas - download the chart', () => {
+    const ref = useRef(undefined)
+
+    button('Download image', () => {
+        const canvas = ref.current
+        const link = document.createElement('a')
+        link.download = 'chart.png'
+        link.href = canvas.toDataURL('image/png')
+        link.click()
+    })
+
+    return (
+        <Wrapper>
+            <ResponsiveLineCanvas {...commonProperties} ref={ref} />
+        </Wrapper>
+    )
+})


### PR DESCRIPTION
This PR adds the ability to get the underlying `<canvas />` of a chart using a ref.

This feature is useful if you want to allow the user to download a chart image.

This fixes only part of #906 as it only handles the normal and responsive version of the LineCanvas and BarCanvas.