### PR TITLE
Add missing peer dependencies

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -54,6 +54,9 @@
     "uuid": "^3.1.0",
     "winston": "^2.3.1"
   },
+  "peerDependencies": {
+    "prop-types": ">= 15.5.10 < 16.0.0"
+  },
   "scripts": {
     "readme": "node misc/readmeData.js | mustache - misc/README.mustache > README.md",
     "start": "node src/app.js",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "serve": "^11.2.0",
     "typescript": "^4.3.4"
   },
+  "peerDependencies": {
+    "webpack": ">=2"
+  },
   "resolutions": {
     "@types/react": "^17.0.11",
     "react": "17.0.2",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -37,7 +37,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/arcs/package.json
+++ b/packages/arcs/package.json
@@ -38,7 +38,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -40,7 +40,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -45,7 +45,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -40,7 +40,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -43,7 +43,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -41,7 +41,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -43,7 +43,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -42,7 +42,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -37,7 +37,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,8 @@
   "peerDependencies": {
     "@nivo/tooltip": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -41,7 +41,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -42,7 +42,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -40,7 +40,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/legends/package.json
+++ b/packages/legends/package.json
@@ -27,7 +27,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -44,7 +44,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -36,7 +36,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -42,7 +42,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -41,7 +41,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pie/package.json
+++ b/packages/pie/package.json
@@ -41,7 +41,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/polar-axes/package.json
+++ b/packages/polar-axes/package.json
@@ -37,7 +37,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -41,7 +41,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/radial-bar/package.json
+++ b/packages/radial-bar/package.json
@@ -44,7 +44,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -43,7 +43,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -42,13 +42,15 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@nivo/core": "0.73.0",
     "@types/d3-scale": "^3.2.2",
-    "@types/d3-shape": "^2.0.0",
-    "@nivo/core": "0.73.0"
+    "@types/d3-shape": "^2.0.0"
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -45,7 +45,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sunburst/package.json
+++ b/packages/sunburst/package.json
@@ -41,7 +41,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -49,7 +49,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -27,7 +27,10 @@
     "@nivo/core": "0.73.0"
   },
   "peerDependencies": {
-    "@nivo/core": "0.73.0"
+    "@nivo/core": "0.73.0",
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -40,7 +40,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/voronoi/package.json
+++ b/packages/voronoi/package.json
@@ -39,7 +39,9 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.73.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/waffle/package.json
+++ b/packages/waffle/package.json
@@ -41,7 +41,8 @@
   "peerDependencies": {
     "@nivo/core": "0.73.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": "^16.8.0  || ^17.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
There are a number of missing peer dependencies in packages which leads to warnings in Yarn 3.
This adds them as peer dependencies to resolve those warnings.

Fixes #1788 