### PR TITLE
fix(bar): types don't allow bar component as any svg element

### DIFF
--- a/packages/bar/index.d.ts
+++ b/packages/bar/index.d.ts
@@ -51,7 +51,7 @@ declare module '@nivo/bar' {
 
     export type ValueFormatter = (value: number) => string | number
 
-    type GraphicsContainer = HTMLCanvasElement | SVGRectElement
+    type GraphicsContainer = HTMLCanvasElement | SVGElement
 
     export type BarMouseEventHandler<T = GraphicsContainer> = (
         datum: BarExtendedDatum,
@@ -146,9 +146,9 @@ declare module '@nivo/bar' {
         SvgDefsAndFill<BarDatum> &
         Partial<{
             layers: Layer[]
-            onClick: BarMouseEventHandler<SVGRectElement>
-            onMouseEnter: BarMouseEventHandler<SVGRectElement>
-            onMouseLeave: BarMouseEventHandler<SVGRectElement>
+            onClick: BarMouseEventHandler<SVGElement>
+            onMouseEnter: BarMouseEventHandler<SVGElement>
+            onMouseLeave: BarMouseEventHandler<SVGElement>
             role: string
         }>
 


### PR DESCRIPTION
Hi Raphaël Benitte,
Thanks for creating such a wonderful chart component library.
I would like to update typedef of GraphicsContainer and on Event.
Due to Nivo provide custom `barComponent` props. The props of bar Item `BarItemProps` would be better to not restricted only on SVGRectElement.