### PR TITLE
Add the ability to round bar index scale

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -99,6 +99,7 @@ declare module '@nivo/bar' {
         padding: number
 
         valueScale: Scale
+        indexedScale: Scale
 
         axisBottom: AxisProps | null
         axisLeft: AxisProps | null

--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -18,7 +18,7 @@ import {
 import { AxisProps, GridValues } from '@nivo/axes'
 import { OrdinalColorScaleConfig, InheritedColorConfig } from '@nivo/colors'
 import { LegendProps } from '@nivo/legends'
-import { Scale } from '@nivo/scales'
+import { Scale, BandScale } from '@nivo/scales'
 
 declare module '@nivo/bar' {
     export type Value = string | number
@@ -99,7 +99,7 @@ declare module '@nivo/bar' {
         padding: number
 
         valueScale: Scale
-        indexScale: Scale
+        indexScale: BandScale
 
         axisBottom: AxisProps | null
         axisLeft: AxisProps | null

--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -99,7 +99,7 @@ declare module '@nivo/bar' {
         padding: number
 
         valueScale: Scale
-        indexedScale: Scale
+        indexScale: Scale
 
         axisBottom: AxisProps | null
         axisLeft: AxisProps | null

--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -58,6 +58,7 @@ const Bar = props => {
         maxValue,
 
         valueScale,
+        indexedScale,
 
         margin,
         width,
@@ -66,7 +67,6 @@ const Bar = props => {
         outerHeight,
         padding,
         innerPadding,
-        nice,
 
         axisTop,
         axisRight,
@@ -129,7 +129,7 @@ const Bar = props => {
         padding,
         innerPadding,
         valueScale,
-        nice,
+        indexedScale,
     })
 
     const motionProps = {

--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -66,6 +66,7 @@ const Bar = props => {
         outerHeight,
         padding,
         innerPadding,
+        nice,
 
         axisTop,
         axisRight,
@@ -128,6 +129,7 @@ const Bar = props => {
         padding,
         innerPadding,
         valueScale,
+        nice,
     })
 
     const motionProps = {

--- a/packages/bar/src/Bar.js
+++ b/packages/bar/src/Bar.js
@@ -58,7 +58,7 @@ const Bar = props => {
         maxValue,
 
         valueScale,
-        indexedScale,
+        indexScale,
 
         margin,
         width,
@@ -129,7 +129,7 @@ const Bar = props => {
         padding,
         innerPadding,
         valueScale,
-        indexedScale,
+        indexScale,
     })
 
     const motionProps = {

--- a/packages/bar/src/BarCanvas.js
+++ b/packages/bar/src/BarCanvas.js
@@ -56,6 +56,7 @@ class BarCanvas extends Component {
             maxValue,
 
             valueScale,
+            indexScale,
 
             width,
             height,
@@ -107,6 +108,7 @@ class BarCanvas extends Component {
             padding,
             innerPadding,
             valueScale,
+            indexScale,
         }
 
         const result =

--- a/packages/bar/src/compute/common.js
+++ b/packages/bar/src/compute/common.js
@@ -11,17 +11,17 @@ import { scaleBand } from 'd3-scale'
 /**
  * Generates indexed scale.
  *
- * @param {Array.<Object>} data
- * @param {Function}       getIndex
- * @param {Array.<number>} range
- * @param {number}         padding
- * @Param {boolean}        nice
+ * @param {Array.<Object>}   data
+ * @param {Function}         getIndex
+ * @param {Array.<number>}   range
+ * @param {number}           padding
+ * @Param {indexedPropType}  indexedScale
  * @returns {Function}
  */
-export const getIndexedScale = (data, getIndex, range, padding, nice) => {
+export const getIndexedScale = (data, getIndex, range, padding, indexedScale) => {
     const scale = scaleBand().domain(data.map(getIndex)).padding(padding)
-    return nice ? scale.rangeRound(range) : scale.range(range)
-}    
+    return indexedScale.round ? scale.rangeRound(range) : scale.range(range)
+}   
 
 export const normalizeData = (data, keys) =>
     data.map(item => ({

--- a/packages/bar/src/compute/common.js
+++ b/packages/bar/src/compute/common.js
@@ -19,9 +19,7 @@ import { scaleBand } from 'd3-scale'
  * @returns {Function}
  */
 export const getIndexedScale = (data, getIndex, range, padding, nice) => {
-    const scale = scaleBand()
-        .domain(data.map(getIndex))
-        .padding(padding)
+    const scale = scaleBand().domain(data.map(getIndex)).padding(padding)
     return nice ? scale.rangeRound(range) : scale.range(range)
 }    
 

--- a/packages/bar/src/compute/common.js
+++ b/packages/bar/src/compute/common.js
@@ -11,17 +11,17 @@ import { scaleBand } from 'd3-scale'
 /**
  * Generates indexed scale.
  *
- * @param {Array.<Object>}   data
- * @param {Function}         getIndex
- * @param {Array.<number>}   range
- * @param {number}           padding
- * @Param {indexedPropType}  indexedScale
+ * @param {Array.<Object>} data
+ * @param {Function}       getIndex
+ * @param {Array.<number>} range
+ * @param {number}         padding
+ * @Param {scalePropType}  indexScale
  * @returns {Function}
  */
-export const getIndexedScale = (data, getIndex, range, padding, indexedScale) => {
+export const getIndexedScale = (data, getIndex, range, padding, indexScale) => {
     const scale = scaleBand().domain(data.map(getIndex)).padding(padding)
-    return indexedScale.round ? scale.rangeRound(range) : scale.range(range)
-}   
+    return indexScale.round ? scale.rangeRound(range) : scale.range(range)
+}
 
 export const normalizeData = (data, keys) =>
     data.map(item => ({

--- a/packages/bar/src/compute/common.js
+++ b/packages/bar/src/compute/common.js
@@ -15,10 +15,15 @@ import { scaleBand } from 'd3-scale'
  * @param {Function}       getIndex
  * @param {Array.<number>} range
  * @param {number}         padding
+ * @Param {boolean}        nice
  * @returns {Function}
  */
-export const getIndexedScale = (data, getIndex, range, padding) =>
-    scaleBand().rangeRound(range).domain(data.map(getIndex)).padding(padding)
+export const getIndexedScale = (data, getIndex, range, padding, nice) => {
+    const scale = scaleBand()
+        .domain(data.map(getIndex))
+        .padding(padding)
+    return nice ? scale.rangeRound(range) : scale.range(range)
+}    
 
 export const normalizeData = (data, keys) =>
     data.map(item => ({

--- a/packages/bar/src/compute/common.js
+++ b/packages/bar/src/compute/common.js
@@ -18,9 +18,12 @@ import { scaleBand } from 'd3-scale'
  * @Param {scalePropType}  indexScale
  * @returns {Function}
  */
-export const getIndexedScale = (data, getIndex, range, padding, indexScale) => {
-    const scale = scaleBand().domain(data.map(getIndex)).padding(padding)
-    return indexScale.round ? scale.rangeRound(range) : scale.range(range)
+export const getIndexScale = (data, getIndex, range, padding, indexScale) => {
+    return scaleBand()
+        .domain(data.map(getIndex))
+        .range(range)
+        .round(Boolean(indexScale.round))
+        .padding(padding)
 }
 
 export const normalizeData = (data, keys) =>

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 import { computeScale } from '@nivo/scales'
-import { getIndexedScale, filterNullValues, normalizeData } from './common'
+import { getIndexScale, filterNullValues, normalizeData } from './common'
 
 const gt = (value, other) => value > other
 const lt = (value, other) => value < other
@@ -146,12 +146,12 @@ export const generateGroupedBars = ({
     padding = 0,
     innerPadding = 0,
     valueScale,
-    indexScale,
+    indexScale: indexScaleConfig,
     ...props
 }) => {
     const data = normalizeData(props.data, keys)
     const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
-    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, indexScale)
+    const indexScale = getIndexScale(data, props.getIndex, range, padding, indexScaleConfig)
 
     const scaleSpec = {
         axis,
@@ -170,9 +170,9 @@ export const generateGroupedBars = ({
 
     const scale = computeScale(scaleSpec, { [axis]: { min, max } }, width, height)
 
-    const [xScale, yScale] = layout === 'vertical' ? [indexedScale, scale] : [scale, indexedScale]
+    const [xScale, yScale] = layout === 'vertical' ? [indexScale, scale] : [scale, indexScale]
 
-    const bandwidth = (indexedScale.bandwidth() - innerPadding * (keys.length - 1)) / keys.length
+    const bandwidth = (indexScale.bandwidth() - innerPadding * (keys.length - 1)) / keys.length
     const params = [
         { ...props, data, keys, innerPadding, xScale, yScale },
         bandwidth,

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -145,12 +145,13 @@ export const generateGroupedBars = ({
     height,
     padding = 0,
     innerPadding = 0,
+    nice,
     valueScale,
     ...props
 }) => {
     const data = normalizeData(props.data, keys)
     const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
-    const indexedScale = getIndexedScale(data, props.getIndex, range, padding)
+    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, nice)
 
     const scaleSpec = {
         axis,

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -145,13 +145,13 @@ export const generateGroupedBars = ({
     height,
     padding = 0,
     innerPadding = 0,
-    nice,
     valueScale,
+    indexedScale: indexedScaleOptions,
     ...props
 }) => {
     const data = normalizeData(props.data, keys)
     const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
-    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, nice)
+    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, indexedScaleOptions)
 
     const scaleSpec = {
         axis,

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -146,12 +146,12 @@ export const generateGroupedBars = ({
     padding = 0,
     innerPadding = 0,
     valueScale,
-    indexedScale: indexedScaleOptions,
+    indexScale,
     ...props
 }) => {
     const data = normalizeData(props.data, keys)
     const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
-    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, indexedScaleOptions)
+    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, indexScale)
 
     const scaleSpec = {
         axis,

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -149,13 +149,13 @@ export const generateStackedBars = ({
     height,
     padding = 0,
     valueScale,
-    indexedScale: indexedScaleOptions,
+    indexScale,
     ...props
 }) => {
     const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(normalizeData(data, keys))
 
     const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
-    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, indexedScaleOptions)
+    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, indexScale)
 
     const scaleSpec = {
         axis,

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -9,7 +9,7 @@
 // import flattenDepth from 'lodash/flattenDepth'
 import { computeScale } from '@nivo/scales'
 import { stack, stackOffsetDiverging } from 'd3-shape'
-import { getIndexedScale, filterNullValues, normalizeData } from './common'
+import { getIndexScale, filterNullValues, normalizeData } from './common'
 
 const flattenDeep = (array, depth = 1) =>
     depth > 0
@@ -149,13 +149,13 @@ export const generateStackedBars = ({
     height,
     padding = 0,
     valueScale,
-    indexScale,
+    indexScale: indexScaleConfig,
     ...props
 }) => {
     const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(normalizeData(data, keys))
 
     const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
-    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, indexScale)
+    const indexScale = getIndexScale(data, props.getIndex, range, padding, indexScaleConfig)
 
     const scaleSpec = {
         axis,
@@ -171,10 +171,10 @@ export const generateStackedBars = ({
 
     const scale = computeScale(scaleSpec, { [axis]: { min, max } }, width, height)
 
-    const [xScale, yScale] = layout === 'vertical' ? [indexedScale, scale] : [scale, indexedScale]
+    const [xScale, yScale] = layout === 'vertical' ? [indexScale, scale] : [scale, indexScale]
 
     const innerPadding = props.innerPadding > 0 ? props.innerPadding : 0
-    const bandwidth = indexedScale.bandwidth()
+    const bandwidth = indexScale.bandwidth()
     const params = [
         { ...props, innerPadding, stackedData, xScale, yScale },
         bandwidth,

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -148,14 +148,14 @@ export const generateStackedBars = ({
     width,
     height,
     padding = 0,
-    nice,
     valueScale,
+    indexedScale: indexedScaleOptions,
     ...props
 }) => {
     const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(normalizeData(data, keys))
 
     const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
-    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, nice)
+    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, indexedScaleOptions)
 
     const scaleSpec = {
         axis,

--- a/packages/bar/src/compute/stacked.js
+++ b/packages/bar/src/compute/stacked.js
@@ -148,13 +148,14 @@ export const generateStackedBars = ({
     width,
     height,
     padding = 0,
+    nice,
     valueScale,
     ...props
 }) => {
     const stackedData = stack().keys(keys).offset(stackOffsetDiverging)(normalizeData(data, keys))
 
     const [axis, range] = layout === 'vertical' ? ['y', [0, width]] : ['x', [height, 0]]
-    const indexedScale = getIndexedScale(data, props.getIndex, range, padding)
+    const indexedScale = getIndexedScale(data, props.getIndex, range, padding, nice)
 
     const scaleSpec = {
         axis,

--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -34,7 +34,7 @@ export const BarPropTypes = {
     layout: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
     reverse: PropTypes.bool.isRequired,
     valueScale: scalePropType.isRequired,
-    indexedScale: scalePropType.isRequired,
+    indexScale: scalePropType.isRequired,
 
     minValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
     maxValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
@@ -115,7 +115,7 @@ export const BarDefaultProps = {
     maxValue: 'auto',
 
     valueScale: { type: 'linear' },
-    indexedScale: { type: 'indexed', round: true },
+    indexScale: { type: 'band', round: true },
 
     padding: 0.1,
     innerPadding: 0,

--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -15,7 +15,7 @@ import {
 } from '@nivo/colors'
 import { axisPropType } from '@nivo/axes'
 import { LegendPropShape } from '@nivo/legends'
-import { scalePropType } from '@nivo/scales'
+import { scalePropType, indexedPropType } from '@nivo/scales'
 import BarItem from './BarItem'
 
 export const BarPropTypes = {
@@ -34,11 +34,12 @@ export const BarPropTypes = {
     layout: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
     reverse: PropTypes.bool.isRequired,
     valueScale: scalePropType.isRequired,
+    indexedScale: indexedPropType.isRequired,
+
     minValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
     maxValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
     padding: PropTypes.number.isRequired,
     innerPadding: PropTypes.number.isRequired,
-    nice: PropTypes.bool.isRequired,
 
     axisTop: axisPropType,
     axisRight: axisPropType,
@@ -114,10 +115,10 @@ export const BarDefaultProps = {
     maxValue: 'auto',
 
     valueScale: { type: 'linear' },
+    indexedScale: { round: true },
 
     padding: 0.1,
     innerPadding: 0,
-    nice: true,
 
     axisBottom: {},
     axisLeft: {},

--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -38,6 +38,7 @@ export const BarPropTypes = {
     maxValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
     padding: PropTypes.number.isRequired,
     innerPadding: PropTypes.number.isRequired,
+    nice: PropTypes.bool.isRequired,
 
     axisTop: axisPropType,
     axisRight: axisPropType,
@@ -116,6 +117,7 @@ export const BarDefaultProps = {
 
     padding: 0.1,
     innerPadding: 0,
+    nice: true,
 
     axisBottom: {},
     axisLeft: {},

--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -15,7 +15,7 @@ import {
 } from '@nivo/colors'
 import { axisPropType } from '@nivo/axes'
 import { LegendPropShape } from '@nivo/legends'
-import { scalePropType } from '@nivo/scales'
+import { scalePropType, bandScalePropTypes } from '@nivo/scales'
 import BarItem from './BarItem'
 
 export const BarPropTypes = {
@@ -34,7 +34,7 @@ export const BarPropTypes = {
     layout: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
     reverse: PropTypes.bool.isRequired,
     valueScale: scalePropType.isRequired,
-    indexScale: scalePropType.isRequired,
+    indexScale: bandScalePropTypes.isRequired,
 
     minValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
     maxValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,

--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -15,7 +15,7 @@ import {
 } from '@nivo/colors'
 import { axisPropType } from '@nivo/axes'
 import { LegendPropShape } from '@nivo/legends'
-import { scalePropType, indexedPropType } from '@nivo/scales'
+import { scalePropType } from '@nivo/scales'
 import BarItem from './BarItem'
 
 export const BarPropTypes = {
@@ -34,7 +34,7 @@ export const BarPropTypes = {
     layout: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
     reverse: PropTypes.bool.isRequired,
     valueScale: scalePropType.isRequired,
-    indexedScale: indexedPropType.isRequired,
+    indexedScale: scalePropType.isRequired,
 
     minValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
     maxValue: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]).isRequired,
@@ -115,7 +115,7 @@ export const BarDefaultProps = {
     maxValue: 'auto',
 
     valueScale: { type: 'linear' },
-    indexedScale: { round: true },
+    indexedScale: { type: 'indexed', round: true },
 
     padding: 0.1,
     innerPadding: 0,

--- a/packages/bar/tests/Bar.test.js
+++ b/packages/bar/tests/Bar.test.js
@@ -370,7 +370,7 @@ it(`should apply scale rounding by default`, () => {
     expect(firstBarWidth).toEqual(Math.floor(firstBarWidth))
 })
 
-it(`should not apply scale rounding when passed indexedScale.round: false`, () => {
+it(`should not apply scale rounding when passed indexScale.round: false`, () => {
     const wrapper = mount(
         <Bar
             width={500}
@@ -381,7 +381,7 @@ it(`should not apply scale rounding when passed indexedScale.round: false`, () =
                 { id: 'three', value: 30 },
             ]}
             animate={false}
-            indexedScale={{ type: 'indexed', round: false }}
+            indexScale={{ type: 'band', round: false }}
         />
     )
 

--- a/packages/bar/tests/Bar.test.js
+++ b/packages/bar/tests/Bar.test.js
@@ -350,3 +350,39 @@ it(`should generate stacked bars correctly when keys are mismatched`, () => {
     expect(bars.at(2).prop('height')).toEqual(69)
     expect(bars.at(2).prop('width')).toEqual(214)
 })
+
+it(`should apply scale rounding by default`, () => {
+    const wrapper = mount(
+        <Bar
+            width={500}
+            height={300}
+            data={[
+                { id: 'one', value: 10 },
+                { id: 'two', value: 20 },
+                { id: 'three', value: 30 },
+            ]}
+            animate={false}
+        />
+    )
+    const firstBarWidth = wrapper.find('g rect').first(3).props().width
+    expect(firstBarWidth).toEqual(Math.floor(firstBarWidth))
+})
+
+it(`should not apply scale rounding when passed indexedScale.round: false`, () => {
+    const wrapper = mount(
+        <Bar
+            width={500}
+            height={300}
+            data={[
+                { id: 'one', value: 10 },
+                { id: 'two', value: 20 },
+                { id: 'three', value: 30 },
+            ]}
+            animate={false}
+            indexedScale={{ type: 'indexed', round: false }}
+        />
+    )
+    const firstBarWidth = wrapper.find('g rect').first(3).props().width
+    expect(firstBarWidth).not.toEqual(Math.floor(firstBarWidth))
+})
+

--- a/packages/bar/tests/Bar.test.js
+++ b/packages/bar/tests/Bar.test.js
@@ -364,7 +364,9 @@ it(`should apply scale rounding by default`, () => {
             animate={false}
         />
     )
-    const firstBarWidth = wrapper.find('g rect').first(3).props().width
+
+    const bars = wrapper.find('BarItem')
+    const firstBarWidth = bars.at(0).prop('width')
     expect(firstBarWidth).toEqual(Math.floor(firstBarWidth))
 })
 
@@ -382,7 +384,8 @@ it(`should not apply scale rounding when passed indexedScale.round: false`, () =
             indexedScale={{ type: 'indexed', round: false }}
         />
     )
-    const firstBarWidth = wrapper.find('g rect').first(3).props().width
+
+    const bars = wrapper.find('BarItem')
+    const firstBarWidth = bars.at(0).prop('width')
     expect(firstBarWidth).not.toEqual(Math.floor(firstBarWidth))
 })
-

--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -50,8 +50,8 @@ declare module '@nivo/scales' {
         max?: 'auto' | number
     }
 
-    export interface IndexedScale {
-        type: 'indexed'
+    export interface BandScale {
+        type: 'band'
         round?: boolean
     }
 
@@ -62,7 +62,7 @@ declare module '@nivo/scales' {
         | TimeScaleFormatted
         | LogScale
         | SymlogScale
-        | IndexedScale
+        | BandScale
 
     export type ScaleFunc = (value: string | number | Date) => number
 }

--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -50,6 +50,11 @@ declare module '@nivo/scales' {
         max?: 'auto' | number
     }
 
+    export interface IndexedScale {
+        type: 'indexed'
+        round?: boolean
+    }
+
     export type Scale =
         | LinearScale
         | PointScale
@@ -57,6 +62,7 @@ declare module '@nivo/scales' {
         | TimeScaleFormatted
         | LogScale
         | SymlogScale
+        | IndexedScale
 
     export type ScaleFunc = (value: string | number | Date) => number
 }

--- a/packages/scales/src/bandScale.js
+++ b/packages/scales/src/bandScale.js
@@ -8,7 +8,7 @@
  */
 import PropTypes from 'prop-types'
 
-export const indexedScalePropTypes = {
-    type: PropTypes.oneOf(['indexed']).isRequired,
+export const bandScalePropTypes = {
+    type: PropTypes.oneOf(['band']).isRequired,
     round: PropTypes.bool,
 }

--- a/packages/scales/src/index.js
+++ b/packages/scales/src/index.js
@@ -17,9 +17,11 @@ import { bandScalePropTypes } from './bandScale'
 export * from './compute'
 export * from './linearScale'
 export * from './logScale'
+export * from './symlogScale'
 export * from './pointScale'
 export * from './timeScale'
 export * from './timeHelpers'
+export * from './bandScale'
 
 export const scalePropType = PropTypes.oneOfType([
     PropTypes.shape(linearScalePropTypes),

--- a/packages/scales/src/index.js
+++ b/packages/scales/src/index.js
@@ -12,7 +12,7 @@ import { logScalePropTypes } from './logScale'
 import { symLogScalePropTypes } from './symlogScale'
 import { pointScalePropTypes } from './pointScale'
 import { timeScalePropTypes } from './timeScale'
-import { indexedScalePropTypes } from './indexedScale'
+import { bandScalePropTypes } from './bandScale'
 
 export * from './compute'
 export * from './linearScale'
@@ -27,5 +27,5 @@ export const scalePropType = PropTypes.oneOfType([
     PropTypes.shape(timeScalePropTypes),
     PropTypes.shape(logScalePropTypes),
     PropTypes.shape(symLogScalePropTypes),
-    PropTypes.shape(indexedScalePropTypes),
+    PropTypes.shape(bandScalePropTypes),
 ])

--- a/packages/scales/src/index.js
+++ b/packages/scales/src/index.js
@@ -12,6 +12,7 @@ import { logScalePropTypes } from './logScale'
 import { symLogScalePropTypes } from './symlogScale'
 import { pointScalePropTypes } from './pointScale'
 import { timeScalePropTypes } from './timeScale'
+import { indexedScalePropTypes } from './indexedScale'
 
 export * from './compute'
 export * from './linearScale'
@@ -26,4 +27,5 @@ export const scalePropType = PropTypes.oneOfType([
     PropTypes.shape(timeScalePropTypes),
     PropTypes.shape(logScalePropTypes),
     PropTypes.shape(symLogScalePropTypes),
+    PropTypes.shape(indexedScalePropTypes),
 ])

--- a/packages/scales/src/indexedScale.js
+++ b/packages/scales/src/indexedScale.js
@@ -1,0 +1,14 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import PropTypes from 'prop-types'
+
+export const indexedScalePropTypes = {
+    type: PropTypes.oneOf(['indexed']).isRequired,
+    round: PropTypes.bool,
+}

--- a/website/src/data/components/bar/props.js
+++ b/website/src/data/components/bar/props.js
@@ -106,7 +106,7 @@ const props = [
         key: 'indexScale',
         type: 'object',
         group: 'Base',
-        help: `indexed scale configuration.`,
+        help: `index scale configuration.`,
         defaultValue: defaults.indexScale,
         controlType: 'object',
         controlOptions: {
@@ -126,7 +126,7 @@ const props = [
                 },
                 {
                     key: 'round',
-                    help: 'Toggle indexed scale (for bar width) rounding.',
+                    help: 'Toggle index scale (for bar width) rounding.',
                     type: 'boolean',
                     controlType: 'switch',
                 },

--- a/website/src/data/components/bar/props.js
+++ b/website/src/data/components/bar/props.js
@@ -103,6 +103,37 @@ const props = [
         },
     },
     {
+        key: 'indexedScale',
+        type: 'object',
+        group: 'Base',
+        help: `indexed scale configuration.`,
+        defaultValue: defaults.indexedScale,
+        controlType: 'object',
+        controlOptions: {
+            props: [
+                {
+                    key: 'type',
+                    help: `Scale type.`,
+                    type: 'string',
+                    controlType: 'choices',
+                    controlOptions: {
+                        disabled: true,
+                        choices: ['indexed'].map(v => ({
+                            label: v,
+                            value: v,
+                        })),
+                    },
+                },
+                {
+                    key: 'round',
+                    help: 'Toggle indexed scale (for bar width) rounding.',
+                    type: 'boolean',
+                    controlType: 'switch',
+                },
+            ],
+        },
+    },
+    {
         key: 'reverse',
         help:
             'Reverse bars, starts on top instead of bottom for vertical layout and right instead of left for horizontal one.',

--- a/website/src/data/components/bar/props.js
+++ b/website/src/data/components/bar/props.js
@@ -103,11 +103,11 @@ const props = [
         },
     },
     {
-        key: 'indexedScale',
+        key: 'indexScale',
         type: 'object',
         group: 'Base',
         help: `indexed scale configuration.`,
-        defaultValue: defaults.indexedScale,
+        defaultValue: defaults.indexScale,
         controlType: 'object',
         controlOptions: {
             props: [
@@ -118,7 +118,7 @@ const props = [
                     controlType: 'choices',
                     controlOptions: {
                         disabled: true,
-                        choices: ['indexed'].map(v => ({
+                        choices: ['band'].map(v => ({
                             label: v,
                             value: v,
                         })),

--- a/website/src/pages/bar/api.js
+++ b/website/src/pages/bar/api.js
@@ -60,7 +60,7 @@ const BarApi = () => {
                     reverse: false,
 
                     valueScale: { type: 'linear' },
-                    indexScale: { type: 'band', round: false },
+                    indexScale: { type: 'band', round: true },
 
                     axisTop: {
                         enable: false,

--- a/website/src/pages/bar/api.js
+++ b/website/src/pages/bar/api.js
@@ -60,7 +60,7 @@ const BarApi = () => {
                     reverse: false,
 
                     valueScale: { type: 'linear' },
-                    indexedScale: { type: 'indexed', round: false },
+                    indexScale: { type: 'band', round: false },
 
                     axisTop: {
                         enable: false,

--- a/website/src/pages/bar/api.js
+++ b/website/src/pages/bar/api.js
@@ -60,6 +60,7 @@ const BarApi = () => {
                     reverse: false,
 
                     valueScale: { type: 'linear' },
+                    indexedScale: { type: 'indexed', round: false },
 
                     axisTop: {
                         enable: false,

--- a/website/src/pages/bar/canvas.js
+++ b/website/src/pages/bar/canvas.js
@@ -41,7 +41,7 @@ const initialProperties = {
     reverse: false,
 
     valueScale: { type: 'linear' },
-    indexedScale: { type: 'indexed', round: false },
+    indexScale: { type: 'band', round: false },
 
     colors: { scheme: 'red_blue' },
     colorBy: 'id',

--- a/website/src/pages/bar/canvas.js
+++ b/website/src/pages/bar/canvas.js
@@ -41,7 +41,7 @@ const initialProperties = {
     reverse: false,
 
     valueScale: { type: 'linear' },
-    indexScale: { type: 'band', round: false },
+    indexScale: { type: 'band', round: true },
 
     colors: { scheme: 'red_blue' },
     colorBy: 'id',

--- a/website/src/pages/bar/canvas.js
+++ b/website/src/pages/bar/canvas.js
@@ -41,6 +41,7 @@ const initialProperties = {
     reverse: false,
 
     valueScale: { type: 'linear' },
+    indexedScale: { type: 'indexed', round: false },
 
     colors: { scheme: 'red_blue' },
     colorBy: 'id',

--- a/website/src/pages/bar/index.js
+++ b/website/src/pages/bar/index.js
@@ -39,6 +39,7 @@ const initialProperties = {
     reverse: false,
 
     valueScale: { type: 'linear' },
+    indexedScale: { type: 'indexed', round: false },
 
     colors: { scheme: 'nivo' },
     colorBy: 'id',

--- a/website/src/pages/bar/index.js
+++ b/website/src/pages/bar/index.js
@@ -39,7 +39,7 @@ const initialProperties = {
     reverse: false,
 
     valueScale: { type: 'linear' },
-    indexScale: { type: 'band', round: false },
+    indexScale: { type: 'band', round: true },
 
     colors: { scheme: 'nivo' },
     colorBy: 'id',

--- a/website/src/pages/bar/index.js
+++ b/website/src/pages/bar/index.js
@@ -39,7 +39,7 @@ const initialProperties = {
     reverse: false,
 
     valueScale: { type: 'linear' },
-    indexedScale: { type: 'indexed', round: false },
+    indexScale: { type: 'band', round: false },
 
     colors: { scheme: 'nivo' },
     colorBy: 'id',


### PR DESCRIPTION
I noticed that `ResponsiveBar` charts with many, narrow bars were varying in width. The `svg` container was the correct width, but the bars within it were offset from the left/right edges.

Screencap:
![nivo-bar-nicing](https://user-images.githubusercontent.com/1127259/99215624-5f218580-2788-11eb-80fb-9ac23ea4f703.gif)

After some digging, I narrowed it down to the use of `d3-scale.scaleBand.rangeRound()` within `Bar`'s `common.js::getIndexedScale()`. This diff puts this nicing behavior behind a `nice` prop, which defaults to `true` to maintain current functionality unless a developer opts out with `nice=false`.

The above test with `nice=false`:
![nivo-bar-nicing-off](https://user-images.githubusercontent.com/1127259/99215646-6d6fa180-2788-11eb-8348-febca38234e5.gif)

I didn't add anything to the Bar demo site; I can if you like, but this prop feels niche / edge-case enough that it may not need to be surfaced in the demo site.