### PR TITLE
feat(scales): add nice argument to linear and time scales

### DIFF
--- a/packages/scales/index.d.ts
+++ b/packages/scales/index.d.ts
@@ -6,6 +6,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+import { CountableTimeInterval } from 'd3-time'
+
 declare module '@nivo/scales' {
     export interface LinearScale {
         type: 'linear'
@@ -14,6 +17,7 @@ declare module '@nivo/scales' {
         stacked?: boolean
         reverse?: boolean
         clamp?: boolean
+        nice?: boolean | number
     }
 
     export interface PointScale {
@@ -35,6 +39,7 @@ declare module '@nivo/scales' {
         useUTC?: boolean
         min?: 'auto' | Date
         max?: 'auto' | Date
+        nice?: boolean | number | CountableTimeInterval
     }
 
     export interface LogScale {

--- a/packages/scales/package.json
+++ b/packages/scales/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "d3-scale": "^3.0.0",
+    "d3-time": "^1.0.11",
     "d3-time-format": "^2.1.3",
     "lodash": "^4.17.11"
   },

--- a/packages/scales/src/linearScale.js
+++ b/packages/scales/src/linearScale.js
@@ -10,7 +10,7 @@ import { scaleLinear } from 'd3-scale'
 import PropTypes from 'prop-types'
 
 export const linearScale = (
-    { axis, min = 0, max = 'auto', stacked = false, reverse = false, clamp = false },
+    { axis, min = 0, max = 'auto', stacked = false, reverse = false, clamp = false, nice = false },
     xy,
     width,
     height
@@ -32,6 +32,9 @@ export const linearScale = (
     if (reverse === true) scale.domain([maxValue, minValue])
     else scale.domain([minValue, maxValue])
 
+    if (nice === true) scale.nice()
+    else if (typeof nice === 'number') scale.nice(nice)
+
     scale.type = 'linear'
     scale.stacked = stacked
     scale.clamp(clamp)
@@ -46,4 +49,5 @@ export const linearScalePropTypes = {
     stacked: PropTypes.bool,
     reverse: PropTypes.bool,
     clamp: PropTypes.bool,
+    nice: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
 }

--- a/packages/scales/src/timeScale.js
+++ b/packages/scales/src/timeScale.js
@@ -18,6 +18,7 @@ export const timeScale = (
         min = 'auto',
         max = 'auto',
         useUTC = true,
+        nice = false,
     },
     xy,
     width,
@@ -44,6 +45,8 @@ export const timeScale = (
 
     const scale = useUTC ? scaleUtc() : scaleTime()
     scale.domain([minValue, maxValue]).range([0, size])
+    if (nice === true) scale.nice()
+    else if (typeof nice === 'object' || typeof nice === 'number') scale.nice(nice)
 
     scale.type = 'time'
     scale.useUTC = useUTC
@@ -55,4 +58,5 @@ export const timeScalePropTypes = {
     type: PropTypes.oneOf(['time']).isRequired,
     format: PropTypes.string,
     precision: PropTypes.oneOf(timePrecisions),
+    nice: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.object]),
 }

--- a/packages/scales/tests/linearScale.test.js
+++ b/packages/scales/tests/linearScale.test.js
@@ -73,3 +73,24 @@ it(`should allow to clamping`, () => {
     expect(scale(0.5)).toBe(100)
     expect(scale(1)).toBe(0)
 })
+
+it(`should allow nice`, () => {
+    const scale = linearScale(
+        { axis: 'x', nice: true },
+        { x: { min: 0.243, max: 0.933 } },
+        100,
+        100
+    )
+
+    expect(scale(0)).toBe(0)
+    expect(scale(0.5)).toBe(50)
+    expect(scale(1)).toBe(100)
+})
+
+it(`should allow numeric nice`, () => {
+    const scale = linearScale({ axis: 'x', nice: 2 }, { x: { min: 0.243, max: 0.933 } }, 100, 100)
+
+    expect(scale(0)).toBe(0)
+    expect(scale(0.5)).toBe(50)
+    expect(scale(1)).toBe(100)
+})


### PR DESCRIPTION
This exposes being able to run the builtin d3 `nice` function over the linear and time scales, which smoothes out the starting/ending points of the range. In both cases, they accept either no argument, a numeric `tickCount`, and in the case of the time scale, a time interval.