### PR TITLE
feat(radar) pass index to tooltipFormat

### DIFF
--- a/packages/radar/src/RadarTooltipItem.js
+++ b/packages/radar/src/RadarTooltipItem.js
@@ -32,7 +32,7 @@ const RadarTooltipItem = memo(
             const rows = keys.map(key => [
                 <Chip key={key} color={colorByKey[key]} />,
                 key,
-                tooltipFormatter(datum[key], key),
+                tooltipFormatter(datum[key], key, index),
             ])
             rows.sort((a, b) => a[2] - b[2])
             rows.reverse()


### PR DESCRIPTION
Related issue: #1315

Pass the `index` for `tooltipFormat` in Radar graph, this gives users much more information if they want to do a custom formatter for tooltips. For me, knowing which `index` the data is a part of allows me to get the true value for to display in tooltip when otherwise I would be showing a normalised value.