### PR TITLE
feat(radar): add support for patterns and gradients

### DIFF
--- a/packages/radar/src/Radar.tsx
+++ b/packages/radar/src/Radar.tsx
@@ -50,6 +50,8 @@ const InnerRadar = <D extends Record<string, unknown>>({
     ariaLabel,
     ariaLabelledBy,
     ariaDescribedBy,
+    defs = svgDefaultProps.defs,
+    fill = svgDefaultProps.fill,
 }: InnerRadarProps<D>) => {
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
@@ -62,6 +64,8 @@ const InnerRadar = <D extends Record<string, unknown>>({
         indices,
         formatValue,
         colorByKey,
+        fillByKey,
+        boundDefs,
         radius,
         radiusScale,
         centerX,
@@ -81,6 +85,8 @@ const InnerRadar = <D extends Record<string, unknown>>({
         height: innerHeight,
         colors,
         legends,
+        defs,
+        fill,
     })
 
     const layerById: Record<RadarLayerId, ReactNode> = {
@@ -116,6 +122,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                         data={data}
                         item={key}
                         colorByKey={colorByKey}
+                        fillByKey={fillByKey}
                         radiusScale={radiusScale}
                         angleStep={angleStep}
                         curveFactory={curveFactory}
@@ -187,6 +194,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
 
     return (
         <SvgWrapper
+            defs={boundDefs}
             width={outerWidth}
             height={outerHeight}
             margin={margin}

--- a/packages/radar/src/RadarLayer.tsx
+++ b/packages/radar/src/RadarLayer.tsx
@@ -10,7 +10,7 @@ interface RadarLayerProps<D extends Record<string, unknown>> {
     data: D[]
     item: string
     colorByKey: Record<string | number, string>
-    fillByKey: Record<string, { fill: string }>
+    fillByKey: Record<string, string | null>
     radiusScale: ScaleLinear<number, number>
     angleStep: number
     curveFactory: CurveFactory
@@ -51,7 +51,7 @@ export const RadarLayer = <D extends Record<string, unknown>>({
         config: springConfig,
         immediate: !animate,
     })
-    const fill = fillByKey[key]?.fill ?? animatedProps.fill
+    const fill = fillByKey[key] ?? animatedProps.fill
 
     return (
         <animated.path

--- a/packages/radar/src/RadarLayer.tsx
+++ b/packages/radar/src/RadarLayer.tsx
@@ -10,6 +10,7 @@ interface RadarLayerProps<D extends Record<string, unknown>> {
     data: D[]
     item: string
     colorByKey: Record<string | number, string>
+    fillByKey: Record<string, { fill: string }>
     radiusScale: ScaleLinear<number, number>
     angleStep: number
     curveFactory: CurveFactory
@@ -23,6 +24,7 @@ export const RadarLayer = <D extends Record<string, unknown>>({
     data,
     item: key,
     colorByKey,
+    fillByKey,
     radiusScale,
     angleStep,
     curveFactory,
@@ -49,12 +51,13 @@ export const RadarLayer = <D extends Record<string, unknown>>({
         config: springConfig,
         immediate: !animate,
     })
+    const fill = fillByKey[key]?.fill ?? animatedProps.fill
 
     return (
         <animated.path
             key={key}
             d={animatedPath}
-            fill={animatedProps.fill}
+            fill={fill}
             fillOpacity={fillOpacity}
             stroke={animatedProps.stroke}
             strokeWidth={borderWidth}

--- a/packages/radar/src/hooks.ts
+++ b/packages/radar/src/hooks.ts
@@ -1,6 +1,12 @@
 import { useMemo } from 'react'
 import { scaleLinear } from 'd3-scale'
-import { bindDefs, useCurveInterpolation, usePropertyAccessor, useValueFormatter } from '@nivo/core'
+import {
+    // @ts-ignore
+    bindDefs,
+    useCurveInterpolation,
+    usePropertyAccessor,
+    useValueFormatter,
+} from '@nivo/core'
 import { useOrdinalColorScale } from '@nivo/colors'
 import { svgDefaultProps } from './props'
 import {

--- a/packages/radar/src/hooks.ts
+++ b/packages/radar/src/hooks.ts
@@ -64,7 +64,7 @@ export const useRadar = <D extends Record<string, unknown>>({
         }, {} as Record<string, { fill: string | null }>)
 
         return { boundDefs, fillByKey }
-    }, [keys, defs, fill, colorByKey])
+    }, [keys, data, defs, fill, colorByKey])
 
     const { radius, radiusScale, centerX, centerY, angleStep } = useMemo(() => {
         const allValues: number[] = data.reduce(

--- a/packages/radar/src/hooks.ts
+++ b/packages/radar/src/hooks.ts
@@ -57,11 +57,11 @@ export const useRadar = <D extends Record<string, unknown>>({
         // expand keys into structure expected by bindDefs
         const keyData = keys.map(k => ({ key: k, color: colorByKey[k], data, fill: null }))
         const boundDefs = bindDefs(defs, keyData, fill)
-        const fillByKey = keyData.reduce((mapping, keyDatum) => {
-            const { key: keyName, ...fill } = keyDatum
+        const fillByKey = keyData.reduce<Record<string, string | null>>((mapping, keyDatum) => {
+            const { key: keyName, fill } = keyDatum
             mapping[keyName] = fill
             return mapping
-        }, {} as Record<string, { fill: string | null }>)
+        }, {})
 
         return { boundDefs, fillByKey }
     }, [keys, data, defs, fill, colorByKey])

--- a/packages/radar/src/props.ts
+++ b/packages/radar/src/props.ts
@@ -38,4 +38,7 @@ export const svgDefaultProps = {
 
     animate: true,
     motionConfig: 'gentle' as const,
+
+    defs: [],
+    fill: [],
 }

--- a/packages/radar/src/types.ts
+++ b/packages/radar/src/types.ts
@@ -133,15 +133,15 @@ export interface RadarCommonProps<D extends Record<string, unknown>> {
 }
 
 interface RadarSvgFillMatcherDatum<D extends Record<string, unknown>> {
-    color: string;
-    data: RadarDataProps<D>['data'];
-    key: string;
+    color: string
+    data: RadarDataProps<D>['data']
+    key: string
 }
 
 export type RadarSvgProps<D extends Record<string, unknown>> = Partial<RadarCommonProps<D>> &
     RadarDataProps<D> &
     Dimensions &
-    ModernMotionProps & 
+    ModernMotionProps &
     SvgDefsAndFill<RadarSvgFillMatcherDatum<D>>
 
 export type BoundLegendProps = Required<Pick<LegendProps, 'data'>> & Omit<LegendProps, 'data'>

--- a/packages/radar/src/types.ts
+++ b/packages/radar/src/types.ts
@@ -10,6 +10,7 @@ import {
     ValueFormat,
     ClosedCurveFactoryId,
     DotsItemSymbolComponent,
+    SvgDefsAndFill,
 } from '@nivo/core'
 import { InheritedColorConfig, OrdinalColorScaleConfig } from '@nivo/colors'
 import { LegendProps } from '@nivo/legends'
@@ -131,9 +132,16 @@ export interface RadarCommonProps<D extends Record<string, unknown>> {
     ariaDescribedBy: AriaAttributes['aria-describedby']
 }
 
+interface RadarSvgFillMatcherDatum<D extends Record<string, unknown>> {
+    color: string;
+    data: RadarDataProps<D>['data'];
+    key: string;
+}
+
 export type RadarSvgProps<D extends Record<string, unknown>> = Partial<RadarCommonProps<D>> &
     RadarDataProps<D> &
     Dimensions &
-    ModernMotionProps
+    ModernMotionProps & 
+    SvgDefsAndFill<RadarSvgFillMatcherDatum<D>>
 
 export type BoundLegendProps = Required<Pick<LegendProps, 'data'>> & Omit<LegendProps, 'data'>

--- a/packages/radar/src/types.ts
+++ b/packages/radar/src/types.ts
@@ -132,7 +132,7 @@ export interface RadarCommonProps<D extends Record<string, unknown>> {
     ariaDescribedBy: AriaAttributes['aria-describedby']
 }
 
-interface RadarSvgFillMatcherDatum<D extends Record<string, unknown>> {
+export interface RadarSvgFillMatcherDatum<D extends Record<string, unknown>> {
     color: string
     data: RadarDataProps<D>['data']
     key: string

--- a/packages/radar/stories/radar.stories.tsx
+++ b/packages/radar/stories/radar.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react'
 import { withKnobs, select } from '@storybook/addon-knobs'
 import { generateWinesTastes } from '@nivo/generators'
-import { ClosedCurveFactoryId } from '@nivo/core'
+import { ClosedCurveFactoryId, patternDotsDef, patternSquaresDef } from '@nivo/core'
 // @ts-ignore
 import { Radar, GridLabelProps } from '../src'
 
@@ -159,6 +159,38 @@ export const CustomLegendLabel = () => (
                 itemTextColor: '#333',
                 symbolSize: 6,
                 symbolShape: 'circle',
+            },
+        ]}
+    />
+)
+
+export const WithGradient = () => (
+    <Radar 
+        {...commonProperties} 
+        defs={[
+            patternDotsDef('dots', {
+                background: '#fc0341',
+                color: 'inherit',
+                size: 4,
+                padding: 2,
+                stagger: true,
+            }),
+            patternSquaresDef('squares', {
+                background: '#4287f5',
+                color: 'inherit',
+                size: 6,
+                padding: 4,
+                stagger: false,
+            }),
+        ]}
+        fill={[
+            {
+                match: node => node.key === commonProperties.keys[0],
+                id: 'dots',
+            },
+            {
+                match: node => node.key === commonProperties.keys[1],
+                id: 'squares',
             },
         ]}
     />

--- a/packages/radar/stories/radar.stories.tsx
+++ b/packages/radar/stories/radar.stories.tsx
@@ -165,8 +165,8 @@ export const CustomLegendLabel = () => (
 )
 
 export const WithGradient = () => (
-    <Radar 
-        {...commonProperties} 
+    <Radar
+        {...commonProperties}
         defs={[
             patternDotsDef('dots', {
                 background: '#fc0341',

--- a/packages/radar/stories/radar.stories.tsx
+++ b/packages/radar/stories/radar.stories.tsx
@@ -164,7 +164,7 @@ export const CustomLegendLabel = () => (
     />
 )
 
-export const WithGradient = () => (
+export const WithPatterns = () => (
     <Radar
         {...commonProperties}
         defs={[

--- a/website/src/data/components/radar/meta.yml
+++ b/website/src/data/components/radar/meta.yml
@@ -15,6 +15,8 @@ Radar:
       link: radar--with-formatted-values
     - label: Custom label component
       link: radar--custom-label-component
+    - label: Adding patterns to radar layers
+      link: radar--with-patterns
   description: |
     Generates a radar chart from an array of data.
     Note that margin object does not take grid labels into account,

--- a/website/src/data/components/radar/props.ts
+++ b/website/src/data/components/radar/props.ts
@@ -1,6 +1,11 @@
 import { closedCurvePropKeys } from '@nivo/core'
 import { svgDefaultProps } from '@nivo/radar'
-import { themeProperty, motionProperties, groupProperties, defsProperties } from '../../../lib/componentProperties'
+import {
+    themeProperty,
+    motionProperties,
+    groupProperties,
+    defsProperties,
+} from '../../../lib/componentProperties'
 import { ChartProperty } from '../../../types'
 
 const props: ChartProperty[] = [

--- a/website/src/data/components/radar/props.ts
+++ b/website/src/data/components/radar/props.ts
@@ -1,6 +1,6 @@
 import { closedCurvePropKeys } from '@nivo/core'
 import { svgDefaultProps } from '@nivo/radar'
-import { themeProperty, motionProperties, groupProperties } from '../../../lib/componentProperties'
+import { themeProperty, motionProperties, groupProperties, defsProperties } from '../../../lib/componentProperties'
 import { ChartProperty } from '../../../types'
 
 const props: ChartProperty[] = [
@@ -210,6 +210,7 @@ const props: ChartProperty[] = [
         defaultValue: svgDefaultProps.borderColor,
         controlType: 'inheritedColor',
     },
+    ...defsProperties('Style', ['svg']),
     {
         key: 'gridLevels',
         group: 'Grid',


### PR DESCRIPTION
Hi, we currently use this chart but need to support patterns with it. 
This PR adds defs and fill props to radar chart to support patterns and gradients.

![Screen Shot 2021-10-18 at 2 53 18 PM](https://user-images.githubusercontent.com/89929613/137812591-c7988924-d482-42d3-b17a-18a33ccd393e.png)


