### PR TITLE
codesandbox examples: fix typo in jsx prop assignment

### DIFF
--- a/examples/codesandbox/src/charts/Chord.tsx
+++ b/examples/codesandbox/src/charts/Chord.tsx
@@ -11,8 +11,8 @@ export function Chord() {
   const [data, flavor] = useChart(() => generateChordData({ size: 7 }))
 
   if (flavor === 'canvas') {
-    return <ResponsiveChordCanvas {...props} data{data.matrix} keys={data.keys} />
+    return <ResponsiveChordCanvas {...props} data={data.matrix} keys={data.keys} />
   }
 
-  return <ResponsiveChord {...props} data{data.matrix} keys={data.keys} />
+  return <ResponsiveChord {...props} data={data.matrix} keys={data.keys} />
 }


### PR DESCRIPTION
The CodeSandbox environment spun up by #1957 failed to start, at least partially due to this typo. Revising the the typo allows the PR sandbox to initialize properly.

Sandbox created from CI for #1957:

![image](https://user-images.githubusercontent.com/142472/159864569-7f2e2f05-ef1f-41a2-9a93-cff855918292.png)

Sandbox created from this PR:

![image](https://user-images.githubusercontent.com/142472/159866405-9bf82791-3651-4a03-beaf-4cf9d28eabb8.png)
