### PR TITLE
Include link's index in the React Component key when creating the SVG element

### DIFF
--- a/packages/sankey/src/SankeyLinks.tsx
+++ b/packages/sankey/src/SankeyLinks.tsx
@@ -59,7 +59,7 @@ export const SankeyLinks = <N extends DefaultNode, L extends DefaultLink>({
         <>
             {links.map(link => (
                 <SankeyLinksItem<N, L>
-                    key={`${link.source.id}.${link.target.id}`}
+                    key={`${link.source.id}.${link.target.id}.${link.index}`}
                     link={link}
                     layout={layout}
                     path={getLinkPath(link, linkContract)}

--- a/packages/sankey/src/SankeyLinksItem.tsx
+++ b/packages/sankey/src/SankeyLinksItem.tsx
@@ -32,7 +32,7 @@ export const SankeyLinksItem = <N extends DefaultNode, L extends DefaultLink>({
     isInteractive,
     onClick,
 }: SankeyLinksItemProps<N, L>) => {
-    const linkId = `${link.source.id}.${link.target.id}`
+    const linkId = `${link.source.id}.${link.target.id}.${link.index}`
 
     const { animate, config: springConfig } = useMotionConfig()
     const animatedPath = useAnimatedPath(path)


### PR DESCRIPTION
Code to support custom color gradients for multiple links between the same two nodes.
Also prevents the duplicate child key error when 2+ links attach to the same two nodes.

<img width="431" alt="image" src="https://user-images.githubusercontent.com/32400363/172858662-70d1a108-67ef-4242-896d-cb55cb454178.png">


<details><summary>(Screenshots) ResponsiveSankey: Link Color-Gradient Issue</summary>

#### Initial Sankey Chart w/ Multiple Links Between Nodes
<img width="450" alt="image" src="https://user-images.githubusercontent.com/32400363/172850000-ea82c5e1-9d1a-463b-b2bf-697f92217b7a.png">

#### Link 1: `endColor: "de77ae" // The 1st link's color gradient takes precedence`
<img width="450" alt="image" src="https://user-images.githubusercontent.com/32400363/172851725-6f354709-19d0-4291-9d47-2043cf068ddb.png">

#### Link 2: `endColor: "#92c5de" // this color is ignored`
<img width="450" alt="image" src="https://user-images.githubusercontent.com/32400363/172851779-3480eeb3-e5ad-4ca1-9c16-4c83a5feeedd.png">

#### Link 3: `endColor: "bcbddc" // this color is ignored`
<img width="450" alt="image" src="https://user-images.githubusercontent.com/32400363/172851854-2e1507ee-bd16-44d1-808b-5733bd8aea5a.png">

#### Link 4: `endColor: "97e3d5" // this color is ignored`
<img width="450" alt="image" src="https://user-images.githubusercontent.com/32400363/172851922-afd08e38-1320-4fff-a905-0b32fd080ff1.png">

#### Sankey Chart w/ Proposed Changes: ca335e6e560104dba126ef6d550e60913860f15b
<img width="450" alt="image" src="https://user-images.githubusercontent.com/32400363/172860832-f48c7273-7b92-40af-a41d-aa1e79a27f9e.png">
</details>

<details><summary><b><i>Code to Generate Bug</i></b></summary>
<p>

```javascript
import { ResponsiveSankey } from '@nivo/sankey';
import { BasicTooltip } from '@nivo/tooltip';

<ResponsiveSankey enableLinkGradient
    colors={(node) => node.nodeColor}
    linkTooltip={({ link }) => {
        const value = `(${link.linkLabel}) ${link.source.nodeLabel} > ${link.target.nodeLabel}: ${link.value}`;
        return <BasicTooltip enableChip color={link.endColor} value={value} />; 
    }}
    data={{
        nodes: [
            { id: "node1", nodeColor: "#e0e0e0", nodeLabel: "Node 1" },
            { id: "node2", nodeColor: "#e0e0e0", nodeLabel: "Node 2" }
        ],
        links: [
            {
                source: "node1",
                target: "node2",
                value: 5,
                linkLabel: "Link #1",
                startColor: "#e0e0e0",
                endColor: "#de77ae" // The 1st link's color gradient takes precedence
            },
            {
                source: "node1",
                target: "node2",
                value: 8,
                linkLabel: "Link #2",
                startColor: "#e0e0e0",
                endColor: "#92c5de" // this color is ignored
            },
            {
                source: "node1",
                target: "node2",
                value: 3,
                linkLabel: "Link #3",
                startColor: "#e0e0e0",
                endColor: "#bcbddc" // this color is ignored
            },
            {
                source: "node1",
                target: "node2",
                value: 1,
                linkLabel: "Link #4",
                startColor: "#e0e0e0",
                endColor: "#97e3d5" // this color is ignored
            }
        ]
    }}
/>
```

</p>
</summary>