### PR TITLE
fix(bar): avoid to redefine react forwardRef type

### DIFF
--- a/packages/bar/src/BarCanvas.tsx
+++ b/packages/bar/src/BarCanvas.tsx
@@ -27,13 +27,6 @@ import { renderLegendToCanvas } from '@nivo/legends'
 import { useTooltip } from '@nivo/tooltip'
 import { useBar } from './hooks'
 
-declare module 'react' {
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    function forwardRef<T, P = {}>(
-        render: (props: P, ref: React.Ref<T>) => React.ReactElement | null
-    ): (props: P & React.RefAttributes<T>) => React.ReactElement | null
-}
-
 type InnerBarCanvasProps<RawDatum extends BarDatum> = Omit<
     BarCanvasProps<RawDatum>,
     'renderWrapper' | 'theme'

--- a/packages/bar/src/ResponsiveBarCanvas.tsx
+++ b/packages/bar/src/ResponsiveBarCanvas.tsx
@@ -9,7 +9,12 @@ export const ResponsiveBarCanvas = forwardRef(function ResponsiveBarCanvas<
     return (
         <ResponsiveWrapper>
             {({ width, height }) => (
-                <BarCanvas width={width} height={height} {...props} ref={ref} />
+                <BarCanvas
+                    width={width}
+                    height={height}
+                    {...(props as Omit<BarCanvasProps<BarDatum>, 'height' | 'width'>)}
+                    ref={ref}
+                />
             )}
         </ResponsiveWrapper>
     )


### PR DESCRIPTION
Avoid to redefine react type ;)

The previous definition was problematic when using proptypes in a typescript file: 

Any typescript codebase importing `@nivo/bar` suddendly can't attach `propTypes` to the returned value of `forwardRef` because they are now just a function and not a `ForwardRefExoticComponent` anymore... unexpected & very disturbing.

This resulted in breaking build with typescript errors!

The symptomatic error is ts(2339):
> Property 'propTypes' does not exist on type '(props: ...) => ReactElement<...> | null'.