### PR TITLE
fix: remove required for labelYOffset in DotsItem

### DIFF
--- a/packages/core/src/components/dots/DotsItem.js
+++ b/packages/core/src/components/dots/DotsItem.js
@@ -59,7 +59,7 @@ DotsItem.propTypes = {
 
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     labelTextAnchor: PropTypes.oneOf(['start', 'middle', 'end']),
-    labelYOffset: PropTypes.number.isRequired,
+    labelYOffset: PropTypes.number,
 }
 
 export default memo(DotsItem)


### PR DESCRIPTION
Currently this is causing error when `labelYOffset` is not provided. But since `labelYOffset` has a default value of `-12`, we should remove `required`.