### PR TITLE
fix(legends): Add missing symbolBorderWidth to typings

### DIFF
--- a/packages/legends/index.d.ts
+++ b/packages/legends/index.d.ts
@@ -83,6 +83,7 @@ declare module '@nivo/legends' {
         symbolSpacing?: number
         symbolShape?: LegendSymbolShape | any
         symbolBorderColor?: string
+        symbolBorderWidth?: number
         textColor?: string
 
         onClick?: LegendMouseHandler


### PR DESCRIPTION
Add missing property `symbolBorderWidth` to the nivo legends Typescript typings.