### PR TITLE
fix(core): add missing marker typings

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -165,8 +165,10 @@ declare module '@nivo/core' {
 
     export interface CartesianMarkerProps {
         axis: 'x' | 'y'
-        value: string | number | Date
+        value: DatumValue
         legend?: string
+        legendOrientation?: 'horizontal' | 'vertical'
+        legendPosition?: BoxAlign
         lineStyle?: Partial<React.CSSProperties>
         textStyle?: Partial<React.CSSProperties>
     }


### PR DESCRIPTION
## Overview 🚀 

Markers are missing two props in their type declarations, `legendOrientation` and `legendPosition`. Those props can be seen in use at [nivo.rocks/adding-markers](https://nivo.rocks/storybook/?path=/story/line--adding-markers).

`legendPosition` utilizes the type declared at [line 20](https://github.com/plouc/nivo/blob/3ba34a22aed3c85f09976f6afee0b42805a04a40/packages/core/index.d.ts#L20) - `BoxAlign`, while `legendOrientation` has a hard coded union `'horizontal' | 'vertical'`.

Additionally, [line 168](https://github.com/plouc/nivo/blob/3ba34a22aed3c85f09976f6afee0b42805a04a40/packages/core/index.d.ts#L168) reuses an already declared `DatumValue` type from [line 5](https://github.com/plouc/nivo/blob/3ba34a22aed3c85f09976f6afee0b42805a04a40/packages/core/index.d.ts#L5).

<hr />

Thanks for the sick dataviz component library 👍 