### PR TITLE
Upgrade react-spring to 9.4.5

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@nivo/colors": "0.79.1",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/arcs/package.json
+++ b/packages/arcs/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@nivo/colors": "0.79.1",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-shape": "^1.3.5"
   },
   "devDependencies": {

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@nivo/scales": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-format": "^1.4.4",
     "d3-time-format": "^3.0.0"
   },

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -35,7 +35,7 @@
     "@nivo/legends": "0.79.1",
     "@nivo/scales": "0.79.0",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.2.2",
     "lodash": "^4.17.21"

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -33,7 +33,7 @@
     "@nivo/colors": "0.79.1",
     "@nivo/legends": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1"
+    "@react-spring/web": "9.4.5"
   },
   "devDependencies": {
     "@nivo/core": "0.79.0"

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -35,7 +35,7 @@
     "@nivo/legends": "0.79.1",
     "@nivo/scales": "0.79.0",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-shape": "^1.3.5"
   },
   "devDependencies": {

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -33,7 +33,7 @@
     "@nivo/colors": "0.79.1",
     "@nivo/legends": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-chord": "^1.0.6",
     "d3-shape": "^1.3.5"
   },

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@nivo/colors": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-hierarchy": "^1.1.8",
     "lodash": "^4.17.21"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@nivo/recompose": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-color": "^2.0.0",
     "d3-format": "^1.4.4",
     "d3-interpolate": "^2.0.1",

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -32,7 +32,7 @@
     "@nivo/annotations": "0.79.1",
     "@nivo/colors": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -33,7 +33,7 @@
     "@nivo/axes": "0.79.0",
     "@nivo/colors": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3"
   },
   "devDependencies": {

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -35,7 +35,7 @@
     "@nivo/scales": "0.79.0",
     "@nivo/tooltip": "0.79.0",
     "@nivo/voronoi": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-shape": "^1.3.5"
   },
   "devDependencies": {

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -24,7 +24,7 @@
     "@nivo/axes": "0.79.0",
     "@nivo/colors": "0.79.1",
     "@nivo/legends": "0.79.1",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5",
     "lodash": "^4.17.21"

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -34,7 +34,7 @@
     "@nivo/annotations": "0.79.1",
     "@nivo/colors": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-force": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -31,7 +31,7 @@
     "@nivo/axes": "0.79.0",
     "@nivo/colors": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/polar-axes/package.json
+++ b/packages/polar-axes/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@nivo/arcs": "0.79.1",
     "@nivo/scales": "0.79.0",
-    "@react-spring/web": "9.3.1"
+    "@react-spring/web": "9.4.5"
   },
   "devDependencies": {
     "@nivo/core": "0.79.0"

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -32,7 +32,7 @@
     "@nivo/colors": "0.79.1",
     "@nivo/legends": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/radial-bar/package.json
+++ b/packages/radial-bar/package.json
@@ -35,7 +35,7 @@
     "@nivo/polar-axes": "0.79.1",
     "@nivo/scales": "0.79.0",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -32,7 +32,7 @@
     "@nivo/colors": "0.79.1",
     "@nivo/legends": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-sankey": "^0.12.3",
     "d3-shape": "^1.3.5",
     "lodash": "^4.17.21"

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -36,7 +36,7 @@
     "@nivo/scales": "0.79.0",
     "@nivo/tooltip": "0.79.0",
     "@nivo/voronoi": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5",
     "lodash": "^4.17.21"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -34,7 +34,7 @@
     "@nivo/legends": "0.79.1",
     "@nivo/scales": "0.79.0",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -37,7 +37,7 @@
     "@nivo/scales": "0.79.0",
     "@nivo/tooltip": "0.79.0",
     "@nivo/voronoi": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-force": "^2.0.1",
     "d3-scale": "^3.2.3",
     "lodash": "^4.17.21"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -21,7 +21,7 @@
     "!dist/tsconfig.tsbuildinfo"
   ],
   "dependencies": {
-    "@react-spring/web": "9.3.1"
+    "@react-spring/web": "9.4.5"
   },
   "devDependencies": {
     "@nivo/core": "0.79.0"

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@nivo/colors": "0.79.1",
     "@nivo/tooltip": "0.79.0",
-    "@react-spring/web": "9.3.1",
+    "@react-spring/web": "9.4.5",
     "d3-hierarchy": "^1.1.8",
     "lodash": "^4.17.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3792,50 +3792,51 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@react-spring/animated@~9.3.0":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.3.1.tgz#ffc4706121e8406efeaeacb407b42b5022943b46"
-  integrity sha512-23YaERZ++BwZ8F8PxPFqrpOwp/JZun1Pj6aHZtPAU42j5LycBRasT9XMw7Eyr7zNFhT+rl3R3wFfd4WX6Ax+UA==
+"@react-spring/animated@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.4.5.tgz#dd9921c716a4f4a3ed29491e0c0c9f8ca0eb1a54"
+  integrity sha512-KWqrtvJSMx6Fj9nMJkhTwM9r6LIriExDRV6YHZV9HKQsaolUFppgkOXpC+rsL1JEtEvKv6EkLLmSqHTnuYjiIA==
   dependencies:
-    "@react-spring/shared" "~9.3.0"
-    "@react-spring/types" "~9.3.0"
+    "@react-spring/shared" "~9.4.5"
+    "@react-spring/types" "~9.4.5"
 
-"@react-spring/core@~9.3.0":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.3.1.tgz#b98e1dca1eb4871dec75fdab350327e8a5222865"
-  integrity sha512-8rmfmEHLHGtF1CUiXRn64YJqsXNxv2cGX8oNnBnsuoE33c48Zc34t2VIMB4R9q5zwIUCvDBGfiEenA8ZAPxqOQ==
+"@react-spring/core@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.4.5.tgz#4616e1adc18dd10f5731f100ebdbe9518b89ba3c"
+  integrity sha512-83u3FzfQmGMJFwZLAJSwF24/ZJctwUkWtyPD7KYtNagrFeQKUH1I05ZuhmCmqW+2w1KDW1SFWQ43RawqfXKiiQ==
   dependencies:
-    "@react-spring/animated" "~9.3.0"
-    "@react-spring/shared" "~9.3.0"
-    "@react-spring/types" "~9.3.0"
+    "@react-spring/animated" "~9.4.5"
+    "@react-spring/rafz" "~9.4.5"
+    "@react-spring/shared" "~9.4.5"
+    "@react-spring/types" "~9.4.5"
 
-"@react-spring/rafz@~9.3.0":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.3.1.tgz#8dd6a598ffea487252b75d05d199e4aca5ea9d5e"
-  integrity sha512-fEBMCarGVl+/2kdO+g6Zig4F+3ymwmcGN8S71gb1c7Cbbxb87kviPz8EhshfIHoiLeJPGlqwcuGbxNmZbBamvA==
+"@react-spring/rafz@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.4.5.tgz#84f809f287f2a66bbfbc66195db340482f886bd7"
+  integrity sha512-swGsutMwvnoyTRxvqhfJBtGM8Ipx6ks0RkIpNX9F/U7XmyPvBMGd3GgX/mqxZUpdlsuI1zr/jiYw+GXZxAlLcQ==
 
-"@react-spring/shared@~9.3.0":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.3.1.tgz#e7f22a4b8f5fea4491fa6a24c108db5abd19ddba"
-  integrity sha512-jhPpxzURGo6Nty90ex1lkxmZae7w/VAbnGmb/nXcYoZwSoNR+W2aAd00iXsh2ZGz6MgoJOsc495JeG3uC7Am8A==
+"@react-spring/shared@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.4.5.tgz#4c3ad817bca547984fb1539204d752a412a6d829"
+  integrity sha512-JhMh3nFKsqyag0KM5IIM8BQANGscTdd0mMv3BXsUiMZrcjQTskyfnv5qxEeGWbJGGar52qr5kHuBHtCjQOzniA==
   dependencies:
-    "@react-spring/rafz" "~9.3.0"
-    "@react-spring/types" "~9.3.0"
+    "@react-spring/rafz" "~9.4.5"
+    "@react-spring/types" "~9.4.5"
 
-"@react-spring/types@~9.3.0":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.3.1.tgz#20f392ecad15a1ea6c0865ffe86ca5016c05a278"
-  integrity sha512-W/YMJMX35XgGGzX0gKORBTwnvQ+1loDOFN3XlZkW5fgpEY+7VkRUpPyqPWXQr3n6lHrsLmHIGdpznqZi54ACTQ==
+"@react-spring/types@~9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.4.5.tgz#9c71e5ff866b5484a7ef3db822bf6c10e77bdd8c"
+  integrity sha512-mpRIamoHwql0ogxEUh9yr4TP0xU5CWyZxVQeccGkHHF8kPMErtDXJlxyo0lj+telRF35XNihtPTWoflqtyARmg==
 
-"@react-spring/web@9.3.1":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.3.1.tgz#5b377ba7ad52e746c2b59e2738c021de3f219d0b"
-  integrity sha512-sisZIgFGva/Z+xKWPSfXpukF0AP3kR9ALTxlHL87fVotMUCJX5vtH/YlVcywToEFwTHKt3MpI5Wy2M+vgVEeaw==
+"@react-spring/web@9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.4.5.tgz#b92f05b87cdc0963a59ee149e677dcaff09f680e"
+  integrity sha512-NGAkOtKmOzDEctL7MzRlQGv24sRce++0xAY7KlcxmeVkR7LRSGkoXHaIfm9ObzxPMcPHQYQhf3+X9jepIFNHQA==
   dependencies:
-    "@react-spring/animated" "~9.3.0"
-    "@react-spring/core" "~9.3.0"
-    "@react-spring/shared" "~9.3.0"
-    "@react-spring/types" "~9.3.0"
+    "@react-spring/animated" "~9.4.5"
+    "@react-spring/core" "~9.4.5"
+    "@react-spring/shared" "~9.4.5"
+    "@react-spring/types" "~9.4.5"
 
 "@rollup/plugin-babel@^5.2.0", "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"


### PR DESCRIPTION
This is a step towards upgrading nivo to support React 18 (#1964), since this is the first version of react-spring that supports React 18.

There's no breaking changes in react-spring.