### PR TITLE
[feature/lint-fix] add lint --fix option and create new make option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ packages-lint: ##@1 packages run eslint on all packages
 	@echo "${YELLOW}Running eslint on all packages${RESET}"
 	@./node_modules/.bin/eslint "./packages/*/{src,tests}/**/*.{js,ts,tsx}"
 
-packages-lint-fix: ##@1 packages run eslint on all packages
+packages-lint-fix: ##@1 packages run eslint on all packages with a fix option
 	@echo "${YELLOW}Running eslint on all packages${RESET}"
 	@./node_modules/.bin/eslint "./packages/*/{src,tests}/**/*.{js,ts,tsx}" --fix
 

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,10 @@ packages-lint: ##@1 packages run eslint on all packages
 	@echo "${YELLOW}Running eslint on all packages${RESET}"
 	@./node_modules/.bin/eslint "./packages/*/{src,tests}/**/*.{js,ts,tsx}"
 
+packages-lint-fix: ##@1 packages run eslint on all packages
+	@echo "${YELLOW}Running eslint on all packages${RESET}"
+	@./node_modules/.bin/eslint "./packages/*/{src,tests}/**/*.{js,ts,tsx}" --fix
+
 package-test-cover-%: ##@1 packages run tests for a package with code coverage
 	@yarn jest -c ./packages/jest.config.js --rootDir . --coverage ./packages/${*}/tests
 


### PR DESCRIPTION
This allows to run `lint --fix` on the files so lint fixes everything it can e.g. formating changes