### PR TITLE
fix(axis): time series rendering

### DIFF
--- a/packages/axes/src/components/Axis.js
+++ b/packages/axes/src/components/Axis.js
@@ -14,8 +14,6 @@ import { computeCartesianTicks, getFormatter } from '../compute'
 import { axisPropTypes } from '../props'
 import AxisTick from './AxisTick'
 
-const defaultTickRenderer = props => <AxisTick {...props} />
-
 const Axis = ({
     axis,
     scale,
@@ -146,7 +144,6 @@ const Axis = ({
                     animatedProps: transitionProps,
                     ...tick,
                     ...(onClick ? { onClick } : {}),
-                    key: tick.key,
                 })
             })}
             <animated.line
@@ -173,7 +170,7 @@ Axis.propTypes = {
     tickPadding: PropTypes.number.isRequired,
     tickRotation: PropTypes.number.isRequired,
     format: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-    renderTick: PropTypes.func.isRequired,
+    renderTick: PropTypes.elementType,
     legend: PropTypes.node,
     legendPosition: PropTypes.oneOf(['start', 'middle', 'end']).isRequired,
     legendOffset: PropTypes.number.isRequired,
@@ -186,7 +183,7 @@ Axis.defaultProps = {
     tickSize: 5,
     tickPadding: 5,
     tickRotation: 0,
-    renderTick: defaultTickRenderer,
+    renderTick: AxisTick,
     legendPosition: 'end',
     legendOffset: 0,
 }

--- a/packages/axes/src/compute.js
+++ b/packages/axes/src/compute.js
@@ -184,7 +184,7 @@ export const computeCartesianTicks = ({
     }
 
     const ticks = values.map(value => ({
-        key: value,
+        key: typeof value === 'number' || typeof value === 'string' ? value : `${value}`,
         value,
         ...translate(value),
         ...line,


### PR DESCRIPTION
Fix for https://github.com/plouc/nivo/issues/1379

The transition uses an ever-incrementing key when the type of the provided key is a `Date`.