### PR TITLE
Fix for Area Bump chart problems in #1301

### DIFF
--- a/packages/bump/src/area-bump/hooks.js
+++ b/packages/bump/src/area-bump/hooks.js
@@ -160,10 +160,10 @@ export const useAreaBump = ({
     const series = useMemo(
         () =>
             rawSeries.map(serie => {
-                serie.color = getColor(serie)
-                serie.style = getSerieStyle(serie)
-
-                return serie
+                const nextSerie = { ...serie }
+                nextSerie.color = getColor(nextSerie)
+                nextSerie.style = getSerieStyle(nextSerie)
+                return nextSerie
             }),
         [rawSeries, getColor, getSerieStyle]
     )

--- a/packages/bump/src/bump/hooks.js
+++ b/packages/bump/src/bump/hooks.js
@@ -187,10 +187,10 @@ export const useBump = ({
     const series = useMemo(
         () =>
             rawSeries.map(serie => {
-                serie.color = getColor(serie)
-                serie.style = getSerieStyle(serie)
-
-                return serie
+                const nextSerie = { ...serie }
+                nextSerie.color = getColor(nextSerie)
+                nextSerie.style = getSerieStyle(nextSerie)
+                return nextSerie
             }),
         [rawSeries, getColor, getSerieStyle]
     )


### PR DESCRIPTION
Please have a look at the original issue described in #1301 and at the commit message descriptions of the two first commits of this PR for more details.

The fix can be observed through storybook or the website. In both cases, hovering over the AreaBump chart will prior to this PR do nothing, and after this PR correctly trigger active/inactive styles on the chart.