### PR TITLE
fix(swarmplot): use the borderWidth property - fixes #1813

### DIFF
--- a/packages/swarmplot/src/SwarmPlot.tsx
+++ b/packages/swarmplot/src/SwarmPlot.tsx
@@ -36,6 +36,7 @@ const InnerSwarmPlot = <RawDatum,>({
     colors = defaultProps.colors as OrdinalColorScaleConfig<Omit<ComputedDatum<RawDatum>, 'color'>>,
     colorBy = defaultProps.colorBy,
     borderColor = defaultProps.borderColor as InheritedColorConfig<ComputedDatum<RawDatum>>,
+    borderWidth = defaultProps.borderWidth,
     layout = defaultProps.layout,
     spacing = defaultProps.spacing,
     gap = defaultProps.gap,
@@ -141,7 +142,7 @@ const InnerSwarmPlot = <RawDatum,>({
             <Circles<RawDatum>
                 key="circles"
                 nodes={nodes}
-                borderWidth={0}
+                borderWidth={borderWidth}
                 borderColor={borderColor}
                 isInteractive={isInteractive}
                 tooltip={tooltip}

--- a/packages/swarmplot/tests/Swarmplot.test.tsx
+++ b/packages/swarmplot/tests/Swarmplot.test.tsx
@@ -137,5 +137,22 @@ describe('SwarmPlot', () => {
             expect(onMouseMove).not.toHaveBeenCalled()
             expect(onMouseLeave).not.toHaveBeenCalled()
         })
+
+        it('should support the borderWidth property', () => {
+            const wrapper = mount(
+                <SwarmPlot
+                    width={400}
+                    height={400}
+                    groupBy="group"
+                    groups={groups}
+                    data={sampleData}
+                    borderWidth={4}
+                />
+            )
+
+            expect(wrapper.find('circle').at(0).getDOMNode().getAttribute('stroke-width')).toEqual(
+                '4'
+            )
+        })
     })
 })


### PR DESCRIPTION
This PR fixes #1813 by passing down the borderWidth property which was omitted in the Swarmplot component.

The result can be seen in the story at `/story/swarmplot--extra-layers` which defined a borderWidth which was not being used. It is now displaying as intended: 
![image](https://user-images.githubusercontent.com/11202803/139106082-97b8075a-cdef-4e5f-a628-6adbf3f07403.png)
