### PR TITLE
Add custom ref to ScatterPlotCanvas and NetworkCanvas

### DIFF
--- a/packages/network/src/NetworkCanvas.tsx
+++ b/packages/network/src/NetworkCanvas.tsx
@@ -246,7 +246,11 @@ export const NetworkCanvas = forwardRef(
         ref: ForwardedRef<HTMLCanvasElement>
     ) => (
         <Container {...{ isInteractive, animate, motionConfig, theme, renderWrapper }}>
-            <InnerNetworkCanvas<Node, Link> isInteractive={isInteractive} {...otherProps} canvasRef={ref} />
+            <InnerNetworkCanvas<Node, Link>
+                isInteractive={isInteractive}
+                {...otherProps}
+                canvasRef={ref}
+            />
         </Container>
     )
 )

--- a/packages/network/src/ResponsiveNetworkCanvas.tsx
+++ b/packages/network/src/ResponsiveNetworkCanvas.tsx
@@ -13,7 +13,15 @@ export const ResponsiveNetworkCanvas = forwardRef(function ResponsiveBarCanvas<
     return (
         <ResponsiveWrapper>
             {({ width, height }) => (
-                <NetworkCanvas<Node, Link> width={width} height={height} {...props} ref={ref} />
+                <NetworkCanvas
+                    width={width}
+                    height={height}
+                    {...(props as Omit<
+                        NetworkCanvasProps<InputNode, InputLink>,
+                        'height' | 'width'
+                    >)}
+                    ref={ref}
+                />
             )}
         </ResponsiveWrapper>
     )

--- a/packages/network/src/ResponsiveNetworkCanvas.tsx
+++ b/packages/network/src/ResponsiveNetworkCanvas.tsx
@@ -1,16 +1,20 @@
 import { ResponsiveWrapper } from '@nivo/core'
+import { ForwardedRef, forwardRef } from 'react'
 import { NetworkCanvasProps, InputNode, InputLink } from './types'
 import { NetworkCanvas } from './NetworkCanvas'
 
-export const ResponsiveNetworkCanvas = <
+export const ResponsiveNetworkCanvas = forwardRef(function ResponsiveBarCanvas<
     Node extends InputNode = InputNode,
     Link extends InputLink = InputLink
 >(
-    props: Omit<NetworkCanvasProps<Node, Link>, 'height' | 'width'>
-) => (
-    <ResponsiveWrapper>
-        {({ width, height }) => (
-            <NetworkCanvas<Node, Link> width={width} height={height} {...props} />
-        )}
-    </ResponsiveWrapper>
-)
+    props: Omit<NetworkCanvasProps<Node, Link>, 'height' | 'width'>,
+    ref: ForwardedRef<HTMLCanvasElement>
+) {
+    return (
+        <ResponsiveWrapper>
+            {({ width, height }) => (
+                <NetworkCanvas<Node, Link> width={width} height={height} {...props} ref={ref} />
+            )}
+        </ResponsiveWrapper>
+    )
+})

--- a/packages/network/stories/networkCanvas.stories.tsx
+++ b/packages/network/stories/networkCanvas.stories.tsx
@@ -9,6 +9,7 @@ import {
     NodeTooltipProps,
     // @ts-ignore
 } from '../src'
+import { useRef } from 'react'
 
 export default {
     component: NetworkCanvas,
@@ -70,3 +71,22 @@ export const CustomNodeRenderer = () => (
 export const OnClickHandler = () => (
     <NetworkCanvas<Node, Link> {...commonProperties} onClick={action('onClick')} />
 )
+
+export const CustomCanvasRef = () => {
+    const ref = useRef(undefined)
+
+    const download = ref => {
+        const canvas = ref.current
+        const link = document.createElement('a')
+        link.download = 'test.png'
+        link.href = canvas.toDataURL('image/png')
+        link.click()
+    }
+
+    return (
+        <>
+            <NetworkCanvas<Node, Link> {...commonProperties} ref={ref} />
+            <button onClick={() => download(ref)}>Download PNG</button>
+        </>
+    )
+}

--- a/packages/scatterplot/src/ResponsiveScatterPlotCanvas.tsx
+++ b/packages/scatterplot/src/ResponsiveScatterPlotCanvas.tsx
@@ -1,13 +1,27 @@
 import { ResponsiveWrapper } from '@nivo/core'
 import { ScatterPlotCanvas } from './ScatterPlotCanvas'
 import { ScatterPlotCanvasProps, ScatterPlotDatum } from './types'
+import { ForwardedRef, forwardRef } from 'react'
 
-export const ResponsiveScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>(
-    props: Omit<ScatterPlotCanvasProps<RawDatum>, 'width' | 'height'>
-) => (
-    <ResponsiveWrapper>
-        {({ width, height }) => (
-            <ScatterPlotCanvas<RawDatum> width={width} height={height} {...props} />
-        )}
-    </ResponsiveWrapper>
-)
+export const ResponsiveScatterPlotCanvas = forwardRef(function ResponsiveBarCanvas<
+    RawDatum extends ScatterPlotDatum
+>(
+    props: Omit<ScatterPlotCanvasProps<RawDatum>, 'width' | 'height'>,
+    ref: ForwardedRef<HTMLCanvasElement>
+) {
+    return (
+        <ResponsiveWrapper>
+            {({ width, height }) => (
+                <ScatterPlotCanvas<RawDatum>
+                    width={width}
+                    height={height}
+                    {...(props as Omit<
+                        ScatterPlotCanvasProps<ScatterPlotDatum>,
+                        'height' | 'width'
+                    >)}
+                    ref={ref}
+                />
+            )}
+        </ResponsiveWrapper>
+    )
+})

--- a/packages/scatterplot/src/ResponsiveScatterPlotCanvas.tsx
+++ b/packages/scatterplot/src/ResponsiveScatterPlotCanvas.tsx
@@ -1,9 +1,10 @@
 import { ResponsiveWrapper } from '@nivo/core'
-import { ScatterPlotCanvas } from './ScatterPlotCanvas'
-import { ScatterPlotCanvasProps, ScatterPlotDatum } from './types'
 import { ForwardedRef, forwardRef } from 'react'
 
-export const ResponsiveScatterPlotCanvas = forwardRef(function ResponsiveBarCanvas<
+import { ScatterPlotCanvas } from './ScatterPlotCanvas'
+import { ScatterPlotCanvasProps, ScatterPlotDatum } from './types'
+
+export const ResponsiveScatterPlotCanvas = forwardRef(function ResponsiveScatterPlotCanvas<
     RawDatum extends ScatterPlotDatum
 >(
     props: Omit<ScatterPlotCanvasProps<RawDatum>, 'width' | 'height'>,

--- a/packages/scatterplot/src/ResponsiveScatterPlotCanvas.tsx
+++ b/packages/scatterplot/src/ResponsiveScatterPlotCanvas.tsx
@@ -12,7 +12,7 @@ export const ResponsiveScatterPlotCanvas = forwardRef(function ResponsiveBarCanv
     return (
         <ResponsiveWrapper>
             {({ width, height }) => (
-                <ScatterPlotCanvas<RawDatum>
+                <ScatterPlotCanvas
                     width={width}
                     height={height}
                     {...(props as Omit<

--- a/packages/scatterplot/src/ScatterPlotCanvas.tsx
+++ b/packages/scatterplot/src/ScatterPlotCanvas.tsx
@@ -1,4 +1,12 @@
-import { createElement, useRef, useState, useEffect, useCallback, useMemo } from 'react'
+import {
+    ForwardedRef,
+    createElement,
+    forwardRef,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+} from 'react'
 import { Container, useDimensions, useTheme, getRelativeCursor, isCursorInRect } from '@nivo/core'
 import { renderAnnotationsToCanvas } from '@nivo/annotations'
 import { CanvasAxisProps, renderAxesToCanvas, renderGridLinesToCanvas } from '@nivo/axes'
@@ -12,7 +20,9 @@ import { ScatterPlotCanvasProps, ScatterPlotDatum, ScatterPlotNodeData } from '.
 type InnerScatterPlotCanvasProps<RawDatum extends ScatterPlotDatum> = Omit<
     ScatterPlotCanvasProps<RawDatum>,
     'renderWrapper' | 'theme'
->
+> & {
+    canvasRef: ForwardedRef<HTMLCanvasElement>
+}
 
 const InnerScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>({
     data,
@@ -46,6 +56,7 @@ const InnerScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>({
     onClick,
     tooltip = canvasDefaultProps.tooltip,
     legends = canvasDefaultProps.legends,
+    canvasRef,
 }: InnerScatterPlotCanvasProps<RawDatum>) => {
     const canvasEl = useRef<HTMLCanvasElement | null>(null)
     const theme = useTheme()
@@ -270,7 +281,10 @@ const InnerScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>({
 
     return (
         <canvas
-            ref={canvasEl}
+            ref={canvas => {
+                canvasEl.current = canvas
+                if (canvasRef && 'current' in canvasRef) canvasRef.current = canvas
+            }}
             width={outerWidth * pixelRatio}
             height={outerHeight * pixelRatio}
             style={{
@@ -286,13 +300,13 @@ const InnerScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>({
     )
 }
 
-export const ScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>({
-    isInteractive,
-    renderWrapper,
-    theme,
-    ...props
-}: ScatterPlotCanvasProps<RawDatum>) => (
-    <Container {...{ isInteractive, renderWrapper, theme }} animate={false}>
-        <InnerScatterPlotCanvas<RawDatum> {...props} />
-    </Container>
+export const ScatterPlotCanvas = forwardRef(
+    <RawDatum extends ScatterPlotDatum>(
+        { isInteractive, renderWrapper, theme, ...props }: ScatterPlotCanvasProps<RawDatum>,
+        ref: ForwardedRef<HTMLCanvasElement>
+    ) => (
+        <Container {...{ isInteractive, renderWrapper, theme }} animate={false}>
+            <InnerScatterPlotCanvas<RawDatum> {...props} canvasRef={ref} />
+        </Container>
+    )
 )

--- a/packages/scatterplot/src/ScatterPlotCanvas.tsx
+++ b/packages/scatterplot/src/ScatterPlotCanvas.tsx
@@ -6,6 +6,7 @@ import {
     useEffect,
     useMemo,
     useRef,
+    useState,
 } from 'react'
 import { Container, useDimensions, useTheme, getRelativeCursor, isCursorInRect } from '@nivo/core'
 import { renderAnnotationsToCanvas } from '@nivo/annotations'

--- a/packages/scatterplot/stories/ScatterPlotCanvas.stories.tsx
+++ b/packages/scatterplot/stories/ScatterPlotCanvas.stories.tsx
@@ -1,8 +1,8 @@
-import { useState, useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import omit from 'lodash/omit'
 import { Meta } from '@storybook/react'
 // @ts-ignore
-import { ScatterPlotCanvas, ResponsiveScatterPlotCanvas, ScatterPlotNodeData } from '../src'
+import { ResponsiveScatterPlotCanvas, ScatterPlotCanvas, ScatterPlotNodeData } from '../src'
 
 export default {
     component: ScatterPlotCanvas,
@@ -403,3 +403,42 @@ export const CustomTooltip = () => (
         )}
     />
 )
+
+export const CustomCanvasRef = () => {
+    const ref = useRef(undefined)
+
+    const download = ref => {
+        const canvas = ref.current
+        const link = document.createElement('a')
+        link.download = 'test.png'
+        link.href = canvas.toDataURL('image/png')
+        link.click()
+    }
+
+    return (
+        <>
+            <ScatterPlotCanvas<SampleDatum>
+                {...commonProps}
+                ref={ref}
+                tooltip={({ node }) => (
+                    <div
+                        style={{
+                            color: node.color,
+                            background: '#333',
+                            padding: '12px 16px',
+                        }}
+                    >
+                        <strong>
+                            {node.id} ({node.serieId})
+                        </strong>
+                        <br />
+                        {`x: ${node.formattedX}`}
+                        <br />
+                        {`y: ${node.formattedY}`}
+                    </div>
+                )}
+            />
+            <button onClick={() => download(ref)}>Download PNG</button>
+        </>
+    )
+}


### PR DESCRIPTION
This mimics the work done in `BarCanvas.tsx` and `ResponsiveBarCanvas.tsx` to allow for custom refs for things like adding a download button.