### PR TITLE
 fix(voronoi): length undefined in production

### DIFF
--- a/packages/voronoi/stories/voronoi.stories.js
+++ b/packages/voronoi/stories/voronoi.stories.js
@@ -132,10 +132,10 @@ const Layer = ({ data, width, height, voronoi, delaunay }) => {
         const point = points[i]
 
         if (d.id === 'mice') {
-            return <circle cx={point[0]} cy={point[1]} r={10} fill="red" />
+            return <circle key={i} cx={point[0]} cy={point[1]} r={10} fill="red" />
         }
 
-        const poly = voronoi.cellPolygon(i)
+        const poly = voronoi.cellPolygon(i) || []
         const maskId = `${d.id}.mask`
 
         return (


### PR DESCRIPTION
This will fix unique key issues & length of undefined for `voronoi`. 

Dev (Warning only shows in dev. The `undefined` error happens after a few seconds.): 
<img width="1904" alt="Screen Shot 2021-03-06 at 9 37 51 PM" src="https://user-images.githubusercontent.com/3586765/110227550-7adfa180-7ec7-11eb-91f1-bcc1d658dff1.png">

Prod (The `undefined` error happens after a few seconds.): 
<img width="1671" alt="Screen Shot 2021-03-06 at 9 42 53 PM" src="https://user-images.githubusercontent.com/3586765/110227431-7b2b6d00-7ec6-11eb-80f4-b3fa34f3f392.png">

Fix:
<img width="1904" alt="Screen Shot 2021-03-07 at 12 30 14 AM" src="https://user-images.githubusercontent.com/3586765/110230130-bafd4f00-7edc-11eb-906b-c33db2c1c7f4.png">

---
❤️ this project. i contributed in [opencollective.com/nivo](https://opencollective.com/nivo).