### PR TITLE
Fix autoscale of linechart when data have holes.

### DIFF
--- a/packages/scales/src/compute.ts
+++ b/packages/scales/src/compute.ts
@@ -195,7 +195,11 @@ export const generateSeriesAxis = <Axis extends ScaleAxis, Value extends ScaleVa
 
     switch (scaleSpec.type) {
         case 'linear': {
-            const all = sortBy(uniq(values as number[]).filter(v => v !== null), v => v)
+            const all = sortBy(
+                // filer null values to deal with holes in linechart
+                uniq(values as number[]).filter(v => v !== null),
+                v => v
+            )
 
             return { all, min: Math.min(...all), max: Math.max(...all) }
         }

--- a/packages/scales/src/compute.ts
+++ b/packages/scales/src/compute.ts
@@ -195,7 +195,7 @@ export const generateSeriesAxis = <Axis extends ScaleAxis, Value extends ScaleVa
 
     switch (scaleSpec.type) {
         case 'linear': {
-            const all = sortBy(uniq(values as number[]), v => v)
+            const all = sortBy(uniq(values as number[]).filter(v => v !== null), v => v)
 
             return { all, min: Math.min(...all), max: Math.max(...all) }
         }

--- a/packages/scales/tests/compute.test.ts
+++ b/packages/scales/tests/compute.test.ts
@@ -20,6 +20,12 @@ describe('generateSeriesAxis', () => {
         max: 4,
     }
 
+    const linearScaleExpectation2 = {
+        all: [2, 3, 4],
+        min: 2,
+        max: 4,
+    }
+
     const timeScaleExpectation = {
         all: [
             new Date(Date.UTC(2018, 3, 1, 0, 0, 0, 0)),
@@ -114,6 +120,33 @@ describe('generateSeriesAxis', () => {
                         { type: 'linear' }
                     )
                 ).toEqual(linearScaleExpectation)
+            })
+
+            it('should filter null values (holes) for linear scale', () => {
+                expect(
+                    generateSeriesAxis(
+                        [
+                            {
+                                id: 'A',
+                                data: [
+                                    { data: { [axis]: '2' } },
+                                    { data: { [axis]: '04' } },
+                                    { data: { [axis]: null } },
+                                ],
+                            },
+                            {
+                                id: 'B',
+                                data: [
+                                    { data: { [axis]: '04' } },
+                                    { data: { [axis]: 2 } },
+                                    { data: { [axis]: '3' } },
+                                ],
+                            },
+                        ],
+                        axis,
+                        { type: 'linear' }
+                    )
+                ).toEqual(linearScaleExpectation2)
             })
 
             it('should compute values for time scale with native dates', () => {


### PR DESCRIPTION
The yScale.auto option is not properly computed when the data have holes and is positive. 

This PR filters those hole from the values of the chart so tat the min is not always 0 in that case.

Before:
![image](https://user-images.githubusercontent.com/70476813/130502947-6d3ec083-ac47-41a8-bcdb-e1cd4777551b.png)

After:
![image](https://user-images.githubusercontent.com/70476813/130502411-6feaeed0-cbbc-4f16-9807-71eb85f912b7.png)

Reported also by: https://github.com/plouc/nivo/issues/859
