### PR TITLE
feat(scales): add option to clamp linear scales

### DIFF
--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -13,6 +13,7 @@ declare module '@nivo/scales' {
         max?: 'auto' | number
         stacked?: boolean
         reverse?: boolean
+        clamp?: boolean
     }
 
     export interface PointScale {

--- a/packages/scales/src/linearScale.js
+++ b/packages/scales/src/linearScale.js
@@ -10,7 +10,7 @@ import { scaleLinear } from 'd3-scale'
 import PropTypes from 'prop-types'
 
 export const linearScale = (
-    { axis, min = 0, max = 'auto', stacked = false, reverse = false },
+    { axis, min = 0, max = 'auto', stacked = false, reverse = false, clamp = false },
     xy,
     width,
     height
@@ -34,6 +34,7 @@ export const linearScale = (
 
     scale.type = 'linear'
     scale.stacked = stacked
+    scale.clamp(clamp)
 
     return scale
 }
@@ -44,4 +45,5 @@ export const linearScalePropTypes = {
     max: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]),
     stacked: PropTypes.bool,
     reverse: PropTypes.bool,
+    clamp: PropTypes.bool,
 }

--- a/packages/scales/tests/linearScale.test.js
+++ b/packages/scales/tests/linearScale.test.js
@@ -59,3 +59,17 @@ it(`should allow to reverse domain`, () => {
     expect(scale(0.5)).toBe(50)
     expect(scale(1)).toBe(100)
 })
+
+it(`should allow to clamping`, () => {
+    const scale = linearScale(
+        { axis: 'y', clamp: true, min: 0.5 },
+        { y: { min: 0, max: 1 } },
+        100,
+        100
+    )
+
+    expect(scale.domain()[0]).toBe(0.5)
+    expect(scale(0)).toBe(100)
+    expect(scale(0.5)).toBe(100)
+    expect(scale(1)).toBe(0)
+})


### PR DESCRIPTION
Optional ability to tell a linear scale to clamp. use case e.g. setting bar
value below zero

fixes #1188