### PR TITLE
feat(colors): support sequential and diverging colors schemes with custom colors

### DIFF
--- a/packages/colors/src/scales/sequentialColorScale.ts
+++ b/packages/colors/src/scales/sequentialColorScale.ts
@@ -2,12 +2,28 @@ import { useMemo } from 'react'
 import { scaleSequential } from 'd3-scale'
 import { colorInterpolators, ColorInterpolatorId } from '../schemes'
 
-export interface SequentialColorScaleConfig {
+export interface SequentialColorScaleBaseConfig {
     type: 'sequential'
-    scheme?: ColorInterpolatorId
     minValue?: number
     maxValue?: number
 }
+
+export interface SequentialColorScaleSchemeConfig extends SequentialColorScaleBaseConfig {
+    scheme?: ColorInterpolatorId
+}
+
+export interface SequentialColorScaleColorsConfig extends SequentialColorScaleBaseConfig {
+    colors: [string, string]
+}
+
+export interface SequentialColorScaleInterpolatorConfig extends SequentialColorScaleBaseConfig {
+    interpolator: (t: number) => string
+}
+
+export type SequentialColorScaleConfig =
+    | SequentialColorScaleSchemeConfig
+    | SequentialColorScaleColorsConfig
+    | SequentialColorScaleInterpolatorConfig
 
 export interface SequentialColorScaleValues {
     min: number
@@ -21,17 +37,24 @@ export const sequentialColorScaleDefaults: {
 }
 
 export const getSequentialColorScale = (
-    {
-        scheme = sequentialColorScaleDefaults.scheme,
-        minValue,
-        maxValue,
-    }: SequentialColorScaleConfig,
+    config: SequentialColorScaleConfig,
     values: SequentialColorScaleValues
 ) => {
+    const { minValue, maxValue } = config
     const min = minValue !== undefined ? minValue : values.min
     const max = maxValue !== undefined ? maxValue : values.max
 
-    return scaleSequential().domain([min, max]).interpolator(colorInterpolators[scheme])
+    const colorScale = scaleSequential<string>().domain([min, max]).clamp(true)
+    if ('colors' in config) {
+        colorScale.range(config.colors)
+    } else if ('interpolator' in config) {
+        colorScale.interpolator(config.interpolator)
+    } else {
+        const scheme = config.scheme ?? sequentialColorScaleDefaults.scheme
+        colorScale.interpolator(colorInterpolators[scheme])
+    }
+
+    return colorScale
 }
 
 export const useSequentialColorScale = (

--- a/packages/colors/tests/continuousColorScale.test.ts
+++ b/packages/colors/tests/continuousColorScale.test.ts
@@ -1,0 +1,108 @@
+import {
+    getContinuousColorScale,
+    colorSchemes,
+    divergingColorSchemeIds,
+    sequentialColorSchemeIds,
+} from '../src'
+import { color } from 'd3-color'
+
+const unitInterval = { min: 0, max: 1 }
+
+const toHex = (x: string) => color(x).formatHex()
+
+describe('continuous scales from named schemes', () => {
+    sequentialColorSchemeIds.forEach(scheme => {
+        it(`generates a scale from sequential colors (${scheme})`, () => {
+            const colorScale = getContinuousColorScale({ type: 'sequential', scheme }, unitInterval)
+            // d3 sequential schemes have 9 colors predefined
+            const schemeColors = colorSchemes[scheme][9]
+            // compare the computed colors and scheme colors at the extrema of the unit interval
+            expect(toHex(colorScale(0))).toBe(schemeColors[0])
+            expect(toHex(colorScale(1))).toBe(schemeColors[8])
+        })
+    })
+
+    divergingColorSchemeIds.forEach(scheme => {
+        it(`generates a scale from diverging colors (${scheme})`, () => {
+            const colorScale = getContinuousColorScale({ type: 'diverging', scheme }, unitInterval)
+            // d3 divergent scales have predefined 11 distinct colors
+            const schemeColors = colorSchemes[scheme][11]
+            // compare the computed colors and scheme colors at the extrema of the unit interval
+            expect(toHex(colorScale(0))).toBe(schemeColors[0])
+            expect(toHex(colorScale(1))).toBe(schemeColors[10])
+        })
+    })
+})
+
+describe('continuous scales from custom colors', () => {
+    it(`generates a sequential scale from custom colors`, () => {
+        // custom colors in rgb are (68, 0, 0) and (170, 0, 0)
+        const customColors = ['#440000', '#aa0000']
+        const colorScale = getContinuousColorScale(
+            {
+                type: 'sequential',
+                colors: customColors,
+            },
+            unitInterval
+        )
+        expect(toHex(colorScale(0))).toBe(customColors[0])
+        expect(toHex(colorScale(1))).toBe(customColors[1])
+        expect(toHex(colorScale(0.5))).toBe('#770000')
+    })
+
+    it(`accepts a sequential scale with custom interpolator`, () => {
+        const customColors = ['#440000', '#aa0000']
+        // this interpolator is actually a threshold-like scale
+        const customInterpolator = (t: number) => {
+            if (t < 0.4) return customColors[0]
+            return customColors[1]
+        }
+        const colorScale = getContinuousColorScale(
+            {
+                type: 'sequential',
+                interpolator: customInterpolator,
+            },
+            unitInterval
+        )
+        expect(toHex(colorScale(0))).toBe(customColors[0])
+        expect(toHex(colorScale(1))).toBe(customColors[1])
+        expect(toHex(colorScale(0.39))).toBe(customColors[0])
+        expect(toHex(colorScale(0.41))).toBe(customColors[1])
+    })
+
+    it(`generates a divergent scale from custom colors`, () => {
+        // custom colors in rgb are (68, 0, 0) and (170, 0, 0)
+        const customColors = ['#440000', '#ffffff', '#004400']
+        const colorScale = getContinuousColorScale(
+            {
+                type: 'diverging',
+                colors: customColors,
+            },
+            unitInterval
+        )
+        expect(toHex(colorScale(0))).toBe(customColors[0])
+        expect(toHex(colorScale(1))).toBe(customColors[2])
+        expect(toHex(colorScale(0.5))).toBe(customColors[1])
+    })
+
+    it(`accepts a divergent scale with custom interpolator`, () => {
+        const customColors = ['#440000', '#ffffff', '#004400']
+        // this interpolator is actually a threshold-like scale
+        const customInterpolator = (t: number) => {
+            if (t < 0.2) return customColors[0]
+            if (t > 0.8) return customColors[2]
+            return customColors[1]
+        }
+        const colorScale = getContinuousColorScale(
+            {
+                type: 'diverging',
+                interpolator: customInterpolator,
+            },
+            unitInterval
+        )
+        expect(toHex(colorScale(0))).toBe(customColors[0])
+        expect(toHex(colorScale(1))).toBe(customColors[2])
+        expect(toHex(colorScale(0.25))).toBe(customColors[1])
+        expect(toHex(colorScale(0.75))).toBe(customColors[1])
+    })
+})

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -32,6 +32,7 @@
     "@nivo/annotations": "0.79.1",
     "@nivo/axes": "0.79.0",
     "@nivo/colors": "0.79.1",
+    "@nivo/legends": "0.79.1",
     "@nivo/tooltip": "0.79.0",
     "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3"

--- a/packages/heatmap/stories/CustomInterpolator.tsx
+++ b/packages/heatmap/stories/CustomInterpolator.tsx
@@ -1,0 +1,23 @@
+import { scaleSequential, scaleThreshold } from 'd3-scale'
+
+// characteristics of the linear scale
+const thresholds = [0, 0.4, 0.5, 0.6, 1]
+
+// array of sequential scales
+const colors = ['#8888ee', '#ffffee', '#eebb00', '#ffeeff', '#dd8888']
+const scales = thresholds.slice(0, thresholds.length - 1).map((v, i) =>
+    scaleSequential<string>()
+        .domain(thresholds.slice(i, i + 2))
+        .range(colors.slice(i, i + 2))
+)
+
+// mapper that will look at a value and pick one of the scales
+const getScaleIndex = scaleThreshold()
+    .domain(thresholds)
+    .range(
+        Array(thresholds.length)
+            .fill(0)
+            .map((v, i) => i - 1)
+    )
+
+export const customInterpolator = (t: number) => scales[getScaleIndex(t)](t)

--- a/packages/heatmap/stories/heatmap.stories.tsx
+++ b/packages/heatmap/stories/heatmap.stories.tsx
@@ -1,10 +1,14 @@
 import { storiesOf } from '@storybook/react'
+import { select } from '@storybook/addon-knobs'
+import { ContinuousColorScaleConfig } from '@nivo/colors'
 // @ts-ignore
 import { HeatMap, ComputedCell } from '../src'
 // @ts-ignore
 import { sampleData } from './data'
 // @ts-ignore
 import { CustomTooltip } from './CustomTooltip'
+// @ts-ignore
+import { customInterpolator } from './CustomInterpolator'
 
 const commonProperties = {
     width: 900,
@@ -85,3 +89,147 @@ stories.add('Custom Tooltip', () => (
         }}
     />
 ))
+
+const customColorConfigs = {
+    'sequential (full domain)': {
+        type: 'sequential',
+        scheme: 'oranges',
+        minValue: -100000,
+        maxValue: 100000,
+    },
+    'sequential (restricted domain)': {
+        type: 'sequential',
+        scheme: 'oranges',
+        minValue: 0,
+        maxValue: 100000,
+    },
+    'diverging at 0.5': {
+        type: 'diverging',
+        scheme: 'purple_orange',
+        minValue: -100000,
+        maxValue: 100000,
+        divergeAt: 0.5,
+    },
+    'diverging at 0.33': {
+        type: 'diverging',
+        scheme: 'purple_orange',
+        minValue: -100000,
+        maxValue: 100000,
+        divergeAt: 0.33,
+    },
+    'custom sequential': {
+        type: 'sequential',
+        colors: ['#f4f4f4', '#74A57F'],
+        minValue: -100000,
+        maxValue: 100000,
+    },
+    'custom diverging at 0.5': {
+        type: 'diverging',
+        colors: ['#aa6052', '#f4f4f4', '#74A57F'],
+        divergeAt: 0.5,
+        minValue: -100000,
+        maxValue: 100000,
+    },
+    'custom diverging at 0.33': {
+        type: 'diverging',
+        colors: ['#aa6052', '#f4f4f4', '#74A57F'],
+        divergeAt: 0.33,
+        minValue: -100000,
+        maxValue: 100000,
+    },
+    'custom interpolator': {
+        type: 'sequential',
+        interpolator: customInterpolator,
+        minValue: -100000,
+        maxValue: 100000,
+    },
+} as Record<string, ContinuousColorScaleConfig>
+
+const HeatMapWithColor = ({ colorConfig }: { colorConfig: string }) => {
+    return (
+        <HeatMap<any, Record<string, unknown>>
+            {...commonProperties}
+            colors={customColorConfigs[colorConfig]}
+            legends={[
+                {
+                    anchor: 'bottom',
+                    translateX: 0,
+                    translateY: 30,
+                    length: 400,
+                    thickness: 8,
+                    direction: 'row',
+                    tickPosition: 'after',
+                    tickSize: 3,
+                    tickSpacing: 4,
+                    tickOverlap: false,
+                    tickFormat: '>-.2s',
+                    title: 'Value →',
+                    titleAlign: 'start',
+                    titleOffset: 4,
+                },
+            ]}
+        />
+    )
+}
+
+stories.add(
+    'Color Scales',
+    () => (
+        <HeatMapWithColor
+            colorConfig={select(
+                'colors',
+                [
+                    'sequential (full domain)',
+                    'sequential (restricted domain)',
+                    'diverging at 0.5',
+                    'diverging at 0.33',
+                ],
+                'sequential (full domain)'
+            )}
+        />
+    ),
+    {
+        info: {
+            text: `
+                Use the knobs to toggle between heatmap variants with different colors.
+                All the variants use named color schemes, and add fine-tuning.
+                 
+                 - sequential (full_domain): sequential scale that covers all values in the heatmap
+                 - sequential (restricted domain): sequential scale that covers only a part of the values in the heatmap                    
+                 - diverging at 0.5: three color scale with the middle color placed the middle of the domain
+                 - diverging at 0.33: three color scale with the middle color at the 33th percentile of the domain   
+            `,
+        },
+    }
+)
+
+stories.add(
+    'Custom Color Scales',
+    () => (
+        <HeatMapWithColor
+            colorConfig={select(
+                'colors',
+                [
+                    'custom sequential',
+                    'custom diverging at 0.5',
+                    'custom diverging at 0.33',
+                    'custom interpolator',
+                ],
+                'custom sequential'
+            )}
+        />
+    ),
+    {
+        info: {
+            text: `
+                Use the knobs to toggle between heatmap variants with different colors.
+                All the variants use color scales with custom colors (specified via rgb strings).
+                 
+                 - custom sequential: two-color scale with custom colors
+                 - custom diverging at 0.5: three-color scale with custom colors
+                 - custom diverging at 0.33: three-color scale with custom colors, with the middle color at the 33 percentile of the domain
+                 - custom interpolator: multi-color scale prepared using a custom interpolator function
+            `,
+        },
+    }
+)

--- a/packages/heatmap/tests/HeatMap.test.tsx
+++ b/packages/heatmap/tests/HeatMap.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme'
+import { mount, ReactWrapper } from 'enzyme'
 import { Globals, SpringValue } from '@react-spring/web'
 import { Axes, Grid } from '@nivo/axes'
 import { Annotation } from '@nivo/annotations'
@@ -237,6 +237,77 @@ describe('size variation', () => {
                 })
             })
         })
+    })
+})
+
+describe('color scales', () => {
+    const customColors = ['#4444ff', '#ffffff', '#44aa44']
+    const customRGBA = ['rgba(68, 68, 255, 1)', 'rgba(255, 255, 255, 1)', 'rgba(68, 170, 68, 1)']
+    const dataB = baseProps.data.slice(1, 2)
+
+    const getBCells = (wrapper: ReactWrapper) => ({
+        X: wrapper.find(`g[data-testid='cell.B.X']`).find('rect'),
+        Y: wrapper.find(`g[data-testid='cell.B.Y']`).find('rect'),
+        Z: wrapper.find(`g[data-testid='cell.B.Z']`).find('rect'),
+    })
+
+    it('allows a quantized color scheme with custom colors', () => {
+        // use data with three values, quantized colors with 2 levels
+        const wrapper = mount(
+            <HeatMap
+                {...baseProps}
+                data={dataB}
+                colors={{ type: 'quantize', colors: [customColors[0], customColors[2]] }}
+            />
+        )
+        // the B series has three cells with values 3, 2, 1
+        // the extreme values should get the extreme colors
+        const cells = getBCells(wrapper)
+        expect(cells.X.exists()).toBeTruthy()
+        expect(cells.X.prop('fill')).toBe(customRGBA[2])
+        expect(cells.Z.exists()).toBeTruthy()
+        expect(cells.Z.prop('fill')).toBe(customRGBA[0])
+        // the middle value should have one of the extreme colors
+        expect(cells.Y.exists()).toBeTruthy()
+        expect(cells.Y.prop('fill')).toBe(customRGBA[2])
+    })
+
+    it('allows a sequential color scheme with custom colors', () => {
+        const wrapper = mount(
+            <HeatMap
+                {...baseProps}
+                data={dataB}
+                colors={{ type: 'sequential', colors: customColors }}
+            />
+        )
+        // the B series has three cells with values 3, 2, 1
+        // the sequential scheme should only use the first two colors in customColors
+        const cells = getBCells(wrapper)
+        // the X value is high, should get second custom color
+        expect(cells.X.prop('fill')).toBe(customRGBA[1])
+        // the Z value is low, should get the first custom color
+        expect(cells.Z.prop('fill')).toBe(customRGBA[0])
+        // the Y value is intermediate, so should get a different color
+        expect(cells.Y.prop('fill')).toBe('rgba(162, 162, 255, 1)')
+    })
+
+    it('allows a diverging color scheme with custom colors', () => {
+        const wrapper = mount(
+            <HeatMap
+                {...baseProps}
+                data={dataB}
+                colors={{ type: 'diverging', colors: customColors }}
+            />
+        )
+        // the B series has three cells with values 3, 2, 1
+        // the diverging scheme should give each cell a color from the customColors
+        const cells = getBCells(wrapper)
+        // the X value is high, should get last custom color
+        expect(cells.X.prop('fill')).toBe(customRGBA[2])
+        // the Z value is low, should get the first custom color
+        expect(cells.Z.prop('fill')).toBe(customRGBA[0])
+        // the Y value is intermediate, so should get middle color
+        expect(cells.Y.prop('fill')).toBe(customRGBA[1])
     })
 })
 


### PR DESCRIPTION
Adds support for color scales with custom colors and custom interpolators

Addresses #1988


## Motivation

Color scales, e.g. for HeatMaps, are defined via 'sequential', 'diverging', and 'quantize' configuration types. While 'quantize' color scales can now be created with an array of custom colors, the 'sequential' and 'diverging' scales can only be selected from a set of named schemes, e.g. 'blues'. 

Custom 'sequential' and 'diverging' color scales would enable charts, e.g. HeatMaps, to integrate with the color scheme outside of the chart.


## Examples

A heatmap with a sequential scheme with two custom colors:
![2022-05-12 08-55-heatmap-1](https://user-images.githubusercontent.com/7260190/168034698-20e3b639-c946-4544-806e-3bea03a00825.png)


Examples of scales with diverging colors, diverging colors with an offset, and a multi-color scheme:

![2022-05-12-scales](https://user-images.githubusercontent.com/7260190/168035603-fd6e6c24-6925-4d7c-816b-ec8e9e3ed699.png)

(These are just for demonstration, not for use in practice.)


## Interface

The new ways to define color scales are:

```
{ 
  type: 'sequential'
  colors: [string, string]
}
{
  type: 'sequential'
  interpolator: (t: number) => string
}
{
  type: 'diverging'
  colors: [string, string, string]
}
{ 
  type: 'diverging'
  interpolator: (t: number) => string
}
```

Consistently with existing features, these all accept `minValue` and `maxValue` to set the domain. The diverging configurations also accept `divergeAt`.


## Changes

 - edited `@nivo/colors` to support new configuration types
 - added unit tests in `@nivo/colors` for continuous color schemes
 - added stories in `@nivo/heatmap` to showcase custom colors
 - added unit tests in `@nivo/heatmap` for custom colors
 - added `@nivo/legends` as a dependency to `@nivo/heatmap`

