### PR TITLE
feat(line): use theme values for line slice tooltip

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -87,6 +87,7 @@ declare module '@nivo/core' {
             chip: Partial<React.CSSProperties>
             table: Partial<React.CSSProperties>
             tableCell: Partial<React.CSSProperties>
+            tableCellValue: Partial<React.CSSProperties>
         }
         annotations: {
             text: Partial<React.CSSProperties>

--- a/packages/core/src/theming/defaultTheme.js
+++ b/packages/core/src/theming/defaultTheme.js
@@ -72,6 +72,9 @@ export const defaultTheme = {
         tableCell: {
             padding: '3px 5px',
         },
+        tableCellValue: {
+            fontWeight: 'bold',
+        },
     },
     crosshair: {
         line: {

--- a/packages/line/src/SliceTooltip.js
+++ b/packages/line/src/SliceTooltip.js
@@ -20,7 +20,7 @@ const SliceTooltip = ({ slice, axis }) => {
             rows={slice.points.map(point => [
                 <Chip key="chip" color={point.serieColor} style={theme.tooltip.chip} />,
                 point.serieId,
-                <span key="value" style={{ ...theme.tooltip.tableCellValue }}>
+                <span key="value" style={theme.tooltip.tableCellValue}>
                     {point.data[`${otherAxis}Formatted`]}
                 </span>,
             ])}

--- a/packages/line/src/SliceTooltip.js
+++ b/packages/line/src/SliceTooltip.js
@@ -8,25 +8,21 @@
  */
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
-import { TableTooltip } from '@nivo/tooltip'
-
-const Chip = ({ color }) => (
-    <span style={{ display: 'block', width: '12px', height: '12px', background: color }} />
-)
-
-Chip.propTypes = {
-    color: PropTypes.string.isRequired,
-}
+import { useTheme } from '@nivo/core'
+import { Chip, TableTooltip } from '@nivo/tooltip'
 
 const SliceTooltip = ({ slice, axis }) => {
+    const theme = useTheme()
     const otherAxis = axis === 'x' ? 'y' : 'x'
 
     return (
         <TableTooltip
             rows={slice.points.map(point => [
-                <Chip key="chip" color={point.serieColor} />,
+                <Chip key="chip" color={point.serieColor} style={theme.tooltip.chip} />,
                 point.serieId,
-                <strong key="value">{point.data[`${otherAxis}Formatted`]}</strong>,
+                <span key="value" style={{ ...theme.tooltip.tableCellValue }}>
+                    {point.data[`${otherAxis}Formatted`]}
+                </span>,
             ])}
         />
     )


### PR DESCRIPTION
I noticed that the line chart slice tooltip did not apply the theme value for chip so I created this quick fix. For that I reused the Chip component from the tooltip package.

Additionally I added another theme value to theme the value part of the tooltip.

Small preview:
![image](https://user-images.githubusercontent.com/3964017/114052396-4f692180-988e-11eb-98e4-a23596ac1ab4.png)
