### PR TITLE
feat(bump): support more series than ranks

### DIFF
--- a/packages/bump/src/bump/compute.js
+++ b/packages/bump/src/bump/compute.js
@@ -10,21 +10,23 @@ import { scalePoint } from 'd3-scale'
 
 export const computeSeries = ({ width, height, data, xPadding, xOuterPadding, yOuterPadding }) => {
     let xValues = new Set()
+    let yValues = new Set()
     data.forEach(serie => {
         serie.data.forEach(datum => {
             if (!xValues.has(datum.x)) {
                 xValues.add(datum.x)
             }
+            if (!yValues.has(datum.y) && datum.y !== null) {
+                yValues.add(datum.y)
+            }
         })
     })
     xValues = Array.from(xValues)
+    yValues = Array.from(yValues).sort((a, b) => a - b)
 
     const xScale = scalePoint().domain(xValues).range([0, width]).padding(xOuterPadding)
 
-    const yScale = scalePoint()
-        .domain(data.map((serie, i) => i + 1))
-        .range([0, height])
-        .padding(yOuterPadding)
+    const yScale = scalePoint().domain(yValues).range([0, height]).padding(yOuterPadding)
 
     const linePointPadding = xScale.step() * Math.min(xPadding * 0.5, 0.5)
 

--- a/packages/bump/stories/bump.stories.js
+++ b/packages/bump/stories/bump.stories.js
@@ -133,6 +133,19 @@ stories.add('Missing data', () => (
     />
 ))
 
+stories.add('More series than ranks', () => (
+    <Bump
+        {...commonProps}
+        data={generateData().map(series => ({
+            ...series,
+            data: series.data.map(datum => ({
+                x: datum.x,
+                y: datum.y >= 5 ? null : datum.y,
+            })),
+        }))}
+    />
+))
+
 stories.add('Area with fill pattern', () => (
     <AreaBump
         {...commonProps}


### PR DESCRIPTION
If a bump chart has more series than ranks, you run into y-scale issues as described in [this closed issue](https://github.com/plouc/nivo/issues/1337). This PR fixes that by scaling the y-axis on the number of rank values, rather than the number of series.