### PR TITLE
fix(colors/marimekko): update react peer dep to be < 18.0.0

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "@nivo/core": "0.69.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.8.4 <= 17.0.0"
+    "react": ">= 16.8.4 < 18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.69.0",
-    "react": ">= 16.8.4 <= 17.0.0"
+    "react": ">= 16.8.4 < 18.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Looks like these packages were outdated and weren't allowing latest version of react in the peer dependencies.

Close #1531 