### PR TITLE
Allow BarCanvas axis to be nullable

### DIFF
--- a/packages/bar/src/types.ts
+++ b/packages/bar/src/types.ts
@@ -289,10 +289,10 @@ export type BarCanvasProps<RawDatum extends BarDatum> = Partial<BarCommonProps<R
     BarHandlers<RawDatum, HTMLCanvasElement> &
     Dimensions &
     Partial<{
-        axisBottom: CanvasAxisProps<any>
-        axisLeft: CanvasAxisProps<any>
-        axisRight: CanvasAxisProps<any>
-        axisTop: CanvasAxisProps<any>
+        axisBottom: CanvasAxisProps<any> | null
+        axisLeft: CanvasAxisProps<any> | null
+        axisRight: CanvasAxisProps<any> | null
+        axisTop: CanvasAxisProps<any> | null
 
         renderBar: (context: CanvasRenderingContext2D, props: RenderBarProps<RawDatum>) => void
 


### PR DESCRIPTION
Types do not currently allow `axisBottom`, `axisLeft`, `axisRight`, or `axisTop` to be set to `null`, however this is required to disable axis and is found in the nivo documentation.