### PR TITLE
feat(timerange): add from, to, and emptyColor props

### DIFF
--- a/packages/calendar/src/TimeRange.tsx
+++ b/packages/calendar/src/TimeRange.tsx
@@ -1,15 +1,13 @@
 import { useMemo } from 'react'
-
 import { Container, SvgWrapper, useValueFormatter, useTheme, useDimensions } from '@nivo/core'
 import { BoxLegendSvg } from '@nivo/legends'
-
 import {
     computeWeekdays,
     computeCellSize,
     computeCellPositions,
     computeMonthLegends,
+    computeTotalDays,
 } from './compute/timeRange'
-
 import { useMonthLegends, useColorScale } from './hooks'
 import { TimeRangeDay } from './TimeRangeDay'
 import { CalendarMonthLegends } from './CalendarMonthLegends'
@@ -24,6 +22,9 @@ const InnerTimeRange = ({
     square = timeRangeDefaultProps.square,
     colors = timeRangeDefaultProps.colors,
     colorScale,
+    emptyColor = timeRangeDefaultProps.emptyColor,
+    from,
+    to,
     data: _data,
     direction = timeRangeDefaultProps.direction,
     minValue = timeRangeDefaultProps.minValue,
@@ -70,10 +71,16 @@ const InnerTimeRange = ({
     const theme = useTheme()
     const colorScaleFn = useColorScale({ data, minValue, maxValue, colors, colorScale })
 
+    const totalDays = computeTotalDays({
+        from,
+        to,
+        data,
+    })
+
     const { cellHeight, cellWidth } = computeCellSize({
         square,
         offset: weekdayLegendOffset,
-        totalDays: data.length + data[0].date.getDay(),
+        totalDays: totalDays,
         width: innerWidth,
         height: innerHeight,
         daySpacing,
@@ -83,8 +90,11 @@ const InnerTimeRange = ({
     const days = computeCellPositions({
         offset: weekdayLegendOffset,
         colorScale: colorScaleFn,
+        emptyColor,
         cellHeight,
         cellWidth,
+        from,
+        to,
         data,
         direction,
         daySpacing,
@@ -134,7 +144,7 @@ const InnerTimeRange = ({
             {days.map(d => {
                 return (
                     <TimeRangeDay
-                        key={d.day.toString()}
+                        key={d.date.toString()}
                         data={d}
                         x={d.coordinates.x}
                         rx={dayRadius}

--- a/packages/calendar/src/TimeRangeDay.tsx
+++ b/packages/calendar/src/TimeRangeDay.tsx
@@ -26,6 +26,10 @@ export const TimeRangeDay = memo(
 
         const handleMouseEnter = useCallback(
             event => {
+                if (!('value' in data)) {
+                    return
+                }
+
                 const formatedData = {
                     ...data,
                     value: formatValue(data.value),
@@ -37,6 +41,10 @@ export const TimeRangeDay = memo(
         )
         const handleMouseMove = useCallback(
             event => {
+                if (!('value' in data)) {
+                    return
+                }
+
                 const formatedData = {
                     ...data,
                     value: formatValue(data.value),
@@ -48,6 +56,10 @@ export const TimeRangeDay = memo(
         )
         const handleMouseLeave = useCallback(
             event => {
+                if (!('value' in data)) {
+                    return
+                }
+
                 hideTooltip()
                 onMouseLeave?.(data, event)
             },

--- a/packages/calendar/src/types.ts
+++ b/packages/calendar/src/types.ts
@@ -193,9 +193,11 @@ export type TimeRangeTooltipProps = Omit<TimeRangeDayData, 'date' | 'value'> & {
 }
 
 export type TimeRangeSvgProps = Dimensions & { data: CalendarDatum[] } & Partial<
+        Omit<CalendarData, 'data'>
+    > &
+    Partial<
         Omit<
             CommonCalendarProps,
-            | 'emptyColor'
             | 'yearLegend'
             | 'yearSpacing'
             | 'yearLegendOffset'

--- a/packages/calendar/src/types.ts
+++ b/packages/calendar/src/types.ts
@@ -174,7 +174,7 @@ export type CalendarCanvasProps = Dimensions &
             }
     >
 
-export type TimeRangeDayData = CalendarDatum & {
+export type TimeRangeDayData = (Omit<CalendarDatum, 'value'> | CalendarDatum) & {
     coordinates: {
         x: number
         y: number

--- a/packages/calendar/stories/timeRange.stories.tsx
+++ b/packages/calendar/stories/timeRange.stories.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react'
-import { withKnobs, number, date, boolean } from '@storybook/addon-knobs'
-import { generateOrderedDayCounts } from '@nivo/generators'
+import { withKnobs, number, date, boolean, color } from '@storybook/addon-knobs'
+import { generateOrderedDayCounts, generateDayCounts } from '@nivo/generators'
 
 import { TimeRange, ResponsiveTimeRange } from '../src'
 
@@ -122,5 +122,54 @@ stories.add('TimeRange vertical', () => {
                 },
             ]}
         />
+    )
+})
+
+stories.add('custom date range', () => {
+    const from = new Date(date('from', new Date(2020, 6, 27)))
+    const to = new Date(date('to', new Date(2020, 11, 7)))
+    const dataFrom = new Date(date('data start', new Date(2020, 7, 27)))
+    const dataTo = new Date(date('data end', new Date(2020, 10, 7)))
+    const data = generateDayCounts(dataFrom, dataTo)
+
+    return (
+        <div
+            style={{
+                height: number('height', 250),
+                width: number('width', 655),
+            }}
+        >
+            <ResponsiveTimeRange
+                {...{
+                    square: boolean('square', true),
+                    dayRadius: number('dayRadius', 5),
+                    formatValue: value => value,
+                    margin: {
+                        top: number('margin-top', 40),
+                        right: number('margin-right', 40),
+                        bottom: number('margin-bottom', 40),
+                        left: number('margin-left', 40),
+                    },
+                    from: from,
+                    to: to,
+                    emptyColor: color('emptyColor', '#EEEEEE'),
+                    data: data,
+                    daySpacing: number('daySpacing', 0),
+                }}
+                weekdayTicks={[]} // hide weekday tickmarks
+                legendFormat={value => value / 10 + 'M'}
+                legends={[
+                    {
+                        anchor: 'bottom',
+                        direction: 'row',
+                        itemCount: 4,
+                        itemWidth: 42,
+                        itemHeight: 36,
+                        itemsSpacing: 14,
+                        translateY: -30,
+                    },
+                ]}
+            />
+        </div>
     )
 })

--- a/website/src/data/components/time-range/props.js
+++ b/website/src/data/components/time-range/props.js
@@ -30,6 +30,20 @@ const props = [
         required: true,
     },
     {
+        key: 'from',
+        group: 'Base',
+        help: 'start date',
+        type: 'string | Date',
+        required: false,
+    },
+    {
+        key: 'to',
+        group: 'Base',
+        help: 'end date',
+        type: 'string | Date',
+        required: false,
+    },
+    {
         key: 'width',
         enableControlForFlavors: ['api'],
         help: 'Chart width.',
@@ -161,6 +175,15 @@ const props = [
         type: 'string[]',
         required: false,
         defaultValue: defaults.colors,
+    },
+    {
+        key: 'emptyColor',
+        help: 'color to use to fill days without available value.',
+        type: 'string',
+        required: false,
+        defaultValue: defaults.emptyColor,
+        controlType: 'colorPicker',
+        group: 'Style',
     },
     // Months
     {

--- a/website/src/pages/time-range/index.js
+++ b/website/src/pages/time-range/index.js
@@ -8,7 +8,7 @@
  */
 import React from 'react'
 import { ResponsiveTimeRange, timeRangeDefaultProps } from '@nivo/calendar'
-import { generateOrderedDayCounts } from '@nivo/generators'
+import { generateDayCounts } from '@nivo/generators'
 import ComponentTemplate from '../../components/components/ComponentTemplate'
 import meta from '../../data/components/time-range/meta.yml'
 import mapper from '../../data/components/time-range/mapper'
@@ -20,7 +20,7 @@ const Tooltip = data => {
 
 const from = new Date(2018, 3, 1)
 const to = new Date(2018, 7, 12)
-const generateData = () => generateOrderedDayCounts(from, to)
+const generateData = () => generateDayCounts(from, to)
 
 const initialProperties = {
     from: '2018-04-01',


### PR DESCRIPTION
Updated the `<TimeRange/>` component to support custom date ranges irregardless of the data provided via optional `from` and `to` props. Also added support for gaps in the data and an `emptyColor` prop for those gaps.