### PR TITLE
fix(legends): update proptypes to avoid generated type error

### DIFF
--- a/packages/legends/src/props.ts
+++ b/packages/legends/src/props.ts
@@ -15,14 +15,7 @@ import PropTypes from 'prop-types'
  * ```
  */
 export const LegendPropShape = {
-    data: PropTypes.arrayOf(
-        PropTypes.shape({
-            id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-            label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-            color: PropTypes.string,
-            fill: PropTypes.string,
-        })
-    ),
+    data: PropTypes.arrayOf(PropTypes.object),
 
     // position & layout
     anchor: PropTypes.oneOf([


### PR DESCRIPTION
Close #1567

Since we are actively removing PropTypes, I think this is an acceptable compromise. Most current legends don't support passing a custom `data` property to the legends config anyways.