### PR TITLE
feat(heatmap): allow label formatting on heatmaps

### DIFF
--- a/packages/heatmap/index.d.ts
+++ b/packages/heatmap/index.d.ts
@@ -15,6 +15,8 @@ declare module '@nivo/heatmap' {
 
     export type IndexByFunc = (datum: HeatMapDatum) => string | number
 
+    export type LabelFormatter = (datum: HeatMapDatum, key: string) => string | number
+
     export type ValueFormatter = (value: number) => string | number
 
     export interface HeatMapData {
@@ -46,6 +48,7 @@ declare module '@nivo/heatmap' {
             enableGridY: boolean
 
             enableLabels: boolean
+            label: LabelFormatter
             labelTextColor: InheritedColorConfig<HeatMapDatumWithColor>
 
             isInteractive: boolean

--- a/packages/heatmap/src/HeatMap.js
+++ b/packages/heatmap/src/HeatMap.js
@@ -10,6 +10,8 @@ import React, { useCallback } from 'react'
 import { SvgWrapper, withContainer, useDimensions } from '@nivo/core'
 import { Axes, Grid } from '@nivo/axes'
 import { useTooltip } from '@nivo/tooltip'
+import setDisplayName from 'recompose/setDisplayName'
+import enhance from './enhance'
 import { HeatMapSvgPropTypes, HeatMapSvgDefaultProps } from './props'
 import { useHeatMap } from './hooks'
 import HeatMapCells from './HeatMapCells'
@@ -40,6 +42,7 @@ const HeatMap = ({
     enableGridX,
     enableGridY,
     enableLabels,
+    getLabel,
     labelTextColor,
     colors,
     nanColor,
@@ -82,6 +85,7 @@ const HeatMap = ({
         nanColor,
         cellOpacity,
         cellBorderColor,
+        getLabel,
         labelTextColor,
         hoverTarget,
         cellHoverOpacity,
@@ -161,4 +165,4 @@ HeatMap.propTypes = HeatMapSvgPropTypes
 const WrappedHeatMap = withContainer(HeatMap)
 WrappedHeatMap.defaultProps = HeatMapSvgDefaultProps
 
-export default WrappedHeatMap
+export default setDisplayName('WrappedHeatMap')(enhance(WrappedHeatMap))

--- a/packages/heatmap/src/HeatMapCanvas.js
+++ b/packages/heatmap/src/HeatMapCanvas.js
@@ -16,6 +16,8 @@ import {
 } from '@nivo/core'
 import { renderAxesToCanvas } from '@nivo/axes'
 import { useTooltip } from '@nivo/tooltip'
+import setDisplayName from 'recompose/setDisplayName'
+import enhance from './enhance'
 import { useHeatMap } from './hooks'
 import { HeatMapDefaultProps, HeatMapPropTypes } from './props'
 import { renderRect, renderCircle } from './canvas'
@@ -41,6 +43,7 @@ const HeatMapCanvas = ({
     axisBottom,
     axisLeft,
     enableLabels,
+    getLabel,
     labelTextColor,
     colors,
     nanColor,
@@ -77,6 +80,7 @@ const HeatMapCanvas = ({
             nanColor,
             cellOpacity,
             cellBorderColor,
+            getLabel,
             labelTextColor,
             hoverTarget,
             cellHoverOpacity,
@@ -137,6 +141,8 @@ const HeatMapCanvas = ({
         axisRight,
         axisBottom,
         axisLeft,
+        xScale,
+        yScale,
         theme,
         enableLabels,
         pixelRatio,
@@ -179,6 +185,7 @@ const HeatMapCanvas = ({
             showTooltipFromEvent,
             hideTooltip,
             tooltip,
+            tooltipFormat,
         ]
     )
 
@@ -219,4 +226,4 @@ HeatMapCanvas.propTypes = HeatMapPropTypes
 const WrappedHeatMapCanvas = withContainer(HeatMapCanvas)
 WrappedHeatMapCanvas.defaultProps = HeatMapDefaultProps
 
-export default WrappedHeatMapCanvas
+export default setDisplayName('WrappedHeatMapCanvas')(enhance(WrappedHeatMapCanvas))

--- a/packages/heatmap/src/HeatMapCellCircle.js
+++ b/packages/heatmap/src/HeatMapCellCircle.js
@@ -13,7 +13,7 @@ import { useTheme, useMotionConfig } from '@nivo/core'
 
 const HeatMapCellCircle = ({
     data,
-    value,
+    label,
     x,
     y,
     width,
@@ -70,7 +70,7 @@ const HeatMapCellCircle = ({
                     }}
                     fillOpacity={animatedProps.opacity}
                 >
-                    {value}
+                    {label}
                 </animated.text>
             )}
         </animated.g>
@@ -79,7 +79,7 @@ const HeatMapCellCircle = ({
 
 HeatMapCellCircle.propTypes = {
     data: PropTypes.object.isRequired,
-    value: PropTypes.number.isRequired,
+    label: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,

--- a/packages/heatmap/src/HeatMapCellRect.js
+++ b/packages/heatmap/src/HeatMapCellRect.js
@@ -13,7 +13,7 @@ import { useMotionConfig, useTheme } from '@nivo/core'
 
 const HeatMapCellRect = ({
     data,
-    value,
+    label,
     x,
     y,
     width,
@@ -76,7 +76,7 @@ const HeatMapCellRect = ({
                     }}
                     fillOpacity={animatedProps.opacity}
                 >
-                    {value}
+                    {label}
                 </animated.text>
             )}
         </animated.g>
@@ -85,7 +85,7 @@ const HeatMapCellRect = ({
 
 HeatMapCellRect.propTypes = {
     data: PropTypes.object.isRequired,
-    value: PropTypes.number.isRequired,
+    label: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,

--- a/packages/heatmap/src/HeatMapCells.js
+++ b/packages/heatmap/src/HeatMapCells.js
@@ -23,7 +23,7 @@ const HeatMapCells = ({
         React.createElement(cellComponent, {
             key: cell.id,
             data: cell,
-            value: cell.value,
+            label: cell.label,
             x: cell.x,
             y: cell.y,
             width: cell.width,

--- a/packages/heatmap/src/canvas.js
+++ b/packages/heatmap/src/canvas.js
@@ -19,12 +19,12 @@
  * @param {string}  color
  * @param {number}  opacity
  * @param {string}  labelTextColor
- * @param {number}  value
+ * @param {number | string}  label
  */
 export const renderRect = (
     ctx,
     { enableLabels, theme },
-    { x, y, width, height, color, opacity, labelTextColor, value }
+    { x, y, width, height, color, opacity, labelTextColor, label }
 ) => {
     ctx.save()
     ctx.globalAlpha = opacity
@@ -35,7 +35,7 @@ export const renderRect = (
     if (enableLabels === true) {
         ctx.fillStyle = labelTextColor
         ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily}`
-        ctx.fillText(value, x, y)
+        ctx.fillText(label, x, y)
     }
 
     ctx.restore()
@@ -53,12 +53,12 @@ export const renderRect = (
  * @param {string}  color
  * @param {number}  opacity
  * @param {string}  labelTextColor
- * @param {number}  value
+ * @param {number | string}  label
  */
 export const renderCircle = (
     ctx,
     { enableLabels, theme },
-    { x, y, width, height, color, opacity, labelTextColor, value }
+    { x, y, width, height, color, opacity, labelTextColor, label }
 ) => {
     ctx.save()
     ctx.globalAlpha = opacity
@@ -73,7 +73,7 @@ export const renderCircle = (
     if (enableLabels === true) {
         ctx.fillStyle = labelTextColor
         ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily}`
-        ctx.fillText(value, x, y)
+        ctx.fillText(label, x, y)
     }
 
     ctx.restore()

--- a/packages/heatmap/src/enhance.js
+++ b/packages/heatmap/src/enhance.js
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the nivo project.
+ *
+ * Copyright 2016-present, Raphaël Benitte.
+ *d
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import { compose } from 'recompose'
+import defaultProps from 'recompose/defaultProps'
+import withPropsOnChange from 'recompose/withPropsOnChange'
+import pure from 'recompose/pure'
+import { getLabelGenerator } from '@nivo/core'
+import { HeatMapDefaultProps } from './props'
+
+export default Component =>
+    compose(
+        defaultProps(HeatMapDefaultProps),
+        withPropsOnChange(['label', 'labelFormat'], ({ label, labelFormat }) => ({
+            getLabel: getLabelGenerator(label, labelFormat),
+        })),
+        pure
+    )(Component)

--- a/packages/heatmap/src/hooks.js
+++ b/packages/heatmap/src/hooks.js
@@ -29,12 +29,14 @@ const computeCells = ({
     cellHeight,
     colorScale,
     nanColor,
+    getLabel,
     getLabelTextColor,
 }) => {
     const cells = []
     data.forEach(datum => {
         keys.forEach(key => {
             const value = datum[key]
+            const label = getLabel(datum, key)
             const index = getIndex(datum)
             const sizeMultiplier = sizeScale ? sizeScale(value) : 1
             const width = sizeMultiplier * cellWidth
@@ -49,6 +51,7 @@ const computeCells = ({
                 width,
                 height,
                 value,
+                label,
                 color: isNaN(value) ? nanColor : colorScale(value),
                 opacity: cellOpacity,
             }
@@ -76,6 +79,7 @@ export const useHeatMap = ({
     nanColor,
     cellOpacity,
     cellBorderColor,
+    getLabel,
     labelTextColor,
     hoverTarget,
     cellHoverOpacity,
@@ -169,6 +173,7 @@ export const useHeatMap = ({
                 cellHeight: layoutConfig.cellHeight,
                 colorScale,
                 nanColor,
+                getLabel,
                 getLabelTextColor,
             }),
         [
@@ -181,6 +186,7 @@ export const useHeatMap = ({
             layoutConfig,
             colorScale,
             nanColor,
+            getLabel,
             getLabelTextColor,
         ]
     )

--- a/packages/heatmap/src/props.js
+++ b/packages/heatmap/src/props.js
@@ -38,6 +38,8 @@ export const HeatMapPropTypes = {
     enableGridY: PropTypes.bool.isRequired,
 
     enableLabels: PropTypes.bool.isRequired,
+    label: PropTypes.func.isRequired,
+    getLabel: PropTypes.func.isRequired, // computed
     labelTextColor: inheritedColorPropType.isRequired,
 
     colors: quantizeColorScalePropType.isRequired,
@@ -83,6 +85,7 @@ export const HeatMapDefaultProps = {
 
     // labels
     enableLabels: true,
+    label: (datum, key) => datum[key],
     labelTextColor: { from: 'color', modifiers: [['darker', 1.4]] },
 
     // theming

--- a/packages/heatmap/stories/heatmapCanvas.stories.js
+++ b/packages/heatmap/stories/heatmapCanvas.stories.js
@@ -1,44 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { generateCountriesData } from '@nivo/generators'
-import { HeatMap } from '../src'
-
-const CustomCell = ({
-    value,
-    x,
-    y,
-    width,
-    height,
-    color,
-    opacity,
-    borderWidth,
-    borderColor,
-    textColor,
-}) => (
-    <g transform={`translate(${x}, ${y})`}>
-        <path
-            transform={`rotate(${value < 50 ? 180 : 0})`}
-            fill={color}
-            fillOpacity={opacity}
-            strokeWidth={borderWidth}
-            stroke={borderColor}
-            d={`
-                M0 -${Math.round(height / 2)}
-                L${Math.round(width / 2)} ${Math.round(height / 2)}
-                L-${Math.round(width / 2)} ${Math.round(height / 2)}
-                L0 -${Math.round(height / 2)}
-            `}
-        />
-        <text
-            dominantBaseline="central"
-            textAnchor="middle"
-            style={{ fill: textColor }}
-            dy={value < 50 ? -6 : 6}
-        >
-            {value}
-        </text>
-    </g>
-)
+import { HeatMapCanvas } from '../src'
 
 const keys = [
     'hot dogs',
@@ -63,12 +26,12 @@ const commonProperties = {
     keys,
 }
 
-const stories = storiesOf('HeatMap', module)
+const stories = storiesOf('HeatMapCanvas', module)
 
-stories.add('default', () => <HeatMap {...commonProperties} />)
+stories.add('default', () => <HeatMapCanvas {...commonProperties} />)
 
 stories.add('square cells', () => (
-    <HeatMap
+    <HeatMapCanvas
         {...commonProperties}
         forceSquare={true}
         axisTop={{
@@ -83,13 +46,13 @@ stories.add('square cells', () => (
 ))
 
 stories.add('circle cells', () => (
-    <HeatMap {...commonProperties} cellShape="circle" padding={2} enableGridY={true} />
+    <HeatMapCanvas {...commonProperties} cellShape="circle" padding={2} enableGridY={true} />
 ))
 
-stories.add('alternative colors', () => <HeatMap {...commonProperties} colors="BrBG" />)
+stories.add('alternative colors', () => <HeatMapCanvas {...commonProperties} colors="BrBG" />)
 
 stories.add('variable cell size', () => (
-    <HeatMap
+    <HeatMapCanvas
         {...commonProperties}
         colors="BuPu"
         cellShape="circle"
@@ -100,18 +63,8 @@ stories.add('variable cell size', () => (
     />
 ))
 
-stories.add('Custom cell component', () => (
-    <HeatMap
-        {...commonProperties}
-        cellShape={CustomCell}
-        padding={4}
-        colors="GnBu"
-        labelTextColor="inherit:darker(1.6)"
-    />
-))
-
 stories.add('with formatted values', () => (
-    <HeatMap
+    <HeatMapCanvas
         {...commonProperties}
         tooltipFormat={value =>
             `${Number(value).toLocaleString('ru-RU', {
@@ -122,7 +75,7 @@ stories.add('with formatted values', () => (
 ))
 
 stories.add('with formatted labels', () => (
-    <HeatMap
+    <HeatMapCanvas
         {...commonProperties}
         label={(datum, key) =>
             `${Number(datum[key]).toLocaleString('ru-RU', {
@@ -133,7 +86,7 @@ stories.add('with formatted labels', () => (
 ))
 
 stories.add('custom tooltip', () => (
-    <HeatMap
+    <HeatMapCanvas
         {...commonProperties}
         tooltip={({ xKey, yKey, value, color }) => (
             <strong style={{ color }}>

--- a/packages/heatmap/tests/HeatMap.test.js
+++ b/packages/heatmap/tests/HeatMap.test.js
@@ -48,3 +48,16 @@ it('should allow to disable labels', () => {
         expect(cell.find('text').exists()).toBe(false)
     })
 })
+
+it('should allow to format labels', () => {
+    const wrapper = mount(
+        <HeatMap {...sampleProps} label={(datum, key) => datum[key].toFixed(2)} />
+    )
+
+    const cells = wrapper.find(HeatMapCellRect)
+    expect(cells).toHaveLength(9)
+    cells.forEach(cell => {
+        expect(cell.find('text').exists()).toBe(true)
+        expect(cell.find('text').text().length).toEqual(5)
+    })
+})


### PR DESCRIPTION
Had a similar need to https://github.com/plouc/nivo/issues/1425, wanted to change the label that's shown in a heatmap cell.

I copied the way Bar handles a `label` prop for this one, please let me know if there's a different preferred way to do so now.