### PR TITLE
chore(core): revert ResizeObserver changes

### DIFF
--- a/packages/core/src/hooks/useMeasure.js
+++ b/packages/core/src/hooks/useMeasure.js
@@ -3,35 +3,20 @@ import ResizeObserver from 'resize-observer-polyfill'
 
 export const useMeasure = () => {
     const measureRef = useRef(null)
-    const animationFrameId = useRef(null)
     const [bounds, setBounds] = useState({
         left: 0,
         top: 0,
         width: 0,
         height: 0,
     })
-    const [observer] = useState(
-        () =>
-            new ResizeObserver(([entry]) => {
-                // wrap this call in requestAnimationFrame to avoid "Resize Observer loop limit exceeded"
-                // error in certain situations
-                animationFrameId.current = requestAnimationFrame(() => {
-                    setBounds(entry.contentRect)
-                })
-            })
-    )
+    const [observer] = useState(() => new ResizeObserver(([entry]) => setBounds(entry.contentRect)))
 
     useEffect(() => {
         if (measureRef.current) {
             observer.observe(measureRef.current)
         }
 
-        return () => {
-            if (animationFrameId.current) {
-                cancelAnimationFrame(animationFrameId.current)
-            }
-            observer.disconnect()
-        }
+        return () => observer.disconnect()
     }, [])
 
     return [measureRef, bounds]


### PR DESCRIPTION
Reverts "fix(core): avoid occasional "ResizeObserver loop" error (#1466)"

This reverts commit 7f88e10da2b1eae178474c9f98e6d652d4a13f6e.

Close #1561 

I'm not sure we had a report about the ResizeObserver loop, but now that the linked issue was created the reverted code is the offender. If you try the latest released version of nivo you can easily reproduce the jumpy tooltip. 

@ollwenjones Sorry I had to revert your PR, but if you want to try another attempt at fixing the ResizeObserver loop error you were receiving. I'll be more than happy to review it and ensure our tooltip doesn't regress this time.