### PR TITLE
feat(network) add nodeComponent to network

### DIFF
--- a/packages/network/index.d.ts
+++ b/packages/network/index.d.ts
@@ -66,6 +66,7 @@ declare module '@nivo/network' {
         layers?: Layer[]
 
         nodeColor: string | NodeAccessor<ComputedNode, string>
+        renderNode: NodeAccessor<ComputedNode, React.ReactNode>
         nodeBorderWidth?: number
         nodeBorderColor?: InheritedColorConfig<ComputedNode>
 

--- a/packages/network/src/AnimatedNodes.js
+++ b/packages/network/src/AnimatedNodes.js
@@ -10,7 +10,7 @@ import { memo } from 'react'
 import PropTypes from 'prop-types'
 import { TransitionMotion, spring } from 'react-motion'
 import { useMotionConfig } from '@nivo/core'
-import Node from './Node'
+import React from 'react'
 
 const willEnter = ({ style }) => ({
     x: style.x.val,
@@ -26,7 +26,7 @@ const willLeave = springConfig => ({ style }) => ({
     scale: spring(0, springConfig),
 })
 
-const AnimatedNodes = ({ nodes, color, borderColor, ...props }) => {
+const AnimatedNodes = ({ nodes, color, borderColor, nodeComponent, ...props }) => {
     const { springConfig } = useMotionConfig()
 
     return (
@@ -47,19 +47,17 @@ const AnimatedNodes = ({ nodes, color, borderColor, ...props }) => {
             {interpolatedStyles => (
                 <>
                     {interpolatedStyles.map(({ key, style, data: node }) => {
-                        return (
-                            <Node
-                                key={key}
-                                node={node}
-                                x={style.x}
-                                y={style.y}
-                                radius={Math.max(style.radius, 0)}
-                                color={color(node)}
-                                borderColor={borderColor(node)}
-                                scale={Math.max(style.scale, 0)}
-                                {...props}
-                            />
-                        )
+                        return React.createElement(nodeComponent, {
+                            key,
+                            node,
+                            x: style.x,
+                            y: style.y,
+                            radius: Math.max(style.radius, 0),
+                            color: color(node),
+                            borderColor: borderColor(node),
+                            scale: Math.max(style.scale, 0),
+                            ...props,
+                        })
                     })}
                 </>
             )}
@@ -74,6 +72,7 @@ AnimatedNodes.propTypes = {
     borderColor: PropTypes.func.isRequired,
     handleNodeHover: PropTypes.func.isRequired,
     handleNodeLeave: PropTypes.func.isRequired,
+    nodeComponent: PropTypes.func.isRequired,
 }
 
 export default memo(AnimatedNodes)

--- a/packages/network/src/Network.js
+++ b/packages/network/src/Network.js
@@ -38,6 +38,7 @@ const Network = props => {
         nodeColor,
         nodeBorderWidth,
         nodeBorderColor,
+        nodeComponent,
 
         linkThickness,
         linkColor,
@@ -99,6 +100,7 @@ const Network = props => {
             color: getColor,
             borderWidth: nodeBorderWidth,
             borderColor: getBorderColor,
+            nodeComponent,
             handleNodeClick: isInteractive ? onClick : undefined,
             handleNodeHover: isInteractive ? handleNodeHover : undefined,
             handleNodeLeave: isInteractive ? handleNodeLeave : undefined,

--- a/packages/network/src/NetworkCanvas.js
+++ b/packages/network/src/NetworkCanvas.js
@@ -37,6 +37,7 @@ const NetworkCanvas = props => {
         nodeColor,
         nodeBorderWidth,
         nodeBorderColor,
+        renderNode,
 
         linkThickness,
         linkColor,
@@ -94,16 +95,11 @@ const NetworkCanvas = props => {
                 })
             } else if (layer === 'nodes') {
                 nodes.forEach(node => {
-                    ctx.fillStyle = getNodeColor(node)
-                    ctx.beginPath()
-                    ctx.arc(node.x, node.y, node.radius, 0, 2 * Math.PI)
-                    ctx.fill()
-
-                    if (nodeBorderWidth > 0) {
-                        ctx.strokeStyle = getBorderColor(node)
-                        ctx.lineWidth = nodeBorderWidth
-                        ctx.stroke()
-                    }
+                    renderNode(ctx, {
+                        node,
+                        getNodeColor,
+                        getBorderColor,
+                    })
                 })
             } else if (typeof layer === 'function') {
                 layer(ctx, {
@@ -122,6 +118,7 @@ const NetworkCanvas = props => {
         nodes,
         links,
         getNodeColor,
+        renderNode,
         nodeBorderWidth,
         getBorderColor,
         getLinkThickness,

--- a/packages/network/src/StaticNodes.js
+++ b/packages/network/src/StaticNodes.js
@@ -8,22 +8,20 @@
  */
 import { memo } from 'react'
 import PropTypes from 'prop-types'
-import Node from './Node'
+import React from 'react'
 
-const StaticNodes = ({ nodes, color, borderColor, ...props }) => {
+const StaticNodes = ({ nodes, color, borderColor, nodeComponent, ...props }) => {
     return nodes.map(node => {
-        return (
-            <Node
-                key={node.id}
-                node={node}
-                x={node.x}
-                y={node.y}
-                radius={node.radius}
-                color={color(node)}
-                borderColor={borderColor(node)}
-                {...props}
-            />
-        )
+        return React.createElement(nodeComponent, {
+            key: node.id,
+            node,
+            x: node.x,
+            y: node.y,
+            radius: node.radius,
+            color: color(node),
+            borderColor: borderColor(node),
+            ...props,
+        })
     })
 }
 
@@ -34,6 +32,7 @@ StaticNodes.propTypes = {
     borderColor: PropTypes.func.isRequired,
     handleNodeHover: PropTypes.func.isRequired,
     handleNodeLeave: PropTypes.func.isRequired,
+    nodeComponent: PropTypes.func.isRequired,
 }
 
 export default memo(StaticNodes)

--- a/packages/network/src/props.js
+++ b/packages/network/src/props.js
@@ -9,6 +9,7 @@
 import PropTypes from 'prop-types'
 import { motionPropTypes } from '@nivo/core'
 import { inheritedColorPropType } from '@nivo/colors'
+import Node from './Node'
 
 const commonPropTypes = {
     nodes: PropTypes.arrayOf(
@@ -48,11 +49,13 @@ const commonPropTypes = {
 export const NetworkPropTypes = {
     ...commonPropTypes,
     role: PropTypes.string.isRequired,
+    nodeComponent: PropTypes.func.isRequired,
     ...motionPropTypes,
 }
 
 export const NetworkCanvasPropTypes = {
     pixelRatio: PropTypes.number.isRequired,
+    renderNode: PropTypes.func.isRequired,
     ...commonPropTypes,
 }
 
@@ -76,13 +79,30 @@ const commonDefaultProps = {
 
 export const NetworkDefaultProps = {
     ...commonDefaultProps,
+    nodeComponent: Node,
     animate: true,
     motionStiffness: 90,
     motionDamping: 15,
     role: 'img',
 }
 
+const renderCanvasNode = (ctx, props) => {
+    const { node, getNodeColor, getBorderColor, nodeBorderWidth } = props
+
+    ctx.fillStyle = getNodeColor(node)
+    ctx.beginPath()
+    ctx.arc(node.x, node.y, node.radius, 0, 2 * Math.PI)
+    ctx.fill()
+
+    if (nodeBorderWidth > 0) {
+        ctx.strokeStyle = getBorderColor(node)
+        ctx.lineWidth = nodeBorderWidth
+        ctx.stroke()
+    }
+}
+
 export const NetworkCanvasDefaultProps = {
     ...commonDefaultProps,
     pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
+    renderNode: renderCanvasNode,
 }

--- a/packages/network/stories/network.stories.js
+++ b/packages/network/stories/network.stories.js
@@ -6,7 +6,7 @@ import { Network } from '../src'
 
 const data = generateNetworkData()
 
-const commonProperties = {
+const commonProps = {
     ...NetworkDefaultProps,
     nodes: data.nodes,
     links: data.links,
@@ -21,11 +21,11 @@ const commonProperties = {
 
 const stories = storiesOf('Network', module)
 
-stories.add('default', () => <Network {...commonProperties} />)
+stories.add('default', () => <Network {...commonProps} />)
 
 stories.add('custom tooltip', () => (
     <Network
-        {...commonProperties}
+        {...commonProps}
         tooltip={node => {
             return (
                 <div>
@@ -43,5 +43,17 @@ stories.add('custom tooltip', () => (
 ))
 
 stories.add('supports onClick for the node', () => (
-    <Network {...commonProperties} onClick={action('onClick')} />
+    <Network {...commonProps} onClick={action('onClick')} />
+))
+
+stories.add('custom node', () => (
+    <Network
+        {...commonProps}
+        nodeComponent={node => (
+            <g transform={`translate(${node.x - 6},${node.y - 8}) scale(${0.5})`}>
+                <circle cx="12" cy="8" r="5" />
+                <path d="M3,21 h18 C 21,12 3,12 3,21" />
+            </g>
+        )}
+    />
 ))

--- a/packages/network/stories/networkCanvas.stories.js
+++ b/packages/network/stories/networkCanvas.stories.js
@@ -1,13 +1,14 @@
 import { action } from '@storybook/addon-actions'
+import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { NetworkDefaultProps } from '../src/props'
+import { NetworkCanvasDefaultProps } from '../src/props'
 import { generateNetworkData } from '@nivo/generators'
 import { NetworkCanvas } from '../src'
 
 const data = generateNetworkData()
 
-const commonProperties = {
-    ...NetworkDefaultProps,
+const commonProps = {
+    ...NetworkCanvasDefaultProps,
     nodes: data.nodes,
     links: data.links,
     width: 900,
@@ -21,11 +22,11 @@ const commonProperties = {
 
 const stories = storiesOf('NetworkCanvas', module)
 
-stories.add('default', () => <NetworkCanvas {...commonProperties} />)
+stories.add('default', () => <NetworkCanvas {...commonProps} />)
 
 stories.add('custom tooltip', () => (
     <NetworkCanvas
-        {...commonProperties}
+        {...commonProps}
         tooltip={node => {
             return (
                 <div>
@@ -43,5 +44,20 @@ stories.add('custom tooltip', () => (
 ))
 
 stories.add('supports onClick for the node', () => (
-    <NetworkCanvas {...commonProperties} onClick={action('onClick')} />
+    <NetworkCanvas {...commonProps} onClick={action('onClick')} />
+))
+
+stories.add('custom node', () => (
+    <NetworkCanvas
+        {...commonProps}
+        renderNode={(ctx, props) => {
+            const { node } = props
+            ctx.fillStyle = 'red'
+            ctx.beginPath()
+            ctx.moveTo(node.x, node.y - node.radius)
+            ctx.lineTo(node.x + node.radius, node.y + node.radius)
+            ctx.lineTo(node.x - node.radius, node.y + node.radius)
+            ctx.fill()
+        }}
+    />
 ))

--- a/packages/network/tests/Network.test.tsx
+++ b/packages/network/tests/Network.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { Network } from '../src/index'
+
+const nodes = [
+    {
+        id: '0',
+        key: '0',
+        radius: 12,
+        depth: 0,
+        color: 'rgb(244, 117, 96)',
+    },
+    {
+        id: '1',
+        key: '1',
+        radius: 8,
+        depth: 1,
+        color: 'rgb(97, 205, 187)',
+    },
+]
+const links = [
+    {
+        source: '0',
+        target: '1',
+    },
+]
+
+describe('Network', () => {
+    describe('node', () => {
+        it('should render default nodes', () => {
+            const wrapper = mount(
+                <Network
+                    width={400}
+                    height={400}
+                    nodes={nodes}
+                    links={links}
+                    animate={false}
+                    nodeColor={function (e) {
+                        return e.color
+                    }}
+                />
+            )
+            const nodeElements = wrapper.find('Node')
+            expect(nodeElements).toHaveLength(nodes.length)
+        })
+
+        it('should render custom nodes', () => {
+            const wrapper = mount(
+                <Network
+                    width={400}
+                    height={400}
+                    nodes={nodes}
+                    links={links}
+                    animate={false}
+                    nodeColor={function (e) {
+                        return e.color
+                    }}
+                    nodeComponent={function (e) {
+                        return <text />
+                    }}
+                />
+            )
+            const nodeElements = wrapper.find('text')
+            expect(nodeElements).toHaveLength(nodes.length)
+        })
+    })
+})

--- a/website/src/data/components/network/props.ts
+++ b/website/src/data/components/network/props.ts
@@ -218,6 +218,48 @@ const props: ChartProperty[] = [
         defaultValue: NetworkDefaultProps.layers,
         flavors: ['svg', 'canvas'],
     },
+    {
+        key: 'nodeComponent',
+        group: 'Customization',
+        flavors: ['svg'],
+        help: 'Override default node component for the SVG implementation.',
+        description: `
+            This property can be used to completely
+            customize the way nodes are rendered.
+            You should return a valid SVG node.
+            You can see a live example of custom node component
+            [here](storybook:/network--custom-node).
+        `,
+        required: false,
+        type: 'Component',
+    },
+    {
+        key: 'renderNode',
+        flavors: ['svg'],
+        group: 'Nodes',
+        type: '(node: Node) => svg',
+        help: 'Control node svg format.',
+    },
+    {
+        key: 'renderNode',
+        group: 'Customization',
+        flavors: ['canvas'],
+        help: 'Override default node rendering for the canvas implementation.',
+        description: `
+            This property can be used to completely
+            customize the way nodes are rendered.
+            The rendering function will receive the canvas 2d
+            context as first argument.
+            Please make sure to use \`context.save()\` and
+            \`context.restore()\` if you make some global
+            modifications to the 2d context inside this function
+            to avoid side effects.
+            You can see a live example of custom circle component
+            [here](storybook:/networkcanvas--custom-node).
+        `,
+        required: false,
+        type: 'Function',
+    },
     ...motionProperties(['svg'], NetworkDefaultProps),
 ]
 


### PR DESCRIPTION
The purpose of this PR is to introduce a new prop `nodeComponent` to @nivo/network. This `nodeComponent` allows for the overriding of the default Node component allowing for more customisation of networks. This has been a requested feature in a [previously stale issue](https://github.com/plouc/nivo/issues/833).

Also noticed there is no test file for `@nivo/network` so added a new one with some tests related to this change.

Adding in user svg:
<img height="250px" src="https://user-images.githubusercontent.com/12289606/110583761-2d1f9f00-813c-11eb-96ce-5a95883a1f6e.png"/>

Adding in a permanent text component below original Node:
<img height="250px" src="https://user-images.githubusercontent.com/12289606/110583623-f77ab600-813b-11eb-8d35-98b603abaa6d.png"/>



EDIT: This change has also added support for custom node components for NodeCanvas.