### PR TITLE
chore(build): bump any nivo peer dep on version mismatch

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,9 @@
     "recompose": "^0.30.0",
     "resize-observer-polyfill": "^1.5.1"
   },
+  "devDependencies": {
+    "@nivo/tooltip": "0.65.1"
+  },
   "peerDependencies": {
     "@nivo/tooltip": "0.63.0",
     "prop-types": ">= 15.5.10 < 16.0.0",


### PR DESCRIPTION
This should work for any peer + dev dependency that starts with '@nivo' and detects a version change. It uses devDependency as the true source since that is what lerna bumps when it is publishing.

Also added the current version of tooltip to core, so next time it runs you will see that get bumped.