### PR TITLE
fix(scatterplot) support multiple legends

### DIFF
--- a/packages/scatterplot/src/ScatterPlot.tsx
+++ b/packages/scatterplot/src/ScatterPlot.tsx
@@ -130,7 +130,6 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
             />
         )
     }
-    //console.log("nodes: "+JSON.stringify(nodes))
 
     if (layers.includes('nodes')) {
         layerById.nodes = (

--- a/packages/scatterplot/src/ScatterPlot.tsx
+++ b/packages/scatterplot/src/ScatterPlot.tsx
@@ -1,13 +1,13 @@
 import { createElement, Fragment, ReactNode, useMemo } from 'react'
 import { SvgWrapper, Container, useDimensions, CartesianMarkers } from '@nivo/core'
 import { Axes, Grid } from '@nivo/axes'
-import { BoxLegendSvg } from '@nivo/legends'
 import { useScatterPlot } from './hooks'
 import { svgDefaultProps } from './props'
 import { ScatterPlotAnnotations } from './ScatterPlotAnnotations'
 import { Nodes } from './Nodes'
 import { Mesh } from './Mesh'
 import { ScatterPlotDatum, ScatterPlotLayerId, ScatterPlotSvgProps } from './types'
+import { ScatterPlotLegends } from './ScatterPlotLegends'
 
 type InnerScatterPlotProps<RawDatum extends ScatterPlotDatum> = Omit<
     ScatterPlotSvgProps<RawDatum>,
@@ -39,6 +39,7 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
     axisLeft = svgDefaultProps.axisLeft,
     annotations = svgDefaultProps.annotations,
     isInteractive = svgDefaultProps.isInteractive,
+    initialHiddenIds = [],
     useMesh = svgDefaultProps.useMesh,
     debugMesh = svgDefaultProps.debugMesh,
     onMouseEnter,
@@ -48,6 +49,7 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
     tooltip = svgDefaultProps.tooltip,
     markers = svgDefaultProps.markers,
     legends = svgDefaultProps.legends,
+    legendLabel,
     role = svgDefaultProps.role,
     ariaLabel,
     ariaLabelledBy,
@@ -59,7 +61,7 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
         partialMargin
     )
 
-    const { xScale, yScale, nodes, legendData } = useScatterPlot<RawDatum>({
+    const { xScale, yScale, nodes, legendsData, toggleSerie } = useScatterPlot<RawDatum>({
         data,
         xScaleSpec,
         xFormat,
@@ -69,7 +71,10 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
         height: innerHeight,
         nodeId,
         nodeSize,
+        initialHiddenIds,
         colors,
+        legends,
+        legendLabel,
     })
 
     const customLayerProps = useMemo(
@@ -125,6 +130,7 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
             />
         )
     }
+    //console.log("nodes: "+JSON.stringify(nodes))
 
     if (layers.includes('nodes')) {
         layerById.nodes = (
@@ -184,15 +190,15 @@ const InnerScatterPlot = <RawDatum extends ScatterPlotDatum>({
     }
 
     if (layers.includes('legends')) {
-        layerById.legends = legends.map((legend, i) => (
-            <BoxLegendSvg
-                key={i}
-                {...legend}
-                containerWidth={innerWidth}
-                containerHeight={innerHeight}
-                data={legendData}
+        layerById.legends = (
+            <ScatterPlotLegends
+                key="legends"
+                width={innerWidth}
+                height={innerHeight}
+                legends={legendsData}
+                toggleSerie={toggleSerie}
             />
-        ))
+        )
     }
 
     return (

--- a/packages/scatterplot/src/ScatterPlotLegends.tsx
+++ b/packages/scatterplot/src/ScatterPlotLegends.tsx
@@ -1,0 +1,22 @@
+import { BoxLegendSvg } from '@nivo/legends'
+import { ScatterPlotLegendsProps } from './types'
+
+export const ScatterPlotLegends = ({
+    width,
+    height,
+    legends,
+    toggleSerie,
+}: ScatterPlotLegendsProps) => (
+    <>
+        {legends.map(([legend, data], i) => (
+            <BoxLegendSvg
+                key={i}
+                {...legend}
+                containerWidth={width}
+                containerHeight={height}
+                data={legend.data ?? data}
+                toggleSerie={legend.toggleSerie && toggleSerie}
+            />
+        ))}
+    </>
+)

--- a/packages/scatterplot/src/ScatterPlotLegends.tsx
+++ b/packages/scatterplot/src/ScatterPlotLegends.tsx
@@ -14,7 +14,7 @@ export const ScatterPlotLegends = ({
                 {...legend}
                 containerWidth={width}
                 containerHeight={height}
-                data={legend.data ?? data}
+                data={data}
                 toggleSerie={legend.toggleSerie && toggleSerie}
             />
         ))}

--- a/packages/scatterplot/src/hooks.ts
+++ b/packages/scatterplot/src/hooks.ts
@@ -1,10 +1,9 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useValueFormatter, usePropertyAccessor } from '@nivo/core'
 import { useOrdinalColorScale } from '@nivo/colors'
-import { computeXYScalesForSeries } from '@nivo/scales'
-import { LegendProps } from '@nivo/legends'
 import { useAnnotations } from '@nivo/annotations'
-import { computePoints, getNodeSizeGenerator } from './compute'
+import { LegendProps } from '@nivo/legends'
+import { computeRawSeriesPoints, computeStyledPoints, getNodeSizeGenerator } from './compute'
 import {
     ScatterPlotCommonProps,
     ScatterPlotDataProps,
@@ -13,6 +12,7 @@ import {
     ScatterPlotNodeData,
     ScatterPlotRawSerie,
 } from './types'
+import { computeLegendData, getBaseLegendData } from './legends'
 
 const useNodeSize = <RawDatum extends ScatterPlotDatum>(
     size: ScatterPlotCommonProps<RawDatum>['nodeSize']
@@ -54,72 +54,52 @@ export const useScatterPlot = <RawDatum extends ScatterPlotDatum>({
         )
     }, [])
 
-    const { series, xScale, yScale } = useMemo(
-        () =>
-            computeXYScalesForSeries<{ id: string | number }, RawDatum>(
-                data.filter(serie => !hiddenIds.includes(String(serie.id))),
-                xScaleSpec,
-                yScaleSpec,
-                width,
-                height
-            ),
-        [data, hiddenIds, xScaleSpec, yScaleSpec, width, height]
-    )
-
     const formatX = useValueFormatter(xFormat)
     const formatY = useValueFormatter(yFormat)
     const getNodeId = usePropertyAccessor(nodeId)
-    const rawNodes = useMemo(
-        () => computePoints<RawDatum>({ series, formatX, formatY, getNodeId }),
-        [series, formatX, formatY, getNodeId]
-    )
-
     const getNodeSize = useNodeSize<RawDatum>(nodeSize)
-
     const getColor = useOrdinalColorScale(colors, 'serieId')
     const getLegendLabel = usePropertyAccessor<ScatterPlotRawSerie<RawDatum>, string>(
         legendLabel ?? 'id'
     )
 
+    const { rawSeriesNodes, xScale, yScale } = useMemo(
+        () =>
+            computeRawSeriesPoints<RawDatum>({
+                data,
+                xScaleSpec,
+                yScaleSpec,
+                width,
+                height,
+                formatX,
+                formatY,
+                getNodeId,
+            }),
+        [data, xScaleSpec, yScaleSpec, width, height, formatX, formatY, getNodeId]
+    )
+
     const nodes: ScatterPlotNodeData<RawDatum>[] = useMemo(
         () =>
-            rawNodes.map(rawNode => ({
-                ...rawNode,
-                size: getNodeSize(rawNode),
-                color: getColor({ serieId: rawNode.serieId }),
-            })),
-        [rawNodes, getNodeSize, getColor]
+            computeStyledPoints<RawDatum>({
+                rawSeriesNodes,
+                hiddenIds,
+                getNodeSize,
+                getColor,
+            }).flat(),
+        [rawSeriesNodes, hiddenIds, getNodeSize, getColor]
     )
 
-    const legendData: ScatterPlotLegendDatum[] = useMemo(
-        () =>
-            data.map(d => {
-                const hidden = hiddenIds.includes(String(d.id))
-                return {
-                    id: d.id,
-                    label: getLegendLabel(d),
-                    color: hidden ? '#000' : getColor({ serieId: d.id }),
-                    hidden: hidden,
-                }
-            }),
-        [data, hiddenIds, getLegendLabel, getColor]
+    const baseLegendData: ScatterPlotLegendDatum[] = useMemo(
+        () => getBaseLegendData({ data, getLegendLabel, getColor }),
+        [data, getLegendLabel, getColor]
     )
-
     const legendsData: [LegendProps, ScatterPlotLegendDatum[]][] = useMemo(
         () =>
-            legends.map(legend => {
-                // for legend items, prefer to use provided array of items
-                // otherwise fallback to displaying info for all series from legendData
-                const computedData = legend.data
-                    ? legend.data.map(d => {
-                          const hidden = hiddenIds.includes(String(d.id))
-                          const color = hidden ? '#000' : getColor({ serieId: d.id }) ?? d.color
-                          return { id: d.id, label: String(d.label), color, hidden }
-                      })
-                    : legendData
-                return [legend, computedData]
-            }),
-        [legends, hiddenIds, legendData, getColor]
+            legends.map(legend => [
+                legend,
+                computeLegendData({ legend, baseLegendData, hiddenIds, getColor }),
+            ]),
+        [legends, baseLegendData, hiddenIds, getColor]
     )
 
     return {

--- a/packages/scatterplot/src/hooks.ts
+++ b/packages/scatterplot/src/hooks.ts
@@ -108,12 +108,16 @@ export const useScatterPlot = <RawDatum extends ScatterPlotDatum>({
     const legendsData: [LegendProps, ScatterPlotLegendDatum[]][] = useMemo(
         () =>
             legends.map(legend => {
-                legend.data = legend.data?.map(d => {
-                    const hidden = hiddenIds.includes(String(d.id))
-                    const color = hidden ? '#000' : getColor({ serieId: d.id })
-                    return { ...d, color, hidden }
-                })
-                return [legend, legendData]
+                // for legend items, prefer to use provided array of items
+                // otherwise fallback to displaying info for all series from legendData
+                const computedData = legend.data
+                    ? legend.data.map(d => {
+                          const hidden = hiddenIds.includes(String(d.id))
+                          const color = hidden ? '#000' : getColor({ serieId: d.id }) ?? d.color
+                          return { id: d.id, label: String(d.label), color, hidden }
+                      })
+                    : legendData
+                return [legend, computedData]
             }),
         [legends, hiddenIds, legendData, getColor]
     )

--- a/packages/scatterplot/src/legends.ts
+++ b/packages/scatterplot/src/legends.ts
@@ -1,0 +1,46 @@
+import {
+    ScatterPlotDataProps,
+    ScatterPlotDatum,
+    ScatterPlotLegendDatum,
+    ScatterPlotRawSerie,
+} from './types'
+import { OrdinalColorScale } from '@nivo/colors'
+import { LegendProps } from '@nivo/legends'
+
+export const getBaseLegendData = <RawDatum extends ScatterPlotDatum>({
+    data,
+    getLegendLabel,
+    getColor,
+}: {
+    data: ScatterPlotDataProps<RawDatum>['data']
+    getColor: OrdinalColorScale<{ serieId: string | number }>
+    getLegendLabel: (datum: ScatterPlotRawSerie<RawDatum>) => string
+}): ScatterPlotLegendDatum[] =>
+    data.map(d => {
+        return {
+            id: d.id,
+            label: getLegendLabel(d),
+            color: getColor({ serieId: d.id }),
+        }
+    })
+
+export const computeLegendData = ({
+    legend,
+    baseLegendData,
+    hiddenIds,
+    getColor,
+}: {
+    legend: LegendProps
+    baseLegendData: ScatterPlotLegendDatum[]
+    hiddenIds: string[]
+    getColor: OrdinalColorScale<{ serieId: string | number }>
+}): ScatterPlotLegendDatum[] => {
+    // attempt to use legend items specified in the legend spec
+    // otherwise default to displaying info on all series (from baseLegendData)
+    const data = legend.data ?? baseLegendData
+    return data.map(d => {
+        const hidden = hiddenIds.includes(String(d.id))
+        const color = hidden ? '#000' : getColor({ serieId: d.id }) ?? d.color
+        return { id: d.id, label: String(d.label), color, hidden }
+    })
+}

--- a/packages/scatterplot/src/types.ts
+++ b/packages/scatterplot/src/types.ts
@@ -29,7 +29,7 @@ export type ScatterPlotRawSerie<RawDatum extends ScatterPlotDatum> = {
     data: RawDatum[]
 }
 
-export interface ScatterPlotNodeData<RawDatum extends ScatterPlotDatum> {
+export interface ScatterPlotRawNodeData<RawDatum extends ScatterPlotDatum> {
     // absolute index, relative to all points in all series
     index: number
     // relative index, in a specific serie
@@ -44,9 +44,13 @@ export interface ScatterPlotNodeData<RawDatum extends ScatterPlotDatum> {
     y: number
     yValue: RawDatum['y']
     formattedY: string | number
+    data: RawDatum
+}
+
+export interface ScatterPlotNodeData<RawDatum extends ScatterPlotDatum>
+    extends ScatterPlotRawNodeData<RawDatum> {
     size: number
     color: string
-    data: RawDatum
 }
 
 export interface ScatterPlotNodeProps<RawDatum extends ScatterPlotDatum> {
@@ -119,8 +123,8 @@ export interface ScatterPlotDataProps<RawDatum extends ScatterPlotDatum> {
 export type ScatterPlotLegendDatum = {
     id: string | number
     label: string
-    hidden: boolean
     color: string
+    hidden?: boolean
 }
 
 // TO DO - replace this by an interface from @nivo/legends

--- a/packages/scatterplot/src/types.ts
+++ b/packages/scatterplot/src/types.ts
@@ -108,11 +108,27 @@ export interface ScatterPlotNodeDynamicSizeSpec {
 
 export type ScatterPlotMouseHandler<RawDatum extends ScatterPlotDatum> = (
     node: ScatterPlotNodeData<RawDatum>,
-    event: MouseEvent<any>
+    event: MouseEvent
 ) => void
 
 export interface ScatterPlotDataProps<RawDatum extends ScatterPlotDatum> {
     data: ScatterPlotRawSerie<RawDatum>[]
+}
+
+// TO DO - replace this by a type from @nivo/legends
+export type ScatterPlotLegendDatum = {
+    id: string | number
+    label: string
+    hidden: boolean
+    color: string
+}
+
+// TO DO - replace this by an interface from @nivo/legends
+export interface ScatterPlotLegendsProps {
+    width: number
+    height: number
+    legends: [LegendProps, ScatterPlotLegendDatum[]][]
+    toggleSerie: (id: string | number) => void
 }
 
 export type ScatterPlotCommonProps<RawDatum extends ScatterPlotDatum> = {
@@ -137,6 +153,7 @@ export type ScatterPlotCommonProps<RawDatum extends ScatterPlotDatum> = {
         | ScatterPlotNodeDynamicSizeSpec
         | PropertyAccessor<Omit<ScatterPlotNodeData<RawDatum>, 'size' | 'color'>, number>
     renderWrapper?: boolean
+    initialHiddenIds: string[]
     isInteractive: boolean
     useMesh: boolean
     debugMesh: boolean
@@ -147,6 +164,9 @@ export type ScatterPlotCommonProps<RawDatum extends ScatterPlotDatum> = {
     tooltip: ScatterPlotTooltip<RawDatum>
     annotations: AnnotationMatcher<ScatterPlotNodeData<RawDatum>>[]
     legends: LegendProps[]
+    legendLabel?:
+        | PropertyAccessor<ScatterPlotRawSerie<RawDatum>, string>
+        | ((serie: ScatterPlotRawSerie<RawDatum>) => string)
     role: string
     ariaLabel: AriaAttributes['aria-label']
     ariaLabelledBy: AriaAttributes['aria-labelledby']

--- a/packages/scatterplot/stories/ScatterPlot.stories.tsx
+++ b/packages/scatterplot/stories/ScatterPlot.stories.tsx
@@ -224,17 +224,14 @@ export const MultiLineLegend = () => {
                         {
                             id: 'girls low',
                             label: 'Low A',
-                            color: serieColors['girls low'],
                         },
                         {
                             id: 'girls med',
                             label: 'Med A',
-                            color: serieColors['girls med'],
                         },
                         {
                             id: 'girls high',
                             label: 'High A',
-                            color: serieColors['girls high'],
                         },
                     ],
                 },
@@ -250,17 +247,20 @@ export const MultiLineLegend = () => {
                         {
                             id: 'boys low',
                             label: 'Low B',
-                            color: serieColors['boys low'],
                         },
                         {
                             id: 'boys med',
                             label: 'Med B',
-                            color: serieColors['boys med'],
                         },
                         {
                             id: 'boys high',
                             label: 'High B',
-                            color: serieColors['boys high'],
+                            color: '#0000dd', // this should be over-ruled by the colors function
+                        },
+                        {
+                            id: 'another',
+                            label: 'Another label',
+                            color: '#dd0000', // this will be displayed as provided
                         },
                     ],
                 },

--- a/packages/scatterplot/stories/ScatterPlot.stories.tsx
+++ b/packages/scatterplot/stories/ScatterPlot.stories.tsx
@@ -143,7 +143,7 @@ const sampleData = [
 const commonProps = {
     width: 900,
     height: 500,
-    margin: { top: 24, right: 24, bottom: 80, left: 80 },
+    margin: { top: 24, right: 24, bottom: 110, left: 80 },
     nodeSize: 10,
     blendMode: 'multiply' as const,
     xFormat: (x: number) => `week ${x}`,
@@ -172,9 +172,102 @@ export const Default = () => <ScatterPlot<SampleDatum> {...commonProps} data={[s
 
 export const mutlipleSeries = () => <ScatterPlot<SampleDatum> {...commonProps} />
 
-export const alternativeColors = () => (
-    <ScatterPlot<SampleDatum> {...commonProps} colors={{ scheme: 'category10' }} />
-)
+export const alternativeColors = () => {
+    const customLabel = (obj: { id: string | number }) => {
+        const parts = String(obj.id).split(' ')
+        return parts[0] + ' (' + parts[1] + ')'
+    }
+    return (
+        <ScatterPlot<SampleDatum>
+            {...commonProps}
+            colors={{ scheme: 'category10' }}
+            legendLabel={customLabel}
+            legends={[
+                {
+                    anchor: 'bottom-left',
+                    direction: 'row',
+                    itemHeight: 18,
+                    itemWidth: 130,
+                    translateY: 60,
+                    toggleSerie: true,
+                    symbolShape: 'circle' as const,
+                },
+            ]}
+        />
+    )
+}
+
+export const MultiLineLegend = () => {
+    const serieColors: { [key: string]: string } = {
+        'girls low': '#e8c1a0',
+        'girls med': '#f47560',
+        'girls high': '#f1e15b',
+        'boys low': '#e8a838',
+        'boys med': '#61cdbb',
+        'boys high': '#97e3d5',
+    }
+    return (
+        <ScatterPlot<SampleDatum>
+            {...commonProps}
+            colors={d => serieColors[d.serieId as string]}
+            initialHiddenIds={['girls med', 'boys med']}
+            legends={[
+                {
+                    anchor: 'bottom-left',
+                    direction: 'row',
+                    itemHeight: 18,
+                    itemWidth: 100,
+                    translateY: 70,
+                    toggleSerie: true,
+                    symbolShape: 'circle' as const,
+                    data: [
+                        {
+                            id: 'girls low',
+                            label: 'Low A',
+                            color: serieColors['girls low'],
+                        },
+                        {
+                            id: 'girls med',
+                            label: 'Med A',
+                            color: serieColors['girls med'],
+                        },
+                        {
+                            id: 'girls high',
+                            label: 'High A',
+                            color: serieColors['girls high'],
+                        },
+                    ],
+                },
+                {
+                    anchor: 'bottom-left',
+                    direction: 'row',
+                    itemHeight: 18,
+                    itemWidth: 100,
+                    translateY: 94,
+                    toggleSerie: true,
+                    symbolShape: 'circle' as const,
+                    data: [
+                        {
+                            id: 'boys low',
+                            label: 'Low B',
+                            color: serieColors['boys low'],
+                        },
+                        {
+                            id: 'boys med',
+                            label: 'Med B',
+                            color: serieColors['boys med'],
+                        },
+                        {
+                            id: 'boys high',
+                            label: 'High B',
+                            color: serieColors['boys high'],
+                        },
+                    ],
+                },
+            ]}
+        />
+    )
+}
 
 export const usingTimeScales = () => (
     <ScatterPlot<{ x: string; y: number }>

--- a/packages/scatterplot/stories/ScatterPlotCanvas.stories.tsx
+++ b/packages/scatterplot/stories/ScatterPlotCanvas.stories.tsx
@@ -135,7 +135,7 @@ const sampleData = [
 const commonProps = {
     width: 900,
     height: 500,
-    margin: { top: 20, right: 20, bottom: 80, left: 80 },
+    margin: { top: 24, right: 24, bottom: 110, left: 24 },
     nodeSize: 10,
     axisBottom: {
         format: (x: number) => `week ${x}`,
@@ -167,6 +167,81 @@ export const MultipleSeries = () => <ScatterPlotCanvas<SampleDatum> {...commonPr
 export const AlternativeColors = () => (
     <ScatterPlotCanvas<SampleDatum> {...commonProps} colors={{ scheme: 'category10' }} />
 )
+
+export const MultiLineLegend = () => {
+    const serieColors: { [key: string]: string } = {
+        'girls low': '#e8c1a0',
+        'girls med': '#f47560',
+        'girls high': '#f1e15b',
+        'boys low': '#e8a838',
+        'boys med': '#61cdbb',
+        'boys high': '#97e3d5',
+    }
+    const legendLabel = (obj: { id: string | number }) => {
+        return 'Group: ' + obj.id
+    }
+    return (
+        <ScatterPlotCanvas<SampleDatum>
+            {...commonProps}
+            colors={d => serieColors[d.serieId as string]}
+            legendLabel={legendLabel}
+            legends={[
+                {
+                    anchor: 'bottom-left',
+                    direction: 'row',
+                    itemHeight: 20,
+                    itemWidth: 100,
+                    translateY: 70,
+                    toggleSerie: true,
+                    symbolShape: 'circle' as const,
+                    data: [
+                        {
+                            id: 'girls low',
+                            label: 'girls low',
+                            color: serieColors['girls low'],
+                        },
+                        {
+                            id: 'girls med',
+                            label: 'girls med',
+                            color: serieColors['girls med'],
+                        },
+                        {
+                            id: 'girls high',
+                            label: 'girls high',
+                            color: serieColors['girls high'],
+                        },
+                    ],
+                },
+                {
+                    anchor: 'bottom-left',
+                    direction: 'row',
+                    itemHeight: 20,
+                    itemWidth: 100,
+                    translateY: 96,
+                    toggleSerie: true,
+                    symbolShape: 'circle' as const,
+                    data: [
+                        {
+                            id: 'boys low',
+                            label: 'boys low',
+                            color: serieColors['boys low'],
+                        },
+                        {
+                            id: 'boys med',
+                            label: 'boys med',
+                            color: serieColors['boys med'],
+                        },
+                        {
+                            id: 'boys high',
+                            label: 'boys high',
+                            color: serieColors['boys high'],
+                        },
+                    ],
+                },
+            ]}
+        />
+    )
+}
 
 export const UsingTimeScales = () => (
     <ScatterPlotCanvas<{ x: string; y: number }>

--- a/packages/scatterplot/tests/ScatterPlot.test.tsx
+++ b/packages/scatterplot/tests/ScatterPlot.test.tsx
@@ -663,6 +663,99 @@ describe('annotations', () => {
     })
 })
 
+describe('legends', () => {
+    // dataset with multiple series
+    const seriesA: TestDatum[] = sampleData.map(d => ({ ...d, y: 0 * d.x }))
+    const seriesB = seriesA.map(d => ({ ...d, y: 1 * d.x }))
+    const seriesC = seriesA.map(d => ({ ...d, y: 2 * d.x }))
+    const seriesD = seriesA.map(d => ({ ...d, y: 3 * d.x }))
+    const multipleSeriesData = [
+        { id: 'A', data: seriesA },
+        { id: 'B', data: seriesB },
+        { id: 'C', data: seriesC },
+        { id: 'D', data: seriesD },
+    ]
+
+    it('generates a default legend', () => {
+        const wrapper = mount(
+            <ScatterPlot<TestDatum>
+                {...baseProps}
+                data={multipleSeriesData}
+                legends={[
+                    {
+                        anchor: 'bottom',
+                        direction: 'row',
+                        itemHeight: 20,
+                        itemWidth: 80,
+                        translateY: 70,
+                    },
+                ]}
+            />
+        )
+        const legend = wrapper.find('ScatterPlotLegends')
+        expect(legend).toHaveLength(1)
+        const labels = legend.find('text')
+        expect(labels).toHaveLength(4)
+    })
+
+    it('generates a custom legend', () => {
+        const customLabels = ['Alpha', 'Beta', 'Gamma', 'Delta']
+        const wrapper = mount(
+            <ScatterPlot<TestDatum>
+                {...baseProps}
+                data={multipleSeriesData}
+                legends={[
+                    {
+                        anchor: 'bottom',
+                        direction: 'row',
+                        itemHeight: 20,
+                        itemWidth: 80,
+                        translateY: 70,
+                        data: [
+                            {
+                                id: 'A',
+                                label: customLabels[0],
+                                color: '#990000',
+                            },
+                            {
+                                id: 'B',
+                                label: customLabels[1],
+                                color: '#ff0000',
+                            },
+                        ],
+                    },
+                    {
+                        anchor: 'bottom',
+                        direction: 'row',
+                        itemHeight: 20,
+                        itemWidth: 80,
+                        translateY: 90,
+                        data: [
+                            {
+                                id: 'C',
+                                label: customLabels[2],
+                                color: '#000099',
+                            },
+                            {
+                                id: 'D',
+                                label: customLabels[3],
+                                color: '#0000ff',
+                            },
+                        ],
+                    },
+                ]}
+            />
+        )
+        const legend = wrapper.find('ScatterPlotLegends')
+        expect(legend).toHaveLength(1)
+        const labels = legend.find('text')
+        expect(labels).toHaveLength(4)
+        labels.forEach((label, i) => {
+            expect(label.text()).toBe(customLabels[i])
+        })
+    })
+})
+
 describe('accessibility', () => {
     it('should forward root aria properties to the SVG element', () => {
         const wrapper = mount(

--- a/packages/scatterplot/tests/ScatterPlot.test.tsx
+++ b/packages/scatterplot/tests/ScatterPlot.test.tsx
@@ -715,12 +715,10 @@ describe('legends', () => {
                             {
                                 id: 'A',
                                 label: customLabels[0],
-                                color: '#990000',
                             },
                             {
                                 id: 'B',
                                 label: customLabels[1],
-                                color: '#ff0000',
                             },
                         ],
                     },
@@ -734,12 +732,10 @@ describe('legends', () => {
                             {
                                 id: 'C',
                                 label: customLabels[2],
-                                color: '#000099',
                             },
                             {
                                 id: 'D',
                                 label: customLabels[3],
-                                color: '#0000ff',
                             },
                         ],
                     },


### PR DESCRIPTION
Addresses #1962

Also provides custom legend labels and toggling visibility of series via the legend


## Background

Issue #1962 describes a scatterplot with multiple series. An attempt to create a legend that spans two lines doesn't work. This is because the chart ignores the manually-specified items under the `legends` prop.


## Change summary

This PR adds support for multi-line legends to @nivo/scatterplot. The fix applies to svg and canvas components (although legends in canvas lack some features, which is an existing limitation)

While editing the legend-handling code, I also added some new features. 

 - support for custom legend labels (new prop `legendLabel`) (svg and canvas)
 - support for toggling series by clicking on legend labels, similar to feature available in @nivo/bar (new prop `initialHiddenIds`) (svg only)

The custom labels and toggling are extras. These can be rolled back or saved for later if you prefer.

Other changes include:

 - some miscellaneous edits to fix linting warnings (e.g. missing dependencies in hooks)
 - unit tests for multi-line legends
 - updated storybook examples for multi-line legends and visibility toggling
 - some re-arrangement in calculations to reduce memory use and avoid redundant calculations when visibility changes (will also be relevant for supporting opacity)

## Example

The screenshot below is based on the dataset in the scatterplot storybook. The dataset has six series. Note the legend uses two lines, the labels are different than the series ids (not shown), two of the series are inactive/invisible. Manual legends can also contains unrelated items if needed.

![2022-05-26-multiline-legend](https://user-images.githubusercontent.com/7260190/170484654-1a13c784-43a0-48f1-ac29-7615c259346d.png)


