### PR TITLE
Upgrade package constraints to include React 18

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/arcs/package.json
+++ b/packages/arcs/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "@nivo/core": "0.79.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@nivo/core": "0.79.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@nivo/tooltip": "0.79.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -30,8 +30,8 @@
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0",
+    "react-dom": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@nivo/core": "0.79.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/legends/package.json
+++ b/packages/legends/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@nivo/core": "0.79.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@nivo/core": "0.79.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "@nivo/core": "0.79.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pie/package.json
+++ b/packages/pie/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/polar-axes/package.json
+++ b/packages/polar-axes/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/radial-bar/package.json
+++ b/packages/radial-bar/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/recompose/package.json
+++ b/packages/recompose/package.json
@@ -32,7 +32,7 @@
     "@types/react-lifecycles-compat": "^3.0.1"
   },
   "peerDependencies": {
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -39,8 +39,8 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0",
+    "react-dom": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sunburst/package.json
+++ b/packages/sunburst/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/voronoi/package.json
+++ b/packages/voronoi/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@nivo/core": "0.79.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/waffle/package.json
+++ b/packages/waffle/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "@nivo/core": "0.79.0",
     "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0 < 19.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This upgrades the package constraints, but does not update the version used for development in the repo (see https://github.com/plouc/nivo/issues/1964#issuecomment-1165480391).

Ref #1964
Fixes #1967