### PR TITLE
chore: update @react-spring/web to 9.3.1

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@nivo/colors": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/arcs/package.json
+++ b/packages/arcs/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@nivo/colors": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-shape": "^1.3.5"
   },
   "devDependencies": {

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@nivo/scales": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-format": "^1.4.4",
     "d3-time-format": "^3.0.0"
   },

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -35,7 +35,7 @@
     "@nivo/legends": "0.74.0",
     "@nivo/scales": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.2.2",
     "lodash": "^4.17.21"

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -33,7 +33,7 @@
     "@nivo/colors": "0.74.0",
     "@nivo/legends": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6"
+    "@react-spring/web": "9.3.1"
   },
   "devDependencies": {
     "@nivo/core": "0.74.0"

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -34,7 +34,7 @@
     "@nivo/colors": "0.74.0",
     "@nivo/legends": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-shape": "^1.3.5"
   },
   "devDependencies": {

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@nivo/colors": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-hierarchy": "^1.1.8",
     "lodash": "^4.17.21"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@nivo/recompose": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-color": "^2.0.0",
     "d3-format": "^1.4.4",
     "d3-hierarchy": "^1.1.8",

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -32,7 +32,7 @@
     "@nivo/annotations": "0.74.0",
     "@nivo/colors": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -31,7 +31,7 @@
     "@nivo/axes": "0.74.0",
     "@nivo/colors": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3"
   },
   "devDependencies": {

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -35,7 +35,7 @@
     "@nivo/scales": "0.74.0",
     "@nivo/tooltip": "0.74.0",
     "@nivo/voronoi": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-shape": "^1.3.5"
   },
   "devDependencies": {

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -24,7 +24,7 @@
     "@nivo/axes": "0.74.0",
     "@nivo/colors": "0.74.0",
     "@nivo/legends": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5",
     "lodash": "^4.17.21"

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -31,7 +31,7 @@
     "@nivo/axes": "0.74.0",
     "@nivo/colors": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/polar-axes/package.json
+++ b/packages/polar-axes/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@nivo/arcs": "0.74.0",
     "@nivo/scales": "0.74.0",
-    "@react-spring/web": "9.2.6"
+    "@react-spring/web": "9.3.1"
   },
   "devDependencies": {
     "@nivo/core": "0.74.0"

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -32,7 +32,7 @@
     "@nivo/colors": "0.74.0",
     "@nivo/legends": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/radial-bar/package.json
+++ b/packages/radial-bar/package.json
@@ -35,7 +35,7 @@
     "@nivo/polar-axes": "0.74.0",
     "@nivo/scales": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -32,7 +32,7 @@
     "@nivo/colors": "0.74.0",
     "@nivo/legends": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-sankey": "^0.12.3",
     "d3-shape": "^1.3.5",
     "lodash": "^4.17.21"

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -36,7 +36,7 @@
     "@nivo/scales": "0.74.0",
     "@nivo/tooltip": "0.74.0",
     "@nivo/voronoi": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5",
     "lodash": "^4.17.21"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -34,7 +34,7 @@
     "@nivo/legends": "0.74.0",
     "@nivo/scales": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -37,7 +37,7 @@
     "@nivo/scales": "0.74.0",
     "@nivo/tooltip": "0.74.0",
     "@nivo/voronoi": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-force": "^2.0.1",
     "d3-scale": "^3.2.3",
     "lodash": "^4.17.21"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -21,7 +21,7 @@
     "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
-    "@react-spring/web": "9.2.6"
+    "@react-spring/web": "9.3.1"
   },
   "devDependencies": {
     "@nivo/core": "0.74.0"

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@nivo/colors": "0.74.0",
     "@nivo/tooltip": "0.74.0",
-    "@react-spring/web": "9.2.6",
+    "@react-spring/web": "9.3.1",
     "d3-hierarchy": "^1.1.8",
     "lodash": "^4.17.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5430,50 +5430,50 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@react-spring/animated@~9.2.6-beta.0":
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.2.6.tgz#58f30fb75d8bfb7ccbc156cfd6b974a8f3dfd54e"
-  integrity sha512-xjL6nmixYNDvnpTs1FFMsMfSC0tURwPCU3b2jWNriYGLfwZ7c/TcyaEZA7yiNnmdFnuR3f3Z27AqIgaFC083Cw==
+"@react-spring/animated@~9.3.0":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.3.1.tgz#ffc4706121e8406efeaeacb407b42b5022943b46"
+  integrity sha512-23YaERZ++BwZ8F8PxPFqrpOwp/JZun1Pj6aHZtPAU42j5LycBRasT9XMw7Eyr7zNFhT+rl3R3wFfd4WX6Ax+UA==
   dependencies:
-    "@react-spring/shared" "~9.2.6-beta.0"
-    "@react-spring/types" "~9.2.6-beta.0"
+    "@react-spring/shared" "~9.3.0"
+    "@react-spring/types" "~9.3.0"
 
-"@react-spring/core@~9.2.6-beta.0":
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.2.6.tgz#ae22338fe55d070caf03abb4293b5519ba620d93"
-  integrity sha512-uPHUxmu+w6mHJrfQTMtmGJ8iZEwiVxz9kH7dRyk69bkZJt9z+w0Oj3UF4J3VcECZsbm3HRhN2ogXSAaqGjwhQw==
+"@react-spring/core@~9.3.0":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.3.1.tgz#b98e1dca1eb4871dec75fdab350327e8a5222865"
+  integrity sha512-8rmfmEHLHGtF1CUiXRn64YJqsXNxv2cGX8oNnBnsuoE33c48Zc34t2VIMB4R9q5zwIUCvDBGfiEenA8ZAPxqOQ==
   dependencies:
-    "@react-spring/animated" "~9.2.6-beta.0"
-    "@react-spring/shared" "~9.2.6-beta.0"
-    "@react-spring/types" "~9.2.6-beta.0"
+    "@react-spring/animated" "~9.3.0"
+    "@react-spring/shared" "~9.3.0"
+    "@react-spring/types" "~9.3.0"
 
-"@react-spring/rafz@~9.2.6-beta.0":
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.2.6.tgz#d97484003875bf5fb5e6ec22dee97cc208363e48"
-  integrity sha512-62SivLKEpo7EfHPkxO5J3g9Cr9LF6+1A1RVOMJhkcpEYtbdbmma/d63Xp8qpMPEpk7uuWxaTb6jjyxW33pW3sg==
+"@react-spring/rafz@~9.3.0":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.3.1.tgz#8dd6a598ffea487252b75d05d199e4aca5ea9d5e"
+  integrity sha512-fEBMCarGVl+/2kdO+g6Zig4F+3ymwmcGN8S71gb1c7Cbbxb87kviPz8EhshfIHoiLeJPGlqwcuGbxNmZbBamvA==
 
-"@react-spring/shared@~9.2.6-beta.0":
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.2.6.tgz#2c84e62cc0cfbbbbeb5546acd46c1f4b248bc562"
-  integrity sha512-Qrm9fopKG/RxZ3Rw+4euhrpnB3uXSyiON9skHbcBfmkkzagpkUR66MX1YLrhHw0UchcZuSDnXs0Lonzt1rpWag==
+"@react-spring/shared@~9.3.0":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.3.1.tgz#e7f22a4b8f5fea4491fa6a24c108db5abd19ddba"
+  integrity sha512-jhPpxzURGo6Nty90ex1lkxmZae7w/VAbnGmb/nXcYoZwSoNR+W2aAd00iXsh2ZGz6MgoJOsc495JeG3uC7Am8A==
   dependencies:
-    "@react-spring/rafz" "~9.2.6-beta.0"
-    "@react-spring/types" "~9.2.6-beta.0"
+    "@react-spring/rafz" "~9.3.0"
+    "@react-spring/types" "~9.3.0"
 
-"@react-spring/types@~9.2.6-beta.0":
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.2.6.tgz#f60722fcf9f8492ae16d0bdc47f0ea3c2a16d2cf"
-  integrity sha512-l7mCw182DtDMnCI8CB9orgTAEoFZRtdQ6aS6YeEAqYcy3nQZPmPggIHH9DxyLw7n7vBPRSzu9gCvUMgXKpTflg==
+"@react-spring/types@~9.3.0":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.3.1.tgz#20f392ecad15a1ea6c0865ffe86ca5016c05a278"
+  integrity sha512-W/YMJMX35XgGGzX0gKORBTwnvQ+1loDOFN3XlZkW5fgpEY+7VkRUpPyqPWXQr3n6lHrsLmHIGdpznqZi54ACTQ==
 
-"@react-spring/web@9.2.6":
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.2.6.tgz#c4fba69e1b1b43bd1d6a62346530cfb07f2be09b"
-  integrity sha512-0HkRsEYR/CO3Uw46FWDWaF2wg2rUXcWE2R9AoZXthEYLUn5w9uE1mf2Jel7BxBxWGQ73owkqSQv+klA1Hb+ViQ==
+"@react-spring/web@9.3.1":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.3.1.tgz#5b377ba7ad52e746c2b59e2738c021de3f219d0b"
+  integrity sha512-sisZIgFGva/Z+xKWPSfXpukF0AP3kR9ALTxlHL87fVotMUCJX5vtH/YlVcywToEFwTHKt3MpI5Wy2M+vgVEeaw==
   dependencies:
-    "@react-spring/animated" "~9.2.6-beta.0"
-    "@react-spring/core" "~9.2.6-beta.0"
-    "@react-spring/shared" "~9.2.6-beta.0"
-    "@react-spring/types" "~9.2.6-beta.0"
+    "@react-spring/animated" "~9.3.0"
+    "@react-spring/core" "~9.3.0"
+    "@react-spring/shared" "~9.3.0"
+    "@react-spring/types" "~9.3.0"
 
 "@rollup/plugin-babel@^5.0.3":
   version "5.0.3"


### PR DESCRIPTION
In `@react-spring/web` 9.2.6, a bug occurs on the `postinstall` script and the build fails due to weird characters. This means that `yarn install` fails for yarn 3.

9.3.1 fixes this: https://github.com/pmndrs/react-spring/releases/tag/v9.3.1

Since that version is pinned in `nivo`, no `nivo` packages could be installed using yarn 3. This simple change fixes that.