### PR TITLE
feat(Line) Allow pointLabel `AccessorFunc` to return the full point info

### DIFF
--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -97,7 +97,7 @@ declare module '@nivo/line' {
         }
     }
 
-    export type AccessorFunc = (datum: Point['data']) => string
+    export type AccessorFunc = (datum: Point['data'], point: Point) => string
 
     export type PointMouseHandler = (point: Point, event: React.MouseEvent) => void
 

--- a/packages/line/src/Points.js
+++ b/packages/line/src/Points.js
@@ -26,7 +26,7 @@ const Points = ({ points, symbol, size, borderWidth, enableLabel, label, labelYO
             datum: point.data,
             fill: point.color,
             stroke: point.borderColor,
-            label: enableLabel ? getLabel(point.data) : null,
+            label: enableLabel ? getLabel(point.data, point) : null,
         }
 
         return mappedPoint


### PR DESCRIPTION
## General request

Hi,

I noticed that the `label` property of the @bar chart allowed to get the full point info (id, value, ...).
It seems that the `AccessorFunc` of the @line chart only pass down the data.

I think that enhancing this function to support the full `Point` type would allow a better customisation at the data point level.

My proposition is to add the `point: Point` directly to the function in order to avoid any breaking changes, but if you think that updating the `datum: Point['data']` to `datum: Point` is more suitable, I can update my PR to match this quickly.


## Case details

I'm requesting this change because in my case I need to format the value at a data point level.
Technically, every data point could have a different formatting in my charts, and without getting the id behind the value (contained in the `Point` but not the `Point['data']`), I have no way to know which value is linked to which formatting if I have more than 1 time the same value.