### PR TITLE
feat(defs): allow gradientTransform to be passed to gradient definitions

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -255,6 +255,7 @@ declare module '@nivo/core' {
             color: string
             opacity?: number
         }[]
+        gradientTransform?: string
     }
 
     export type PatternDotsDef = {

--- a/packages/core/src/components/defs/gradients/LinearGradient.js
+++ b/packages/core/src/components/defs/gradients/LinearGradient.js
@@ -8,8 +8,8 @@
  */
 import PropTypes from 'prop-types'
 
-export const LinearGradient = ({ id, colors }) => (
-    <linearGradient id={id} x1={0} x2={0} y1={0} y2={1}>
+export const LinearGradient = ({ id, colors, ...rest }) => (
+    <linearGradient id={id} x1={0} x2={0} y1={0} y2={1} {...rest}>
         {colors.map(({ offset, color, opacity }) => (
             <stop
                 key={offset}
@@ -30,6 +30,7 @@ LinearGradient.propTypes = {
             opacity: PropTypes.number,
         })
     ).isRequired,
+    gradientTransform: PropTypes.string,
 }
 
 export const linearGradientDef = (id, colors, options = {}) => ({

--- a/packages/core/tests/lib/defs.test.js
+++ b/packages/core/tests/lib/defs.test.js
@@ -163,6 +163,24 @@ describe('bindDefs()', () => {
             ])
         })
 
+        it('should allow gradientTransform to be used', () => {
+            const defs = [
+                {
+                    id: 'gradient',
+                    type: 'linearGradient',
+                    colors: [],
+                    gradientTransform: 'rotate(90 0.5 0.5)',
+                },
+            ]
+            const nodes = [{}, {}]
+
+            const boundDefs = bindDefs(defs, nodes, [{ match: '*', id: 'gradient' }], {
+                targetKey: 'style.fill',
+            })
+
+            expect(boundDefs).toEqual(defs)
+        })
+
         it('should support inheritance', () => {
             const defs = [
                 {

--- a/packages/treemap/stories/treemap.stories.js
+++ b/packages/treemap/stories/treemap.stories.js
@@ -46,11 +46,15 @@ stories.add('patterns & gradients', () => (
             modifiers: [['darker', 3]],
         }}
         defs={[
-            linearGradientDef('gradient', [
-                { offset: 0, color: '#ffffff' },
-                { offset: 15, color: 'inherit' },
-                { offset: 100, color: 'inherit' },
-            ]),
+            linearGradientDef(
+                'gradient',
+                [
+                    { offset: 0, color: '#ffffff' },
+                    { offset: 15, color: 'inherit' },
+                    { offset: 100, color: 'inherit' },
+                ],
+                { gradientTransform: 'rotate(-90 0.5 0.5)' }
+            ),
             patternDotsDef('pattern', {
                 background: 'inherit',
                 color: '#ffffff',

--- a/website/src/components/guides/gradients/GradientsExample.js
+++ b/website/src/components/guides/gradients/GradientsExample.js
@@ -20,7 +20,13 @@ const MyChart = () => (
             linearGradientDef('gradientB', [
                 { offset: 0, color: '#000' },
                 { offset: 100, color: 'inherit' },
-            ]),
+            ],
+            // you may specify transforms for your gradients, e.g. rotations and skews,
+            // following the transform attribute format.
+            // For instance here we rotate 90 degrees relative to the center of the object.
+            {
+                gradientTransform: 'rotate(90 0.5 0.5)'
+            }),
             // using plain object
             {
                 id: 'gradientC',


### PR DESCRIPTION
Fixes #1098

This PR allows defining gradient transforms as part of the `defs` for linear gradients. 
This fixes the (now stale, but still relevant) associated feature request #1098. 

Example usage: 

```tsx
 <Line
        {...commonProperties}
        enableArea={true}
        yScale={{
            type: 'linear',
            stacked: true,
        }}
        curve={select('curve', curveOptions, 'linear')}
        defs={[
            linearGradientDef(
                'gradientA',
                [
                    { offset: 0, color: 'inherit' },
                    { offset: 100, color: 'inherit', opacity: 0 },
                ],
                { gradientTransform: 'rotate(90 0.5 0.5)' }
            ),
        ]}
        fill={[{ match: '*', id: 'gradientA' }]}
    />
```

The transform attribute follows the SVG spec documented here: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform 

I added a test and modified the gradient example to show how to use that new property, which for instance allows horizontal gradients on lines: 
![image](https://user-images.githubusercontent.com/11202803/139069853-40369b46-3b55-4284-8ed8-df6fed3dc99c.png)

