### PR TITLE
feat(bar): use custom label for legends

### DIFF
--- a/packages/bar/src/compute/legends.js
+++ b/packages/bar/src/compute/legends.js
@@ -12,7 +12,7 @@ export const getLegendDataForKeys = (bars, layout, direction, groupMode, reverse
     const data = uniqBy(
         bars.map(bar => ({
             id: bar.data.id,
-            label: bar.data.id,
+            label: bar.data.label || bar.data.id,
             color: bar.color,
             fill: bar.data.fill,
         })),
@@ -36,7 +36,7 @@ export const getLegendDataForIndexes = bars => {
     return uniqBy(
         bars.map(bar => ({
             id: bar.data.indexValue,
-            label: bar.data.indexValue,
+            label: bar.data.label || bar.data.indexValue,
             color: bar.color,
             fill: bar.data.fill,
         })),


### PR DESCRIPTION
allow for custom labels to show in the legend instead of the id or index of the series