### PR TITLE
fix(voronoi): fix typo in export class name

### DIFF
--- a/packages/voronoi/index.d.ts
+++ b/packages/voronoi/index.d.ts
@@ -38,5 +38,5 @@ declare module '@nivo/voronoi' {
     }
 
     export class Voronoi extends React.Component<VoronoiProps & Dimensions> {}
-    export class ResponsiveVoroinoi extends React.Component<VoronoiProps> {}
+    export class ResponsiveVoronoi extends React.Component<VoronoiProps> {}
 }


### PR DESCRIPTION
As mentioned in the title.