### PR TITLE
Upgrade d3 color

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,5 +2,6 @@
   "installCommand": "make:init",
   "buildCommand": false,
   "packages": ["packages/*"],
-  "sandboxes": ["/examples/codesandbox", "/website"]
+  "sandboxes": ["/examples/codesandbox", "/website"],
+  "node": "14"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12', '14']
+        node-version: ['14', '16']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-${{ matrix.node-version }}-yarn-
       - name: Restore Lerna cache
         uses: actions/cache@v2
         with:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: make bootstrap
       - run: make packages-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-yarn-
+            ${{ runner.os }}-node${{ matrix.node-version }}-yarn-
       - name: Restore Lerna cache
         uses: actions/cache@v2
         with:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: make bootstrap
       - run: make packages-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14', '16']
+        node-version: ['14']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node ${{ matrix.node-version }}

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -21,7 +21,7 @@
     "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
-    "d3-color": "^2.0.0",
+    "d3-color": "^3.0.1",
     "d3-scale": "^3.2.3",
     "d3-scale-chromatic": "^2.0.0",
     "lodash": "^4.17.21",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@nivo/core": "0.73.0",
-    "@types/d3-color": "^2.0.0",
+    "@types/d3-color": "^3.0.2",
     "@types/d3-scale-chromatic": "^2.0.0",
     "@types/lodash": "^4.14.170",
     "@types/react-motion": "^0.0.29"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@nivo/recompose": "0.73.0",
     "@react-spring/web": "9.2.4",
-    "d3-color": "^2.0.0",
+    "d3-color": "^3.0.1",
     "d3-format": "^1.4.4",
     "d3-hierarchy": "^1.1.8",
     "d3-interpolate": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5469,10 +5469,10 @@
   resolved "https://registry.yarnpkg.com/@types/configstore/-/configstore-2.1.1.tgz#cd1e8553633ad3185c3f2f239ecff5d2643e92b6"
   integrity sha1-zR6FU2M60xhcPy8jns/10mQ+krY=
 
-"@types/d3-color@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-2.0.0.tgz#febdfadade56e215a4c3f612fe3000d92999f5d5"
-  integrity sha512-Bs0maTeU47rdZT+n42iQ0C4gnbnJlIDJkqHFtIsDx2tPPITDeoSdIrm+00UYXzegzArYC2GsG80eHNMwz08IAw==
+"@types/d3-color@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.0.2.tgz#53f2d6325f66ee79afd707c05ac849e8ae0edbb0"
+  integrity sha512-WVx6zBiz4sWlboCy7TCgjeyHpNjMsoF36yaagny1uXfbadc9f+5BeBf7U+lRmQqY3EHbGQpP8UdW8AC+cywSwQ==
 
 "@types/d3-delaunay@^5.3.0":
   version "5.3.0"
@@ -9913,10 +9913,15 @@ d3-chord@^1.0.6:
     d3-array "1"
     d3-path "1"
 
-"d3-color@1 - 2", d3-color@^2.0.0:
+"d3-color@1 - 2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
   integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
+
+d3-color@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.0.1.tgz#03316e595955d1fcd39d9f3610ad41bb90194d0a"
+  integrity sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==
 
 d3-delaunay@^5.3.0:
   version "5.3.0"


### PR DESCRIPTION
fix https://github.com/plouc/nivo/issues/1728

Also upgrade the Node.js version used on CI to `14` (active), as `12` is now in maintenance mode and not compatible with the new `d3-color` version, I couldn't enable `16` at the moment because of an incompatible package used for the website (`sharp`), I think we can enable it when upgrading gatsby and its plugins.