### PR TITLE
Bar renderToStatic or renderToString ends up in empty chart

### DIFF
--- a/packages/bar/src/Bar.tsx
+++ b/packages/bar/src/Bar.tsx
@@ -247,6 +247,7 @@ const InnerBar = <RawDatum extends BarDatum>({
         }),
         config: springConfig,
         immediate: !animate,
+        initial: animate ? undefined : null,
     })
 
     const shouldRenderLabel = useCallback(


### PR DESCRIPTION
can be fixed with initial: null