### PR TITLE
fix(line): make copy of points data before reversing

### DIFF
--- a/packages/line/src/Points.js
+++ b/packages/line/src/Points.js
@@ -18,7 +18,7 @@ const Points = ({ points, symbol, size, borderWidth, enableLabel, label, labelYO
      * We reverse the `points` array so that points from the lower lines in stacked lines
      * graph are drawn on top. See https://github.com/plouc/nivo/issues/1051.
      */
-    const mappedPoints = points.reverse().map(point => {
+    const mappedPoints = points.slice(0).reverse().map(point => {
         const mappedPoint = {
             id: point.id,
             x: point.x,


### PR DESCRIPTION
Hello 👋 

this is a fix for basically a very similar problem to #1644. If `enablePoints` is set to `true` the order of the points in any custom layer changes between the first and any subsequent render, because the points array is modified in place.

Best,
Ben