### PR TITLE
fix(packages): remove `global` from default props

### DIFF
--- a/packages/bar/src/props.js
+++ b/packages/bar/src/props.js
@@ -152,8 +152,7 @@ export const BarDefaultProps = {
 
     annotations: [],
 
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }
 
 export const BarSvgDefaultProps = {

--- a/packages/calendar/src/props.js
+++ b/packages/calendar/src/props.js
@@ -117,6 +117,5 @@ export const CalendarDefaultProps = {
 
 export const CalendarCanvasDefaultProps = {
     ...commonDefaultProps,
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }

--- a/packages/chord/src/props.js
+++ b/packages/chord/src/props.js
@@ -122,6 +122,5 @@ export const ChordDefaultProps = {
 
 export const ChordCanvasDefaultProps = {
     ...commonDefaultProps,
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }

--- a/packages/geo/src/props.js
+++ b/packages/geo/src/props.js
@@ -113,8 +113,7 @@ export const GeoMapDefaultProps = {
 
 export const GeoMapCanvasDefaultProps = {
     ...commonDefaultProps,
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }
 
 const commonChoroplethDefaultProps = {

--- a/packages/heatmap/src/props.js
+++ b/packages/heatmap/src/props.js
@@ -99,8 +99,7 @@ export const HeatMapDefaultProps = {
     cellHoverOthersOpacity: 0.35,
 
     // canvas specific
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }
 
 export const HeatMapSvgDefaultProps = {

--- a/packages/line/src/props.js
+++ b/packages/line/src/props.js
@@ -212,6 +212,5 @@ export const LineDefaultProps = {
 
 export const LineCanvasDefaultProps = {
     ...commonDefaultProps,
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }

--- a/packages/network/src/props.js
+++ b/packages/network/src/props.js
@@ -83,6 +83,5 @@ export const NetworkDefaultProps = {
 
 export const NetworkCanvasDefaultProps = {
     ...commonDefaultProps,
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }

--- a/packages/parallel-coordinates/src/ParallelCoordinatesCanvas.js
+++ b/packages/parallel-coordinates/src/ParallelCoordinatesCanvas.js
@@ -130,8 +130,7 @@ ParallelCoordinatesCanvas.propTypes = {
 const WrappedParallelCoordinatesCanvas = withContainer(ParallelCoordinatesCanvas)
 WrappedParallelCoordinatesCanvas.defaultProps = {
     ...commonDefaultProps,
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }
 
 export default WrappedParallelCoordinatesCanvas

--- a/packages/scatterplot/src/props.js
+++ b/packages/scatterplot/src/props.js
@@ -151,8 +151,7 @@ export const ScatterPlotDefaultProps = {
 export const ScatterPlotCanvasDefaultProps = {
     ...commonDefaultProps,
     layers: ['grid', 'axes', 'nodes', 'mesh', 'legends', 'annotations'],
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }
 
 export const NodePropType = PropTypes.shape({

--- a/packages/swarmplot/src/props.js
+++ b/packages/swarmplot/src/props.js
@@ -132,6 +132,5 @@ export const SwarmPlotDefaultProps = {
 
 export const SwarmPlotCanvasDefaultProps = {
     ...commonDefaultProps,
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }

--- a/packages/treemap/src/props.js
+++ b/packages/treemap/src/props.js
@@ -122,6 +122,5 @@ export const TreeMapHtmlDefaultProps = {
 
 export const TreeMapCanvasDefaultProps = {
     ...commonDefaultProps,
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }

--- a/packages/waffle/src/props.js
+++ b/packages/waffle/src/props.js
@@ -103,6 +103,5 @@ export const WaffleHtmlDefaultProps = {
 export const WaffleCanvasDefaultProps = {
     ...commonDefaultProps,
     legends: [],
-    pixelRatio:
-        global.window && global.window.devicePixelRatio ? global.window.devicePixelRatio : 1,
+    pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 }


### PR DESCRIPTION
This change removes the use of the `global` global variable, which
doesn't exist in browsers and is automatically polyfilled by Webpack.
Other bundlers such as Vite do not do that.
Check for the presence of `window` instead, which should work in more
environments.
