### PR TITLE
fix bug (typescript) in creating log scales

### DIFF
--- a/packages/bar/src/Bar.tsx
+++ b/packages/bar/src/Bar.tsx
@@ -19,7 +19,7 @@ import {
     useMotionConfig,
 } from '@nivo/core'
 import { Fragment, ReactNode, createElement, useMemo } from 'react'
-import { defaultProps, svgDefaultProps } from './props'
+import { svgDefaultProps } from './props'
 import { useTransition } from '@react-spring/web'
 import { useBar } from './hooks'
 
@@ -61,10 +61,10 @@ const InnerBar = <RawDatum extends BarDatum>({
     layers = svgDefaultProps.layers as BarLayer<RawDatum>[],
     barComponent = svgDefaultProps.barComponent,
 
-    enableLabel = defaultProps.enableLabel,
+    enableLabel = svgDefaultProps.enableLabel,
     label,
-    labelSkipWidth = defaultProps.labelSkipWidth,
-    labelSkipHeight = defaultProps.labelSkipHeight,
+    labelSkipWidth = svgDefaultProps.labelSkipWidth,
+    labelSkipHeight = svgDefaultProps.labelSkipHeight,
     labelTextColor,
 
     markers = svgDefaultProps.markers,

--- a/packages/bar/src/Bar.tsx
+++ b/packages/bar/src/Bar.tsx
@@ -1,6 +1,13 @@
 import { Axes, Grid } from '@nivo/axes'
 import { BarAnnotations } from './BarAnnotations'
-import { BarDatum, BarLayer, BarLayerId, BarSvgProps, ComputedBarDatumWithValue } from './types'
+import {
+    BarCustomLayerProps,
+    BarDatum,
+    BarLayer,
+    BarLayerId,
+    BarSvgProps,
+    ComputedBarDatumWithValue,
+} from './types'
 import { BarLegends } from './BarLegends'
 import {
     CartesianMarkers,
@@ -12,7 +19,7 @@ import {
     useMotionConfig,
 } from '@nivo/core'
 import { Fragment, ReactNode, createElement, useMemo } from 'react'
-import { svgDefaultProps } from './props'
+import { defaultProps, svgDefaultProps } from './props'
 import { useTransition } from '@react-spring/web'
 import { useBar } from './hooks'
 
@@ -54,10 +61,10 @@ const InnerBar = <RawDatum extends BarDatum>({
     layers = svgDefaultProps.layers as BarLayer<RawDatum>[],
     barComponent = svgDefaultProps.barComponent,
 
-    enableLabel,
+    enableLabel = defaultProps.enableLabel,
     label,
-    labelSkipWidth,
-    labelSkipHeight,
+    labelSkipWidth = defaultProps.labelSkipWidth,
+    labelSkipHeight = defaultProps.labelSkipHeight,
     labelTextColor,
 
     markers = svgDefaultProps.markers,
@@ -287,8 +294,8 @@ const InnerBar = <RawDatum extends BarDatum>({
         layerById.axes = (
             <Axes
                 key="axes"
-                xScale={xScale as any}
-                yScale={yScale as any}
+                xScale={xScale}
+                yScale={yScale}
                 width={innerWidth}
                 height={innerHeight}
                 top={axisTop}
@@ -321,8 +328,8 @@ const InnerBar = <RawDatum extends BarDatum>({
                 key="grid"
                 width={innerWidth}
                 height={innerHeight}
-                xScale={enableGridX ? (xScale as any) : null}
-                yScale={enableGridY ? (yScale as any) : null}
+                xScale={enableGridX ? xScale : null}
+                yScale={enableGridY ? yScale : null}
                 xValues={gridXValues}
                 yValues={gridYValues}
             />
@@ -354,20 +361,43 @@ const InnerBar = <RawDatum extends BarDatum>({
         )
     }
 
-    // We use `any` here until we can figure out the best way to type xScale/yScale
-    const layerContext: any = useMemo(
+    const layerContext: BarCustomLayerProps<RawDatum> = useMemo(
         () => ({
             ...commonProps,
             margin,
-            innerWidth,
-            innerHeight,
             width,
             height,
+            innerWidth,
+            innerHeight,
             bars,
+            legendData: legendsWithData,
+            enableLabel,
             xScale,
             yScale,
+            tooltip,
+            getTooltipLabel,
+            onClick,
+            onMouseEnter,
+            onMouseLeave,
         }),
-        [commonProps, margin, innerWidth, innerHeight, width, height, bars, xScale, yScale]
+        [
+            commonProps,
+            margin,
+            width,
+            height,
+            innerWidth,
+            innerHeight,
+            bars,
+            legendsWithData,
+            enableLabel,
+            xScale,
+            yScale,
+            tooltip,
+            getTooltipLabel,
+            onClick,
+            onMouseEnter,
+            onMouseLeave,
+        ]
     )
 
     return (

--- a/packages/bar/src/BarCanvas.tsx
+++ b/packages/bar/src/BarCanvas.tsx
@@ -1,4 +1,10 @@
-import { BarCanvasLayer, BarCanvasProps, BarDatum, ComputedBarDatum } from './types'
+import {
+    BarCanvasCustomLayerProps,
+    BarCanvasLayer,
+    BarCanvasProps,
+    BarDatum,
+    ComputedBarDatum,
+} from './types'
 import {
     Container,
     Margin,
@@ -130,10 +136,10 @@ const InnerBarCanvas = <RawDatum extends BarDatum>({
         }
     },
 
-    enableLabel,
+    enableLabel = canvasDefaultProps.enableLabel,
     label,
-    labelSkipWidth,
-    labelSkipHeight,
+    labelSkipWidth = canvasDefaultProps.labelSkipWidth,
+    labelSkipHeight = canvasDefaultProps.labelSkipHeight,
     labelTextColor,
 
     colorBy,
@@ -231,48 +237,51 @@ const InnerBarCanvas = <RawDatum extends BarDatum>({
     })
 
     // We use `any` here until we can figure out the best way to type xScale/yScale
-    const layerContext: any = useMemo(
+    const layerContext: BarCanvasCustomLayerProps<RawDatum> = useMemo(
         () => ({
             borderRadius,
             borderWidth,
-            enableLabel,
             isInteractive,
+            isFocusable: false,
             labelSkipWidth,
             labelSkipHeight,
+            margin,
+            width,
+            height,
+            innerWidth,
+            innerHeight,
+            bars,
+            legendData: legendsWithData,
+            enableLabel,
+            xScale,
+            yScale,
+            tooltip,
+            getTooltipLabel,
             onClick,
             onMouseEnter,
             onMouseLeave,
-            getTooltipLabel,
-            tooltip,
-            margin,
-            innerWidth,
-            innerHeight,
-            width,
-            height,
-            bars,
-            xScale,
-            yScale,
         }),
         [
             borderRadius,
             borderWidth,
-            enableLabel,
-            getTooltipLabel,
-            height,
-            innerHeight,
-            innerWidth,
             isInteractive,
-            labelSkipHeight,
             labelSkipWidth,
+            labelSkipHeight,
             margin,
-            onClick,
-            onMouseEnter,
-            onMouseLeave,
+            width,
+            height,
+            innerWidth,
+            innerHeight,
             bars,
+            legendsWithData,
+            enableLabel,
             xScale,
             yScale,
             tooltip,
-            width,
+            getTooltipLabel,
+            onClick,
+            onMouseEnter,
+            onMouseLeave,
         ]
     )
 
@@ -301,7 +310,7 @@ const InnerBarCanvas = <RawDatum extends BarDatum>({
                         renderGridLinesToCanvas<string | number>(ctx, {
                             width,
                             height,
-                            scale: xScale as any,
+                            scale: xScale,
                             axis: 'x',
                             values: gridXValues,
                         })
@@ -311,7 +320,7 @@ const InnerBarCanvas = <RawDatum extends BarDatum>({
                         renderGridLinesToCanvas<string | number>(ctx, {
                             width,
                             height,
-                            scale: yScale as any,
+                            scale: yScale,
                             axis: 'y',
                             values: gridYValues,
                         })
@@ -319,8 +328,8 @@ const InnerBarCanvas = <RawDatum extends BarDatum>({
                 }
             } else if (layer === 'axes') {
                 renderAxesToCanvas(ctx, {
-                    xScale: xScale as any,
-                    yScale: yScale as any,
+                    xScale: xScale,
+                    yScale: yScale,
                     width: innerWidth,
                     height: innerHeight,
                     top: axisTop,

--- a/packages/bar/src/types.ts
+++ b/packages/bar/src/types.ts
@@ -118,6 +118,8 @@ interface BarCustomLayerBaseProps<RawDatum>
 
     isFocusable: boolean
 
+    getTooltipLabel: (datum: ComputedDatum<RawDatum>) => string | number
+
     xScale: AnyScale
     yScale: AnyScale
 }

--- a/packages/bar/src/types.ts
+++ b/packages/bar/src/types.ts
@@ -14,7 +14,7 @@ import {
 } from '@nivo/core'
 import { InheritedColorConfig, OrdinalColorScaleConfig } from '@nivo/colors'
 import { LegendProps } from '@nivo/legends'
-import { Scale, ScaleSpec, ScaleBandSpec } from '@nivo/scales'
+import { AnyScale, ScaleSpec, ScaleBandSpec } from '@nivo/scales'
 import { SpringValues } from '@react-spring/web'
 
 export interface BarDatum {
@@ -97,7 +97,7 @@ export type ValueFormatter = (value: number) => string | number
 
 export type BarLayerId = 'grid' | 'axes' | 'bars' | 'markers' | 'legends' | 'annotations'
 
-export interface BarCustomLayerProps<RawDatum>
+interface BarCustomLayerBaseProps<RawDatum>
     extends Pick<
             BarCommonProps<RawDatum>,
             | 'borderRadius'
@@ -108,24 +108,31 @@ export interface BarCustomLayerProps<RawDatum>
             | 'labelSkipWidth'
             | 'tooltip'
         >,
-        Dimensions,
-        BarHandlers<RawDatum, SVGRectElement> {
+        Dimensions {
     bars: ComputedBarDatum<RawDatum>[]
-    legendData: BarsWithHidden<RawDatum>
+    legendData: [BarLegendProps, LegendData[]][]
 
     margin: Margin
     innerWidth: number
     innerHeight: number
 
-    getTooltipLabel: (datum: ComputedDatum<RawDatum>) => string | number
+    isFocusable: boolean
 
-    xScale: Scale<any, any>
-    yScale: Scale<any, any>
+    xScale: AnyScale
+    yScale: AnyScale
 }
+
+export interface BarCustomLayerProps<RawDatum>
+    extends BarCustomLayerBaseProps<RawDatum>,
+        BarHandlers<RawDatum, SVGRectElement> {}
+
+export interface BarCanvasCustomLayerProps<RawDatum>
+    extends BarCustomLayerBaseProps<RawDatum>,
+        BarHandlers<RawDatum, HTMLCanvasElement> {}
 
 export type BarCanvasCustomLayer<RawDatum> = (
     context: CanvasRenderingContext2D,
-    props: BarCustomLayerProps<RawDatum>
+    props: BarCanvasCustomLayerProps<RawDatum>
 ) => void
 export type BarCustomLayer<RawDatum> = React.FC<BarCustomLayerProps<RawDatum>>
 

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -24,14 +24,13 @@
     "@nivo/axes": "0.79.0",
     "@nivo/colors": "0.79.1",
     "@nivo/legends": "0.79.1",
+    "@nivo/scales": "0.79.0",
     "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@nivo/core": "0.79.0",
-    "@types/d3-scale": "^3.2.2",
     "@types/d3-shape": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/marimekko/src/Marimekko.tsx
+++ b/packages/marimekko/src/Marimekko.tsx
@@ -108,8 +108,8 @@ const InnerMarimekko = <RawDatum,>({
         layerById.grid = (
             <Grid
                 key="grid"
-                xScale={enableGridX ? (xScale as any) : undefined}
-                yScale={enableGridY ? (yScale as any) : undefined}
+                xScale={enableGridX ? xScale : undefined}
+                yScale={enableGridY ? yScale : undefined}
                 width={innerWidth}
                 height={innerHeight}
                 xValues={gridXValues}
@@ -122,8 +122,8 @@ const InnerMarimekko = <RawDatum,>({
         layerById.axes = (
             <Axes
                 key="axes"
-                xScale={xScale as any}
-                yScale={yScale as any}
+                xScale={xScale}
+                yScale={yScale}
                 width={innerWidth}
                 height={innerHeight}
                 top={axisTop}

--- a/packages/marimekko/src/types.ts
+++ b/packages/marimekko/src/types.ts
@@ -6,7 +6,7 @@ import {
     stackOffsetSilhouette,
     stackOffsetWiggle,
 } from 'd3-shape'
-import { ScaleLinear } from 'd3-scale'
+import { ScaleLinear } from '@nivo/scales'
 import { Box, Dimensions, Theme, SvgDefsAndFill, ModernMotionProps, ValueFormat } from '@nivo/core'
 import { AxisProps } from '@nivo/axes'
 import { OrdinalColorScaleConfig, InheritedColorConfig } from '@nivo/colors'
@@ -70,8 +70,8 @@ export type LayerId = 'grid' | 'axes' | 'bars' | 'legends'
 export interface CustomLayerProps<RawDatum> {
     data: ComputedDatum<RawDatum>[]
     bars: BarDatum<RawDatum>[]
-    thicknessScale: ScaleLinear<number, number>
-    dimensionsScale: ScaleLinear<number, number>
+    thicknessScale: ScaleLinear<number>
+    dimensionsScale: ScaleLinear<number>
 }
 
 export type CustomLayer<RawDatum> = React.FC<CustomLayerProps<RawDatum>>

--- a/packages/marimekko/tests/.eslintrc.yml
+++ b/packages/marimekko/tests/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+  jest: true

--- a/packages/marimekko/tests/Marimekko.test.tsx
+++ b/packages/marimekko/tests/Marimekko.test.tsx
@@ -1,0 +1,82 @@
+import { mount, ReactWrapper } from 'enzyme'
+// @ts-ignore
+import { Marimekko } from '../src/Marimekko'
+
+const commonProps = {
+    width: 500,
+    height: 300,
+    margin: { top: 60, right: 80, bottom: 60, left: 80 },
+    data: [
+        {
+            statement: 'A',
+            participation: 20,
+            agree: 70,
+            disagree: 30,
+        },
+        {
+            statement: 'B',
+            participation: 80,
+            agree: 10,
+            disagree: 90,
+        },
+    ],
+    id: 'statement',
+    value: 'participation',
+    dimensions: [
+        {
+            id: 'disagree',
+            value: 'disagree',
+        },
+        {
+            id: 'agree',
+            value: 'agree',
+        },
+    ],
+    animate: false,
+}
+
+it('should render a basic chart', () => {
+    const wrapper = mount(<Marimekko {...commonProps} />)
+    // the basic chart has two categories and two values each -> 4 bars
+    const bars = wrapper.find('Bar')
+    expect(bars).toHaveLength(4)
+})
+
+describe('layout', () => {
+    const getSizes = (bars: ReactWrapper) => {
+        return [0, 1, 2, 3].map(i => {
+            const props = bars.at(i).find('rect').props()
+            const width = Number(props.width)
+            const height = Number(props.height)
+            return { width, height, area: width * height }
+        })
+    }
+
+    it('vertical layout', () => {
+        const wrapper = mount(<Marimekko {...commonProps} />)
+        // in vertical layout, first two rectangles should be in a column, i.e. equal width
+        const sizes = getSizes(wrapper.find('Bar'))
+        expect(sizes[0].width).toBe(sizes[1].width)
+        expect(sizes[2].width).toBe(sizes[3].width) // width of next two rectangles
+        expect(sizes[2].width).toBeGreaterThan(sizes[0].width)
+        // the first two bars should have the same width, also the next two bars
+        // the areas of the bars should be proportional to:
+        // (A*disagree)=(20*30)=600,  (A*agree)=(20*70)=1400,
+        // (B*disagree)=(80*90)=7200, (B*agree)=(80*10)=800
+        expect(sizes[0].area).toBeLessThan(sizes[1].area)
+        expect(sizes[0].area).toBeLessThan(sizes[2].area)
+        expect(sizes[0].area).toBeLessThan(sizes[3].area)
+        expect(sizes[1].area).toBeLessThan(sizes[2].area)
+        expect(sizes[1].area).toBeGreaterThan(sizes[3].area)
+        expect(sizes[2].area).toBeGreaterThan(sizes[3].area)
+    })
+
+    it('horizontal layout', () => {
+        const wrapper = mount(<Marimekko {...commonProps} layout={'horizontal'} />)
+        // in horizontal layout, first two rectangles should be in a row, i.e. equal height
+        const sizes = getSizes(wrapper.find('Bar'))
+        expect(sizes[0].height).toBe(sizes[1].height)
+        expect(sizes[2].height).toBe(sizes[3].height)
+        expect(sizes[2].height).toBeGreaterThan(sizes[0].height)
+    })
+})

--- a/packages/scales/src/logScale.ts
+++ b/packages/scales/src/logScale.ts
@@ -52,5 +52,5 @@ export const createLogScale = (
     const typedScale = scale as ScaleLog
     typedScale.type = 'log'
 
-    return scale
+    return typedScale
 }

--- a/packages/scatterplot/src/ScatterPlot.tsx
+++ b/packages/scatterplot/src/ScatterPlot.tsx
@@ -102,8 +102,8 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
                 key="grid"
                 width={innerWidth}
                 height={innerHeight}
-                xScale={enableGridX ? (xScale as any) : null}
-                yScale={enableGridY ? (yScale as any) : null}
+                xScale={enableGridX ? xScale : null}
+                yScale={enableGridY ? yScale : null}
                 xValues={gridXValues}
                 yValues={gridYValues}
             />
@@ -114,8 +114,8 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
         layerById.axes = (
             <Axes
                 key="axes"
-                xScale={xScale as any}
-                yScale={yScale as any}
+                xScale={xScale}
+                yScale={yScale}
                 width={innerWidth}
                 height={innerHeight}
                 top={axisTop}

--- a/packages/scatterplot/src/ScatterPlotCanvas.tsx
+++ b/packages/scatterplot/src/ScatterPlotCanvas.tsx
@@ -128,7 +128,7 @@ const InnerScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>({
                     renderGridLinesToCanvas<RawDatum['x']>(ctx, {
                         width: innerWidth,
                         height: innerHeight,
-                        scale: xScale as any,
+                        scale: xScale,
                         axis: 'x',
                         values: gridXValues,
                     })
@@ -137,7 +137,7 @@ const InnerScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>({
                     renderGridLinesToCanvas<RawDatum['y']>(ctx, {
                         width: innerWidth,
                         height: innerHeight,
-                        scale: yScale as any,
+                        scale: yScale,
                         axis: 'y',
                         values: gridYValues,
                     })
@@ -148,8 +148,8 @@ const InnerScatterPlotCanvas = <RawDatum extends ScatterPlotDatum>({
                 })
             } else if (layer === 'axes') {
                 renderAxesToCanvas<RawDatum['x'], RawDatum['y']>(ctx, {
-                    xScale: xScale as any,
-                    yScale: yScale as any,
+                    xScale: xScale,
+                    yScale: yScale,
                     width: innerWidth,
                     height: innerHeight,
                     top: axisTop as CanvasAxisProps<RawDatum['x']>,

--- a/packages/scatterplot/src/types.ts
+++ b/packages/scatterplot/src/types.ts
@@ -10,7 +10,7 @@ import {
     CartesianMarkerProps,
     PropertyAccessor,
 } from '@nivo/core'
-import { ScaleSpec } from '@nivo/scales'
+import { AnyScale, ScaleSpec } from '@nivo/scales'
 import { OrdinalColorScaleConfig } from '@nivo/colors'
 import { AxisProps, GridValues } from '@nivo/axes'
 import { LegendProps } from '@nivo/legends'
@@ -84,8 +84,8 @@ export type ScatterPlotLayerId =
     | 'legends'
     | 'annotations'
 export interface ScatterPlotLayerProps<RawDatum extends ScatterPlotDatum> {
-    xScale: any
-    yScale: any
+    xScale: AnyScale
+    yScale: AnyScale
     nodes: ScatterPlotNodeData<RawDatum>[]
     innerWidth: number
     innerHeight: number

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -35,12 +35,10 @@
     "@nivo/scales": "0.79.0",
     "@nivo/tooltip": "0.79.0",
     "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3",
     "d3-shape": "^1.3.5"
   },
   "devDependencies": {
     "@nivo/core": "0.79.0",
-    "@types/d3-scale": "^3.2.2",
     "@types/d3-shape": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/stream/src/Stream.tsx
+++ b/packages/stream/src/Stream.tsx
@@ -122,8 +122,8 @@ const InnerStream = <RawDatum extends StreamDatum>({
                 key="grid"
                 width={innerWidth}
                 height={innerHeight}
-                xScale={enableGridX ? (xScale as any) : null}
-                yScale={enableGridY ? (yScale as any) : null}
+                xScale={enableGridX ? xScale : null}
+                yScale={enableGridY ? yScale : null}
             />
         )
     }
@@ -132,8 +132,8 @@ const InnerStream = <RawDatum extends StreamDatum>({
         layerById.axes = (
             <Axes
                 key="axes"
-                xScale={xScale as any}
-                yScale={yScale as any}
+                xScale={xScale}
+                yScale={yScale}
                 width={innerWidth}
                 height={innerHeight}
                 top={axisTop}

--- a/packages/stream/src/hooks.ts
+++ b/packages/stream/src/hooks.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 import { area, stack as d3Stack } from 'd3-shape'
-import { scaleLinear, scalePoint } from 'd3-scale'
 import {
     useTheme,
     usePropertyAccessor,
@@ -22,6 +21,7 @@ import {
     StreamSliceData,
 } from './types'
 import { defaultProps } from './props'
+import { createLinearScale, createPointScale } from '@nivo/scales'
 
 export const useStream = <RawDatum extends StreamDatum>({
     width,
@@ -95,13 +95,18 @@ export const useStream = <RawDatum extends StreamDatum>({
         const minValue = Math.min(...allMin)
         const maxValue = Math.max(...allMax)
 
-        return [
-            layers,
-            scalePoint<number>()
-                .domain(Array.from({ length: data.length }, (_, i) => i))
-                .range([0, width]),
-            scaleLinear().domain([minValue, maxValue]).range([height, 0]),
-        ]
+        const xScale = createPointScale(
+            { type: 'point' },
+            { all: Array.from({ length: data.length }, (_, i) => i), min: 0, max: data.length },
+            width
+        )
+        const yScale = createLinearScale(
+            { type: 'linear' },
+            { all: [minValue, maxValue], min: minValue, max: maxValue },
+            height,
+            'y'
+        )
+        return [layers, xScale, yScale]
     }, [stack, data, width, height])
 
     const theme = useTheme()

--- a/packages/stream/src/types.ts
+++ b/packages/stream/src/types.ts
@@ -14,12 +14,13 @@ import {
 import { AxisProps, GridValues } from '@nivo/axes'
 import { InheritedColorConfig, OrdinalColorScaleConfig } from '@nivo/colors'
 import { LegendProps } from '@nivo/legends'
+import { ScaleLinear, ScalePoint } from '@nivo/scales'
 
 export type StreamLayerId = 'grid' | 'axes' | 'layers' | 'dots' | 'slices' | 'legends'
 
 export interface StreamCustomLayerProps {
-    xScale: any
-    yScale: any
+    xScale: ScalePoint<number>
+    yScale: ScaleLinear<number>
     layers: StreamLayerData[]
     slices: StreamSliceData[]
 }


### PR DESCRIPTION
Fixes a typescript-related bug in a function that creates log scales (package `@nivo/scales`)

**Edited:** adjusts usage of scale-related ts types in packages @nivo/bar, @nivo/marimekko, @nivo/scatterplot, @nivo/stream 

## Context

The function `createLogScale` creates an object correctly. However, the way the object is returned at the end creates confusion for the TypeScript compiler, making it believe the object has an incorrect type. 

As an example, consider:

```
// prep
const mySpec: ScaleLogSpec = { type: 'log', min: 1, max: 1000 }
const myData = { all: [1, 1000], min: 1, max: 1000 }
// create scale objects
const myScale1: Scale<number, number> = createLogScale(mySpec, myData, 500, 'x') // gives error
const myScale2: Scale<any, any> = computeScale(mySpec, myData, 500, 'x')         // gives error  
```

Currently, the compiler gives errors, stating that outputs from `createLogScale` and from `computeScale` are incompatible with the types on the left-hand-side. The outputs actually carry all the right content - its just that the compiler is confused. The fix gives typescript a clearer indication about the returned object.

I tried to create unit tests that would yield an error before the fix and pass after the fix, but I couldn't manage. The reason is that this is problem appears only during builds of code like above. Putting such code in unit tests shows messages in an IDE, but executes without problems, regardless of the fix. To trigger an error, such code should be in the package src. However, `@nivo/scales` doesn't have/need such code in src. That pattern is found in other packages.


## Impact

The issue addressed by this fix is the likely cause why some nivo packages occasionally use castings like `xScale as any`. With this edit, such fragments could be replaced by `xScale as AnyScale` or even plain `xScale`. 

Affected packages are Bar, Marimekko, ScatterPlot, Stream. It could be relevant to Line once that is migrated to TypeScript (#1932). Swarmplot could be extended to support log scales, so this would be relevant there too. 

I can edit those packages and remove ~24 linting warnings. If so, changes would be dispersed across several packages. What do you think?

## Edited:

After discussion, scope expanded to update usage of typescript types for scale objects across packages.

- @nivo/scatterplot
  - removed "as any" in the context of scales
  
- @nivo/bar  
  - removed "as any" in the context of scales
  - added types to layer props. The Bar and BarCanvas components had comments conveying layer props were set to "any" because of issues with scales. I added an explicit type in both cases. There were some conflicts between the layer props being created in Bar and BarCanvas and the draft type definitions in `type.ts`. In those cases, I opted to include more fields in the layer props (not removing anything). Existing code that relies on these props should work as before.
  
  
- @nivo/marimekko
  - refactored creation of scales to use @nivo/scales rather than d3-scale. This is just so that scale objects conform to nivo types so that they can be passed to Axes and Grid.
  - updated package dependencies to add @nivo/scales and remove d3-scale
  - removed "as any" in the context of scales
  - added some simple tests

- @nivo/stream
  - refactored creation of scales to use @nivo/scales rather than d3-scale. Again, this is just so that objects conform to nivo types so that they can be passed to Axes and Grid.
  - updated package dependencies to remove d3-scale (@nivo/scales already present) 
  - removed "as any" in the context of scales

Some of the changes involve replacing `Scale<any, any>` by `AnyScale`. The latter is defined in @nivo/scales and it is actually the same as `Scale<any, any>`. The advantage is that `AnyScale` can now be restricted, if needed, in only one place.

Overall, the changes do not add external features and there should be no breaking changes. The number of warnings emited from `make packages-lint` decreased from 287 to 254.