### PR TITLE
fix(tooltip): Add anchor param to showTooltipFromEvent type

### DIFF
--- a/packages/tooltip/src/context.ts
+++ b/packages/tooltip/src/context.ts
@@ -7,7 +7,7 @@ export interface TooltipActionsContextData {
         position: [number, number],
         anchor?: TooltipAnchor
     ) => void
-    showTooltipFromEvent: (content: JSX.Element, event: MouseEvent) => void
+    showTooltipFromEvent: (content: JSX.Element, event: MouseEvent, anchor?: TooltipAnchor) => void
     hideTooltip: () => void
 }
 


### PR DESCRIPTION
Using the tooltip hook `showTooltipFromEvent` it only allows two parameters, but in the function definition it actually receives the anchor. So, in order to the TS compilation works I had to do the following:

```
showTooltipFromEvent(
      content,
      event,
      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
      // @ts-ignore
      'left',
    );
``` 

So, I added the anchor param to the `TooltipActionsContextData`, which now is:

`showTooltipFromEvent: (content: JSX.Element, event: MouseEvent, anchor?: TooltipAnchor) => void`