### PR TITLE
fix(arcs) skip generation of very small arcs

### DIFF
--- a/packages/arcs/src/ArcsLayer.tsx
+++ b/packages/arcs/src/ArcsLayer.tsx
@@ -5,6 +5,7 @@ import { DatumWithArcAndColor, ArcGenerator } from './types'
 import { useArcsTransition } from './useArcsTransition'
 import { ArcTransitionMode } from './arcTransitionMode'
 import { ArcMouseHandler, ArcShape, ArcShapeProps } from './ArcShape'
+import { useFilteredDataBySkipAngle } from './utils'
 
 export type ArcComponent<Datum extends DatumWithArcAndColor> = (
     props: ArcShapeProps<Datum>
@@ -22,6 +23,7 @@ interface ArcsLayerProps<Datum extends DatumWithArcAndColor> {
     onMouseLeave?: ArcMouseHandler<Datum>
     transitionMode: ArcTransitionMode
     component?: ArcComponent<Datum>
+    skipAngle?: number
 }
 
 export const ArcsLayer = <Datum extends DatumWithArcAndColor>({
@@ -36,10 +38,12 @@ export const ArcsLayer = <Datum extends DatumWithArcAndColor>({
     onMouseLeave,
     transitionMode,
     component = ArcShape,
+    skipAngle = 1e-7,
 }: ArcsLayerProps<Datum>) => {
     const theme = useTheme()
     const getBorderColor = useInheritedColor<Datum>(borderColor, theme)
 
+    const filteredData = useFilteredDataBySkipAngle(data, skipAngle)
     const { transition, interpolate } = useArcsTransition<
         Datum,
         {
@@ -47,7 +51,7 @@ export const ArcsLayer = <Datum extends DatumWithArcAndColor>({
             color: string
             borderColor: string
         }
-    >(data, transitionMode, {
+    >(filteredData, transitionMode, {
         enter: datum => ({
             opacity: 0,
             color: datum.color,

--- a/packages/pie/tests/Pie.test.tsx
+++ b/packages/pie/tests/Pie.test.tsx
@@ -249,6 +249,32 @@ describe('Pie', () => {
             expect(arc.prop('datum').arc.innerRadius).toEqual(200)
             expect(arc.prop('datum').arc.outerRadius).toEqual(400)
         })
+
+        it('should skip rendering very small slices', () => {
+            const data = JSON.parse(JSON.stringify(sampleData))
+            data.push({
+                id: 'small',
+                value: 1e-9,
+                color: '#000000',
+            })
+            const wrapper = mount(
+                <Pie
+                    width={800}
+                    height={400}
+                    data={data}
+                    arcLinkLabelsSkipAngle={1e-6}
+                    arcLabelsSkipAngle={1e-6}
+                    animate={false}
+                />
+            )
+            // there should be a path for each slice, but not for the very small slice
+            const paths = wrapper.find('Arcs').find('path')
+            expect(paths).toHaveLength(data.length - 1)
+            // there should be a label and numeric value label for each slice,
+            // but not for the very small slice
+            const labels = wrapper.find('text')
+            expect(labels).toHaveLength(2 * (data.length - 1))
+        })
     })
 
     describe('colors', () => {

--- a/packages/sunburst/tests/Sunburst.test.tsx
+++ b/packages/sunburst/tests/Sunburst.test.tsx
@@ -183,6 +183,22 @@ describe('Sunburst', () => {
             expect(layer.exists()).toBeTruthy()
             expect(layer.prop('arcGenerator').cornerRadius()()).toEqual(3)
         })
+
+        it('should skip rendering very small arcs', () => {
+            const smallChild = {
+                id: 'small',
+                value: 1e-9,
+                color: '#ffdd00',
+            }
+            const sampleDataWithSmallChild = JSON.parse(JSON.stringify(sampleData))
+            sampleDataWithSmallChild.children.push(smallChild)
+            const wrapper = mount(
+                <Sunburst width={400} height={400} data={sampleDataWithSmallChild} />
+            )
+            const paths = wrapper.find('Arcs').find('path')
+            expect(paths.exists()).toBeTruthy()
+            expect(paths).toHaveLength(5)
+        })
     })
 
     describe('colors', () => {
@@ -641,6 +657,27 @@ describe('Sunburst', () => {
             expect(customLayer.prop('centerY')).toEqual(200)
             expect(customLayer.prop('arcGenerator')).toBeDefined()
             expect(customLayer.prop('radius')).toEqual(200)
+        })
+
+        it('should provide layer info about all children, including small ones', () => {
+            const smallChild = {
+                id: 'small',
+                value: 1e-9,
+                color: '#ffdd00',
+            }
+            const sampleDataWithSmallChild = JSON.parse(JSON.stringify(sampleData))
+            sampleDataWithSmallChild.children.push(smallChild)
+            const CustomLayer = () => null
+            const wrapper = mount(
+                <Sunburst
+                    width={400}
+                    height={400}
+                    data={sampleDataWithSmallChild}
+                    layers={['arcs', 'arcLabels', CustomLayer]}
+                />
+            )
+            const customLayer = wrapper.find(CustomLayer)
+            expect(customLayer.prop('nodes')).toHaveLength(6)
         })
     })
 })


### PR DESCRIPTION
Addresses #942

## Background

Issue #942 reports unexpected behavior in the sunburst chart. When the data contains an element that should produce an extremely small arc, that arc can instead "flip around" and dominate the chart.

A similar effect can occur with the pie chart.

```js
const pieData = [
  {
    id: "A",
    value: 30
  },
  {
    id: "B",
    value: 20
  },
  {
    id: "C",
    value: 1e-9  // very small value compared to values in 'A' and 'B'
  }
];
```
Visualizing the above data in a donut chart produces:

<img src="https://user-images.githubusercontent.com/7260190/170758927-96cee6e4-4405-4b95-a6d9-37d7a0b82886.png" width=300 />

Slice C should be tiny or invisible, but instead the yellow color (third color in the nivo color scheme) dominates the visualization. 

https://codesandbox.io/s/stoic-cray-nfyf1n?file=/src/App.js

## Fix

The cause of this effect lies in `d3-shape`. The bug only affects arcs with rounded corners. I raised an [issue](https://github.com/d3/d3-shape/issues/199) to let them know. 

The proposed fix for nivo involves setting a nonzero angle threshold in the `@nivo/arcs` package. The arc renderer can now skip rendering arcs that would be too small to see. Fixing the arcs package automatically fixes issues in `@nivo/pie` and `@nivo/sunburst`.

The new threshold (now set to 1e-7 radians) is set via a prop `skipAngle` in `ArcsLayer`. The name matches a similar prop in `ArcLabelsLayer` and `ArcLinkLabelsLayer`. However, this prop is now 'hidden' inside the arcs package - there are no changes to the API for the Pie and Sunburst components. The justification for 'hiding' this threshold is that it should not have any impact on expected behavior of the chart - tiny slices are expected to be invisible, and this threshold ensures this is the case despite the bug in d3-shape.

The PR also includes some unit tests for the pie and sunburst packages.




