### PR TITLE
chore(build): workaround lerna issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
   "scripts": {
     "changelog": "rm CHANGELOG.md && node scripts/generate-changelog.js",
     "make:init": "make init",
-    "version": "yarn changelog && node scripts/bump-peer-deps.js"
+    "prepublishOnly": "yarn release:prepare",
+    "release:prepare": "node scripts/bump-peer-deps.js && yarn changelog",
+    "version": "yarn release:prepare"
   },
   "workspaces": [
     "packages/*",

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -25,7 +25,8 @@
   "files": [
     "README.md",
     "LICENSE.md",
-    "dist/"
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "@nivo/axes": "0.66.0",

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -17,7 +17,8 @@
   "files": [
     "README.md",
     "LICENSE.md",
-    "dist/"
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "d3-color": "^2.0.0",

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -17,7 +17,8 @@
   "files": [
     "README.md",
     "LICENSE.md",
-    "dist/"
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "@nivo/axes": "0.66.0",

--- a/packages/pie/package.json
+++ b/packages/pie/package.json
@@ -25,7 +25,8 @@
   "files": [
     "README.md",
     "LICENSE.md",
-    "dist/"
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "@nivo/colors": "0.66.0",

--- a/packages/sunburst/package.json
+++ b/packages/sunburst/package.json
@@ -25,7 +25,8 @@
   "files": [
     "README.md",
     "LICENSE.md",
-    "dist/"
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "@nivo/colors": "0.66.0",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -17,7 +17,8 @@
   "files": [
     "README.md",
     "LICENSE.md",
-    "dist/"
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
     "react-spring": "9.0.0-rc.3"

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -64,6 +64,13 @@ const run = async () => {
         if (i === 0) await changes({ tag: tags[i], from: '0.31.0', to: tags[i][1] })
         else await changes({ tag: tags[i], from: tags[i - 1][1], to: tags[i][1] })
     }
+
+    await new Promise((resolve, reject) => {
+        exec('git add --all', err => {
+            if (err) return reject(err)
+            resolve()
+        })
+    })
 }
 
 run()


### PR DESCRIPTION
It was pointed out that after the last release, the peerDependencies still weren't updated correctly. If we go look at https://unpkg.com/browse/@nivo/colors@0.66.0/package.json we can see indeed, peer dependencies are still at 0.65.0 for @nivo/core. It also has the `gitHead` field that points to the commit, https://github.com/plouc/nivo/commit/1f6cb2c933d1a319f223ea5509f12e17a952addc, which _does_ include the correct peer dependencies.

So, we are going to run the script in 2 different lifecycle methods, `version` and `prepublishOnly`. Also, note that the generated changelog was not in that commit, so updated the script to stage it for commit.

Unrelated, but the build includes the `tsconfig.tsbuildinfo` from typescript for our typescript packages, so I added an exclude in the `files` field for that file.

Reference #1314