### PR TITLE
feat(radar): orientation of radar chart

### DIFF
--- a/packages/line/src/Points.js
+++ b/packages/line/src/Points.js
@@ -18,19 +18,22 @@ const Points = ({ points, symbol, size, borderWidth, enableLabel, label, labelYO
      * We reverse the `points` array so that points from the lower lines in stacked lines
      * graph are drawn on top. See https://github.com/plouc/nivo/issues/1051.
      */
-    const mappedPoints = points.slice(0).reverse().map(point => {
-        const mappedPoint = {
-            id: point.id,
-            x: point.x,
-            y: point.y,
-            datum: point.data,
-            fill: point.color,
-            stroke: point.borderColor,
-            label: enableLabel ? getLabel(point.data) : null,
-        }
+    const mappedPoints = points
+        .slice(0)
+        .reverse()
+        .map(point => {
+            const mappedPoint = {
+                id: point.id,
+                x: point.x,
+                y: point.y,
+                datum: point.data,
+                fill: point.color,
+                stroke: point.borderColor,
+                label: enableLabel ? getLabel(point.data) : null,
+            }
 
-        return mappedPoint
-    })
+            return mappedPoint
+        })
 
     return (
         <g>

--- a/packages/radar/src/Radar.tsx
+++ b/packages/radar/src/Radar.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, Fragment, createElement } from 'react'
-import { Container, useDimensions, SvgWrapper, degreesToRadians } from '@nivo/core'
+import { Container, useDimensions, SvgWrapper } from '@nivo/core'
 import { BoxLegendSvg } from '@nivo/legends'
 import { RadarLayer } from './RadarLayer'
 import { RadarGrid } from './RadarGrid'
@@ -19,7 +19,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
     keys,
     indexBy,
     layers = svgDefaultProps.layers,
-    angle: angleDegrees = svgDefaultProps.angle,
+    rotation: rotationDegrees = svgDefaultProps.rotation,
     maxValue = svgDefaultProps.maxValue,
     valueFormat,
     curve = svgDefaultProps.curve,
@@ -60,7 +60,6 @@ const InnerRadar = <D extends Record<string, unknown>>({
         partialMargin
     )
 
-    const angle = degreesToRadians(angleDegrees)
     const {
         getIndex,
         indices,
@@ -68,6 +67,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
         colorByKey,
         fillByKey,
         boundDefs,
+        rotation,
         radius,
         radiusScale,
         centerX,
@@ -80,6 +80,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
         data,
         keys,
         indexBy,
+        rotationDegrees,
         maxValue,
         valueFormat,
         curve,
@@ -106,7 +107,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                     levels={gridLevels}
                     shape={gridShape}
                     radius={radius}
-                    angle={angle}
+                    rotation={rotation}
                     angleStep={angleStep}
                     indices={indices}
                     label={gridLabel}
@@ -127,7 +128,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                         colorByKey={colorByKey}
                         fillByKey={fillByKey}
                         radiusScale={radiusScale}
-                        angle={angle}
+                        rotation={rotation}
                         angleStep={angleStep}
                         curveFactory={curveFactory}
                         borderWidth={borderWidth}
@@ -150,7 +151,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                     formatValue={formatValue}
                     colorByKey={colorByKey}
                     radius={radius}
-                    angle={angle}
+                    rotation={rotation}
                     angleStep={angleStep}
                     tooltip={sliceTooltip}
                 />
@@ -166,7 +167,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                     keys={keys}
                     getIndex={getIndex}
                     radiusScale={radiusScale}
-                    angle={angle}
+                    rotation={rotation}
                     angleStep={angleStep}
                     symbol={dotSymbol}
                     size={dotSize}

--- a/packages/radar/src/Radar.tsx
+++ b/packages/radar/src/Radar.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, Fragment, createElement } from 'react'
-import { Container, useDimensions, SvgWrapper } from '@nivo/core'
+import { Container, useDimensions, SvgWrapper, degreesToRadians } from '@nivo/core'
 import { BoxLegendSvg } from '@nivo/legends'
 import { RadarLayer } from './RadarLayer'
 import { RadarGrid } from './RadarGrid'
@@ -19,6 +19,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
     keys,
     indexBy,
     layers = svgDefaultProps.layers,
+    angle: angleDegrees = svgDefaultProps.angle,
     maxValue = svgDefaultProps.maxValue,
     valueFormat,
     curve = svgDefaultProps.curve,
@@ -59,6 +60,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
         partialMargin
     )
 
+    const angle = degreesToRadians(angleDegrees)
     const {
         getIndex,
         indices,
@@ -104,6 +106,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                     levels={gridLevels}
                     shape={gridShape}
                     radius={radius}
+                    angle={angle}
                     angleStep={angleStep}
                     indices={indices}
                     label={gridLabel}
@@ -124,6 +127,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                         colorByKey={colorByKey}
                         fillByKey={fillByKey}
                         radiusScale={radiusScale}
+                        angle={angle}
                         angleStep={angleStep}
                         curveFactory={curveFactory}
                         borderWidth={borderWidth}
@@ -146,6 +150,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                     formatValue={formatValue}
                     colorByKey={colorByKey}
                     radius={radius}
+                    angle={angle}
                     angleStep={angleStep}
                     tooltip={sliceTooltip}
                 />
@@ -161,6 +166,7 @@ const InnerRadar = <D extends Record<string, unknown>>({
                     keys={keys}
                     getIndex={getIndex}
                     radiusScale={radiusScale}
+                    angle={angle}
                     angleStep={angleStep}
                     symbol={dotSymbol}
                     size={dotSize}

--- a/packages/radar/src/RadarDots.tsx
+++ b/packages/radar/src/RadarDots.tsx
@@ -10,6 +10,7 @@ interface RadarDotsProps<D extends Record<string, unknown>> {
     radiusScale: ScaleLinear<number, number>
     getIndex: (d: D) => string
     colorByKey: RadarColorMapping
+    angle: number
     angleStep: number
     symbol?: RadarCommonProps<D>['dotSymbol']
     size: number
@@ -28,6 +29,7 @@ export const RadarDots = <D extends Record<string, unknown>>({
     getIndex,
     colorByKey,
     radiusScale,
+    angle,
     angleStep,
     symbol,
     size = 6,
@@ -66,7 +68,7 @@ export const RadarDots = <D extends Record<string, unknown>>({
                             fill: fillColor(pointData),
                             stroke: strokeColor(pointData),
                             ...positionFromAngle(
-                                angleStep * i - Math.PI / 2,
+                                angle + angleStep * i - Math.PI / 2,
                                 radiusScale(datum[key] as number)
                             ),
                         },
@@ -86,6 +88,7 @@ export const RadarDots = <D extends Record<string, unknown>>({
             formatValue,
             fillColor,
             strokeColor,
+            angle,
             angleStep,
             radiusScale,
         ]

--- a/packages/radar/src/RadarDots.tsx
+++ b/packages/radar/src/RadarDots.tsx
@@ -10,7 +10,7 @@ interface RadarDotsProps<D extends Record<string, unknown>> {
     radiusScale: ScaleLinear<number, number>
     getIndex: (d: D) => string
     colorByKey: RadarColorMapping
-    angle: number
+    rotation: number
     angleStep: number
     symbol?: RadarCommonProps<D>['dotSymbol']
     size: number
@@ -29,7 +29,7 @@ export const RadarDots = <D extends Record<string, unknown>>({
     getIndex,
     colorByKey,
     radiusScale,
-    angle,
+    rotation,
     angleStep,
     symbol,
     size = 6,
@@ -68,7 +68,7 @@ export const RadarDots = <D extends Record<string, unknown>>({
                             fill: fillColor(pointData),
                             stroke: strokeColor(pointData),
                             ...positionFromAngle(
-                                angle + angleStep * i - Math.PI / 2,
+                                rotation + angleStep * i - Math.PI / 2,
                                 radiusScale(datum[key] as number)
                             ),
                         },
@@ -88,7 +88,7 @@ export const RadarDots = <D extends Record<string, unknown>>({
             formatValue,
             fillColor,
             strokeColor,
-            angle,
+            rotation,
             angleStep,
             radiusScale,
         ]

--- a/packages/radar/src/RadarGrid.tsx
+++ b/packages/radar/src/RadarGrid.tsx
@@ -9,6 +9,7 @@ interface RadarGridProps<D extends Record<string, unknown>> {
     shape: RadarCommonProps<D>['gridShape']
     radius: number
     levels: number
+    angle: number
     angleStep: number
     label: GridLabelComponent
     labelOffset: number
@@ -19,6 +20,7 @@ export const RadarGrid = <D extends Record<string, unknown>>({
     levels,
     shape,
     radius,
+    angle,
     angleStep,
     label,
     labelOffset,
@@ -29,9 +31,11 @@ export const RadarGrid = <D extends Record<string, unknown>>({
             radii: Array.from({ length: levels })
                 .map((_, i) => (radius / levels) * (i + 1))
                 .reverse(),
-            angles: Array.from({ length: indices.length }, (_, i) => i * angleStep - Math.PI / 2),
+            angles: Array.from({ length: indices.length }).map(
+                (_, i) => angle + i * angleStep - Math.PI / 2
+            ),
         }
-    }, [indices, levels, radius, angleStep])
+    }, [indices, levels, radius, angle, angleStep])
 
     return (
         <>
@@ -53,6 +57,7 @@ export const RadarGrid = <D extends Record<string, unknown>>({
                     key={`level.${i}`}
                     shape={shape}
                     radius={radius}
+                    angle={angle}
                     angleStep={angleStep}
                     dataLength={indices.length}
                 />

--- a/packages/radar/src/RadarGrid.tsx
+++ b/packages/radar/src/RadarGrid.tsx
@@ -9,7 +9,7 @@ interface RadarGridProps<D extends Record<string, unknown>> {
     shape: RadarCommonProps<D>['gridShape']
     radius: number
     levels: number
-    angle: number
+    rotation: number
     angleStep: number
     label: GridLabelComponent
     labelOffset: number
@@ -20,7 +20,7 @@ export const RadarGrid = <D extends Record<string, unknown>>({
     levels,
     shape,
     radius,
-    angle,
+    rotation,
     angleStep,
     label,
     labelOffset,
@@ -32,10 +32,10 @@ export const RadarGrid = <D extends Record<string, unknown>>({
                 .map((_, i) => (radius / levels) * (i + 1))
                 .reverse(),
             angles: Array.from({ length: indices.length }).map(
-                (_, i) => angle + i * angleStep - Math.PI / 2
+                (_, i) => rotation + i * angleStep - Math.PI / 2
             ),
         }
-    }, [indices, levels, radius, angle, angleStep])
+    }, [indices, levels, radius, rotation, angleStep])
 
     return (
         <>
@@ -57,7 +57,7 @@ export const RadarGrid = <D extends Record<string, unknown>>({
                     key={`level.${i}`}
                     shape={shape}
                     radius={radius}
-                    angle={angle}
+                    rotation={rotation}
                     angleStep={angleStep}
                     dataLength={indices.length}
                 />

--- a/packages/radar/src/RadarGridLevels.tsx
+++ b/packages/radar/src/RadarGridLevels.tsx
@@ -29,14 +29,14 @@ const RadarGridLevelCircular = memo(({ radius }: RadarGridLevelCircularProps) =>
 
 interface RadarGridLevelLinearProps {
     radius: number
-    angle: number
+    rotation: number
     angleStep: number
     dataLength: number
 }
 
 const RadarGridLevelLinear = ({
     radius,
-    angle,
+    rotation,
     angleStep,
     dataLength,
 }: RadarGridLevelLinearProps) => {
@@ -45,10 +45,10 @@ const RadarGridLevelLinear = ({
     const radarLineGenerator = useMemo(
         () =>
             lineRadial<number>()
-                .angle(i => angle + i * angleStep)
+                .angle(i => rotation + i * angleStep)
                 .radius(radius)
                 .curve(curveLinearClosed),
-        [angle, angleStep, radius]
+        [rotation, angleStep, radius]
     )
 
     const points = Array.from({ length: dataLength }, (_, i) => i)
@@ -66,7 +66,7 @@ const RadarGridLevelLinear = ({
 interface RadarGridLevelsProps<D extends Record<string, unknown>> {
     shape: RadarCommonProps<D>['gridShape']
     radius: number
-    angle: number
+    rotation: number
     angleStep: number
     dataLength: number
 }

--- a/packages/radar/src/RadarGridLevels.tsx
+++ b/packages/radar/src/RadarGridLevels.tsx
@@ -29,20 +29,26 @@ const RadarGridLevelCircular = memo(({ radius }: RadarGridLevelCircularProps) =>
 
 interface RadarGridLevelLinearProps {
     radius: number
+    angle: number
     angleStep: number
     dataLength: number
 }
 
-const RadarGridLevelLinear = ({ radius, angleStep, dataLength }: RadarGridLevelLinearProps) => {
+const RadarGridLevelLinear = ({
+    radius,
+    angle,
+    angleStep,
+    dataLength,
+}: RadarGridLevelLinearProps) => {
     const theme = useTheme()
 
     const radarLineGenerator = useMemo(
         () =>
             lineRadial<number>()
-                .angle(i => i * angleStep)
+                .angle(i => angle + i * angleStep)
                 .radius(radius)
                 .curve(curveLinearClosed),
-        [angleStep, radius]
+        [angle, angleStep, radius]
     )
 
     const points = Array.from({ length: dataLength }, (_, i) => i)
@@ -60,6 +66,7 @@ const RadarGridLevelLinear = ({ radius, angleStep, dataLength }: RadarGridLevelL
 interface RadarGridLevelsProps<D extends Record<string, unknown>> {
     shape: RadarCommonProps<D>['gridShape']
     radius: number
+    angle: number
     angleStep: number
     dataLength: number
 }

--- a/packages/radar/src/RadarLayer.tsx
+++ b/packages/radar/src/RadarLayer.tsx
@@ -12,7 +12,7 @@ interface RadarLayerProps<D extends Record<string, unknown>> {
     colorByKey: Record<string | number, string>
     fillByKey: Record<string, string | null>
     radiusScale: ScaleLinear<number, number>
-    angle: number
+    rotation: number
     angleStep: number
     curveFactory: CurveFactory
     borderWidth: RadarCommonProps<D>['borderWidth']
@@ -27,7 +27,7 @@ export const RadarLayer = <D extends Record<string, unknown>>({
     colorByKey,
     fillByKey,
     radiusScale,
-    angle,
+    rotation,
     angleStep,
     curveFactory,
     borderWidth,
@@ -41,9 +41,9 @@ export const RadarLayer = <D extends Record<string, unknown>>({
     const lineGenerator = useMemo(() => {
         return lineRadial<number>()
             .radius(d => radiusScale(d))
-            .angle((_, i) => angle + i * angleStep)
+            .angle((_, i) => rotation + i * angleStep)
             .curve(curveFactory)
-    }, [radiusScale, angle, angleStep, curveFactory])
+    }, [radiusScale, rotation, angleStep, curveFactory])
 
     const { animate, config: springConfig } = useMotionConfig()
     const animatedPath = useAnimatedPath(lineGenerator(data.map(d => d[key] as number)) as string)

--- a/packages/radar/src/RadarLayer.tsx
+++ b/packages/radar/src/RadarLayer.tsx
@@ -12,6 +12,7 @@ interface RadarLayerProps<D extends Record<string, unknown>> {
     colorByKey: Record<string | number, string>
     fillByKey: Record<string, string | null>
     radiusScale: ScaleLinear<number, number>
+    angle: number
     angleStep: number
     curveFactory: CurveFactory
     borderWidth: RadarCommonProps<D>['borderWidth']
@@ -26,6 +27,7 @@ export const RadarLayer = <D extends Record<string, unknown>>({
     colorByKey,
     fillByKey,
     radiusScale,
+    angle,
     angleStep,
     curveFactory,
     borderWidth,
@@ -39,9 +41,9 @@ export const RadarLayer = <D extends Record<string, unknown>>({
     const lineGenerator = useMemo(() => {
         return lineRadial<number>()
             .radius(d => radiusScale(d))
-            .angle((_, i) => i * angleStep)
+            .angle((_, i) => angle + i * angleStep)
             .curve(curveFactory)
-    }, [radiusScale, angleStep, curveFactory])
+    }, [radiusScale, angle, angleStep, curveFactory])
 
     const { animate, config: springConfig } = useMotionConfig()
     const animatedPath = useAnimatedPath(lineGenerator(data.map(d => d[key] as number)) as string)

--- a/packages/radar/src/RadarSlices.tsx
+++ b/packages/radar/src/RadarSlices.tsx
@@ -9,7 +9,7 @@ interface RadarSlicesProps<D extends Record<string, unknown>> {
     formatValue: (value: number, context: string) => string
     colorByKey: RadarColorMapping
     radius: number
-    angle: number
+    rotation: number
     angleStep: number
     tooltip: RadarCommonProps<D>['sliceTooltip']
 }
@@ -21,14 +21,14 @@ export const RadarSlices = <D extends Record<string, unknown>>({
     formatValue,
     colorByKey,
     radius,
-    angle,
+    rotation,
     angleStep,
     tooltip,
 }: RadarSlicesProps<D>) => {
     const arc = d3Arc<{ startAngle: number; endAngle: number }>().outerRadius(radius).innerRadius(0)
 
     const halfAngleStep = angleStep * 0.5
-    let rootStartAngle = angle - halfAngleStep
+    let rootStartAngle = rotation - halfAngleStep
 
     return (
         <>

--- a/packages/radar/src/RadarSlices.tsx
+++ b/packages/radar/src/RadarSlices.tsx
@@ -9,6 +9,7 @@ interface RadarSlicesProps<D extends Record<string, unknown>> {
     formatValue: (value: number, context: string) => string
     colorByKey: RadarColorMapping
     radius: number
+    angle: number
     angleStep: number
     tooltip: RadarCommonProps<D>['sliceTooltip']
 }
@@ -20,13 +21,14 @@ export const RadarSlices = <D extends Record<string, unknown>>({
     formatValue,
     colorByKey,
     radius,
+    angle,
     angleStep,
     tooltip,
 }: RadarSlicesProps<D>) => {
     const arc = d3Arc<{ startAngle: number; endAngle: number }>().outerRadius(radius).innerRadius(0)
 
     const halfAngleStep = angleStep * 0.5
-    let rootStartAngle = -halfAngleStep
+    let rootStartAngle = angle - halfAngleStep
 
     return (
         <>

--- a/packages/radar/src/hooks.ts
+++ b/packages/radar/src/hooks.ts
@@ -7,6 +7,7 @@ import {
     usePropertyAccessor,
     useValueFormatter,
 } from '@nivo/core'
+import { degreesToRadians } from '@nivo/core'
 import { useOrdinalColorScale } from '@nivo/colors'
 import { svgDefaultProps } from './props'
 import {
@@ -22,6 +23,7 @@ export const useRadar = <D extends Record<string, unknown>>({
     data,
     keys,
     indexBy,
+    rotationDegrees,
     maxValue,
     valueFormat,
     curve,
@@ -35,6 +37,7 @@ export const useRadar = <D extends Record<string, unknown>>({
     data: RadarDataProps<D>['data']
     keys: RadarDataProps<D>['keys']
     indexBy: RadarDataProps<D>['indexBy']
+    rotationDegrees: RadarCommonProps<D>['rotation']
     maxValue: RadarCommonProps<D>['maxValue']
     valueFormat?: RadarCommonProps<D>['valueFormat']
     curve: RadarCommonProps<D>['curve']
@@ -48,6 +51,7 @@ export const useRadar = <D extends Record<string, unknown>>({
     const getIndex = usePropertyAccessor<D, string>(indexBy)
     const indices = useMemo(() => data.map(getIndex), [data, getIndex])
     const formatValue = useValueFormatter<number, string>(valueFormat)
+    const rotation = degreesToRadians(rotationDegrees)
 
     const getColor = useOrdinalColorScale<{ key: string; index: number }>(colors, 'key')
     const colorByKey: RadarColorMapping = useMemo(
@@ -133,6 +137,7 @@ export const useRadar = <D extends Record<string, unknown>>({
         colorByKey,
         fillByKey,
         boundDefs,
+        rotation,
         radius,
         radiusScale,
         centerX,

--- a/packages/radar/src/props.ts
+++ b/packages/radar/src/props.ts
@@ -7,7 +7,7 @@ export const svgDefaultProps = {
 
     maxValue: 'auto' as const,
 
-    angle: 0,
+    rotation: 0,
 
     curve: 'linearClosed' as const,
 

--- a/packages/radar/src/props.ts
+++ b/packages/radar/src/props.ts
@@ -7,6 +7,8 @@ export const svgDefaultProps = {
 
     maxValue: 'auto' as const,
 
+    angle: 0,
+
     curve: 'linearClosed' as const,
 
     borderWidth: 2,

--- a/packages/radar/src/types.ts
+++ b/packages/radar/src/types.ts
@@ -90,7 +90,7 @@ export interface RadarCommonProps<D extends Record<string, unknown>> {
     // second argument passed to the formatter is the key
     valueFormat: ValueFormat<number, string>
 
-    angle: number
+    rotation: number
 
     layers: (RadarLayerId | RadarCustomLayer<D>)[]
 

--- a/packages/radar/src/types.ts
+++ b/packages/radar/src/types.ts
@@ -90,6 +90,8 @@ export interface RadarCommonProps<D extends Record<string, unknown>> {
     // second argument passed to the formatter is the key
     valueFormat: ValueFormat<number, string>
 
+    angle: number
+
     layers: (RadarLayerId | RadarCustomLayer<D>)[]
 
     margin: Box

--- a/packages/radar/stories/radar.stories.tsx
+++ b/packages/radar/stories/radar.stories.tsx
@@ -14,7 +14,7 @@ export default {
 const commonProperties = {
     width: 900,
     height: 500,
-    margin: { top: 60, right: 80, bottom: 20, left: 80 },
+    margin: { top: 60, right: 80, bottom: 30, left: 80 },
     ...generateWinesTastes(),
     indexBy: 'taste',
     animate: true,
@@ -195,3 +195,5 @@ export const WithPatterns = () => (
         ]}
     />
 )
+
+export const WithAngle = () => <Radar {...commonProperties} angle={36} />

--- a/packages/radar/stories/radar.stories.tsx
+++ b/packages/radar/stories/radar.stories.tsx
@@ -196,4 +196,4 @@ export const WithPatterns = () => (
     />
 )
 
-export const WithAngle = () => <Radar {...commonProperties} angle={36} />
+export const WithRotation = () => <Radar {...commonProperties} rotation={36} />

--- a/packages/radar/tests/Radar.test.tsx
+++ b/packages/radar/tests/Radar.test.tsx
@@ -29,21 +29,38 @@ const baseLegend: LegendProps = {
     itemHeight: 24,
 }
 
-it('should render a basic radar chart', () => {
-    const wrapper = mount(<Radar<TestDatum> {...baseProps} />)
+describe('layout', () => {
+    it('should render a basic radar chart', () => {
+        const wrapper = mount(<Radar<TestDatum> {...baseProps} />)
 
-    const layers = wrapper.find('RadarLayer')
-    expect(layers).toHaveLength(2)
+        const layers = wrapper.find('RadarLayer')
+        expect(layers).toHaveLength(2)
 
-    const layer0 = layers.at(0)
-    expect(layer0.prop('item')).toBe('A')
-    const layer0path = layer0.find('path')
-    expect(layer0path.prop('fill')).toBe('rgba(232, 193, 160, 1)')
+        const layer0 = layers.at(0)
+        expect(layer0.prop('item')).toBe('A')
+        const layer0path = layer0.find('path')
+        expect(layer0path.prop('fill')).toBe('rgba(232, 193, 160, 1)')
 
-    const layer1 = layers.at(1)
-    expect(layer1.prop('item')).toBe('B')
-    const layer1path = layer1.find('path')
-    expect(layer1path.prop('fill')).toBe('rgba(244, 117, 96, 1)')
+        const layer1 = layers.at(1)
+        expect(layer1.prop('item')).toBe('B')
+        const layer1path = layer1.find('path')
+        expect(layer1path.prop('fill')).toBe('rgba(244, 117, 96, 1)')
+    })
+
+    it('should support global rotation', () => {
+        const wrapperA = mount(<Radar<TestDatum> {...baseProps} rotation={90} />)
+        const wrapperB = mount(<Radar<TestDatum> {...baseProps} rotation={-90} />)
+        // the two first labels in the two components should have the same text content
+        const labelA0 = wrapperA.find('RadarGridLabels').at(0)
+        const labelB0 = wrapperB.find('RadarGridLabels').at(0)
+        // but positions should be opposite each other on the x axis, equal position on y axis
+        const getPos = (transformString: string) =>
+            transformString.replace('translate(', '').replace(')', '').split(', ')
+        const posA0 = getPos(labelA0.find('g').first().prop('transform') as string)
+        const posB0 = getPos(labelB0.find('g').first().prop('transform') as string)
+        expect(Number(posB0[0])).toBeCloseTo(-Number(posA0[0]), 4)
+        expect(Number(posB0[1])).toBeCloseTo(Number(posA0[1]), 4)
+    })
 })
 
 describe('data', () => {

--- a/packages/radar/tests/Radar.test.tsx
+++ b/packages/radar/tests/Radar.test.tsx
@@ -29,24 +29,24 @@ const baseLegend: LegendProps = {
     itemHeight: 24,
 }
 
+it('should render a basic radar chart', () => {
+    const wrapper = mount(<Radar<TestDatum> {...baseProps} />)
+
+    const layers = wrapper.find('RadarLayer')
+    expect(layers).toHaveLength(2)
+
+    const layer0 = layers.at(0)
+    expect(layer0.prop('item')).toBe('A')
+    const layer0path = layer0.find('path')
+    expect(layer0path.prop('fill')).toBe('rgba(232, 193, 160, 1)')
+
+    const layer1 = layers.at(1)
+    expect(layer1.prop('item')).toBe('B')
+    const layer1path = layer1.find('path')
+    expect(layer1path.prop('fill')).toBe('rgba(244, 117, 96, 1)')
+})
+
 describe('layout', () => {
-    it('should render a basic radar chart', () => {
-        const wrapper = mount(<Radar<TestDatum> {...baseProps} />)
-
-        const layers = wrapper.find('RadarLayer')
-        expect(layers).toHaveLength(2)
-
-        const layer0 = layers.at(0)
-        expect(layer0.prop('item')).toBe('A')
-        const layer0path = layer0.find('path')
-        expect(layer0path.prop('fill')).toBe('rgba(232, 193, 160, 1)')
-
-        const layer1 = layers.at(1)
-        expect(layer1.prop('item')).toBe('B')
-        const layer1path = layer1.find('path')
-        expect(layer1path.prop('fill')).toBe('rgba(244, 117, 96, 1)')
-    })
-
     it('should support global rotation', () => {
         const wrapperA = mount(<Radar<TestDatum> {...baseProps} rotation={90} />)
         const wrapperB = mount(<Radar<TestDatum> {...baseProps} rotation={-90} />)


### PR DESCRIPTION
Addresses #1898

Provides a prop `angle` that sets the global orientation for the radar chart.

Example of a default radar chart (left, `angle=0`) and a rotated chart (right, `angle=36`):

![2022-04-30-radar-angle](https://user-images.githubusercontent.com/7260190/166106025-82d2eae5-d657-4b78-a5b4-5d617f9738a3.png)

