### PR TITLE
chore(build): add version script to bump peer dependencies on new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
   },
   "scripts": {
     "changelog": "rm CHANGELOG.md && node scripts/generate-changelog.js",
-    "make:init": "make init"
+    "make:init": "make init",
+    "version": "node scripts/bump-peer-deps.js"
   },
   "workspaces": [
     "packages/*",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -35,7 +35,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -36,7 +36,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -44,7 +44,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -40,7 +40,7 @@
     "@types/d3-scale": "^3.2.1"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "react": ">= 16.8.4 < 18.0.0"
   },
   "publishConfig": {

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -41,7 +41,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -41,7 +41,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -40,7 +40,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -38,7 +38,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -34,7 +34,7 @@
     "@types/react-motion": "^0.0.29"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 <= 17.0.0"
   },

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@nivo/annotations": "0.63.1",
     "@nivo/colors": "0.63.0",
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "@nivo/tooltip": "0.63.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -40,7 +40,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -38,7 +38,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/legends/package.json
+++ b/packages/legends/package.json
@@ -29,7 +29,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -42,7 +42,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -34,7 +34,7 @@
     "@types/d3-shape": "^2.0.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "react": ">= 16.8.4 <= 17.0.0"
   },
   "publishConfig": {

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -40,7 +40,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -39,7 +39,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/pie/package.json
+++ b/packages/pie/package.json
@@ -39,7 +39,7 @@
     "@types/d3-shape": "^2.0.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "react": ">= 16.8.4 < 18.0.0"
   },
   "publishConfig": {

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -39,7 +39,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -40,7 +40,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -44,7 +44,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -41,7 +41,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/sunburst/package.json
+++ b/packages/sunburst/package.json
@@ -39,7 +39,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -1,55 +1,55 @@
 {
-    "name": "@nivo/swarmplot",
-    "version": "0.65.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/swarmplot"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "force",
-        "swarmplot"
-    ],
-    "main": "./dist/nivo-swarmplot.cjs.js",
-    "module": "./dist/nivo-swarmplot.es.js",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "index.d.ts",
-        "dist/"
-    ],
-    "dependencies": {
-        "@nivo/annotations": "0.65.0",
-        "@nivo/axes": "0.65.0",
-        "@nivo/colors": "0.65.0",
-        "@nivo/legends": "0.65.0",
-        "@nivo/scales": "0.65.0",
-        "@nivo/tooltip": "0.65.0",
-        "@nivo/voronoi": "0.65.0",
-        "d3-force": "^2.0.1",
-        "d3-scale": "^3.0.0",
-        "lodash": "^4.17.11",
-        "react-motion": "^0.5.2"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.65.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.64.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
-        "react": ">= 16.8.4 < 18.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/swarmplot",
+  "version": "0.65.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/swarmplot"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "force",
+    "swarmplot"
+  ],
+  "main": "./dist/nivo-swarmplot.cjs.js",
+  "module": "./dist/nivo-swarmplot.es.js",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "index.d.ts",
+    "dist/"
+  ],
+  "dependencies": {
+    "@nivo/annotations": "0.65.0",
+    "@nivo/axes": "0.65.0",
+    "@nivo/colors": "0.65.0",
+    "@nivo/legends": "0.65.0",
+    "@nivo/scales": "0.65.0",
+    "@nivo/tooltip": "0.65.0",
+    "@nivo/voronoi": "0.65.0",
+    "d3-force": "^2.0.1",
+    "d3-scale": "^3.0.0",
+    "lodash": "^4.17.11",
+    "react-motion": "^0.5.2"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.65.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.65.0",
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.8.4 < 18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -26,7 +26,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0"
+    "@nivo/core": "0.65.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -38,7 +38,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/voronoi/package.json
+++ b/packages/voronoi/package.json
@@ -37,7 +37,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/packages/waffle/package.json
+++ b/packages/waffle/package.json
@@ -40,7 +40,7 @@
     "@nivo/core": "0.65.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.64.0",
+    "@nivo/core": "0.65.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
     "react": ">= 16.8.4 < 18.0.0"
   },

--- a/scripts/bump-peer-deps.js
+++ b/scripts/bump-peer-deps.js
@@ -1,0 +1,29 @@
+const fs = require('fs')
+const { join } = require('path')
+
+function parseFile(file) {
+    return JSON.parse(fs.readFileSync(file, 'utf-8'))
+}
+
+const packages = fs
+    .readdirSync('./packages', { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory() && dirent.name !== 'core')
+    .map(dirent => join('packages', dirent.name, 'package.json'))
+
+packages
+    .map(file => [file, parseFile(file)])
+    .filter(
+        ([, { devDependencies, peerDependencies }]) =>
+            '@nivo/core' in (peerDependencies || {}) &&
+            '@nivo/core' in (devDependencies || {}) &&
+            peerDependencies['@nivo/core'] !== devDependencies['@nivo/core']
+    )
+    .forEach(([file, package]) => {
+        const version = package.devDependencies['@nivo/core']
+
+        package.peerDependencies['@nivo/core'] = version
+
+        console.log(`Bumping peerDependency of '@nivo/core' in '${package.name}' to ${version}.`)
+
+        fs.writeFileSync(file, JSON.stringify(package, null, 2) + '\n', { encoding: 'utf-8' })
+    })


### PR DESCRIPTION
This should run on publish automatically. I did run it to increment all the outstanding changes, maybe we can do it in a separate commit. It should only increment it when the core package version changes and out of sync with any package that has a peerDependency on core.