### PR TITLE
feat(bar): typescript - uses string unions to define BarLayerType

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -136,13 +136,7 @@ declare module '@nivo/bar' {
         markers: CartesianMarkerProps[]
     }>
 
-    export enum BarLayerType {
-        Grid = 'grid',
-        Axes = 'axes',
-        Bars = 'bars',
-        Markers = 'markers',
-        Legends = 'legends',
-    }
+    export type BarLayerType = 'grid' | 'axes' | 'bars' | 'markers' | 'legends'
     export type BarCustomLayer = (props: any) => React.ReactNode
     export type Layer = BarLayerType | BarCustomLayer
 


### PR DESCRIPTION
Switching BarLayerType typescript type definition from enum to a string union as discussed in #1322