### PR TITLE
bugfix for an error that was preventing custom ranges in bullet graph

### DIFF
--- a/packages/bullet/src/hooks.ts
+++ b/packages/bullet/src/hooks.ts
@@ -18,7 +18,7 @@ export const useEnhancedData = (
 
                 const max = Math.max(...all)
 
-                const min = Math.min(...all, 0)
+                const min = Math.min(...all)
 
                 const scale = scaleLinear().domain([min, max])
 

--- a/packages/bullet/stories/bullet.stories.tsx
+++ b/packages/bullet/stories/bullet.stories.tsx
@@ -156,3 +156,34 @@ stories.add('custom title', () => (
         }))}
     />
 ))
+
+
+
+const temperatureData = [{
+    "id":"temperature",
+    "ranges":[30,45],
+    "measures":[34,36,40,42],
+    "markers":[37]
+}]
+
+stories.add('temperature (C)', function(){
+    return (
+        <Bullet 
+            width={900}
+            height={120} 
+            margin={{top: 10, right: 30, bottom: 50, left: 110 }}
+            titleOffsetX={-80}
+            data={temperatureData}
+            spacing={80}
+            animate={false}   
+            rangeComponent={CustomRange} 
+            measureColors={['none', 'orange', 'green', 'orange']} 
+            rangeColors={["none", "#cccccc"]} 
+            markerColors={["black"]}
+        />
+    )
+}, {
+    info: {
+        text: `You can customize ranges using the \`rangeComponent\` property.`,
+    }
+})


### PR DESCRIPTION
Bugfix that was preventing the bullet graph from displaying custom ranges.  Fixes #1447 and #606 

![Screen Shot 2021-03-12 at 7 51 03 PM](https://user-images.githubusercontent.com/675910/111055079-eaa9db00-8437-11eb-8439-0f49bfb3e7c4.png)
