### PR TITLE
fix makefile rule for linting an individual package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ lint: ##@0 run eslint & tslint
 
 package-lint-%: ##@1 packages run eslint on package
 	@echo "${YELLOW}Running eslint on package ${WHITE}@nivo/${*}${RESET}"
-	@yarn eslint ./packages/${*}/{src,tests}
+	@yarn eslint ./packages/${*}/{src,tests}/**/*.{js,ts,tsx}
 
 packages-lint: ##@1 packages run eslint on all packages
 	@echo "${YELLOW}Running eslint on all packages${RESET}"


### PR DESCRIPTION
The makefile has a rule for linting an individual package, e.g. `make package-lint-calendar`.

The current rule does not find the intended files in the package, and prints an error.

```
No files matching the pattern "./packages/calendar/{src,tests}" were found.
Please check for typing mistakes in the pattern.
```

The pull request adjusts the rule to lint all files in `src` and `tests` directories.