### PR TITLE
feat(choropleth): add defs and fill capabilities

### DIFF
--- a/packages/geo/src/Choropleth.js
+++ b/packages/geo/src/Choropleth.js
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 import { memo, Fragment, useCallback } from 'react'
-import { SvgWrapper, withContainer, useDimensions, useTheme } from '@nivo/core'
+import { SvgWrapper, withContainer, useDimensions, useTheme, bindDefs } from '@nivo/core'
 import { BoxLegendSvg } from '@nivo/legends'
 import { useTooltip } from '@nivo/tooltip'
 import { ChoroplethPropTypes, ChoroplethDefaultProps } from './props'
@@ -44,6 +44,10 @@ const Choropleth = memo(
         onClick,
         tooltip: Tooltip,
         role,
+
+        defs = ChoroplethDefaultProps.defs,
+        fill = ChoroplethDefaultProps.fill
+
     }) => {
         const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
         const { graticule, path, getBorderWidth, getBorderColor } = useGeoMap({
@@ -70,6 +74,11 @@ const Choropleth = memo(
         })
 
         const theme = useTheme()
+
+        const boundDefs = bindDefs(defs, boundFeatures, fill, {
+            dataKey: 'data',
+            targetKey: 'fill',
+        })
 
         const { showTooltipFromEvent, hideTooltip } = useTooltip()
         const handleClick = useCallback(
@@ -101,6 +110,7 @@ const Choropleth = memo(
                 height={outerHeight}
                 margin={margin}
                 theme={theme}
+                defs={boundDefs}
                 role={role}
             >
                 {layers.map((layer, i) => {

--- a/packages/geo/src/Choropleth.js
+++ b/packages/geo/src/Choropleth.js
@@ -44,10 +44,8 @@ const Choropleth = memo(
         onClick,
         tooltip: Tooltip,
         role,
-
         defs = ChoroplethDefaultProps.defs,
-        fill = ChoroplethDefaultProps.fill
-
+        fill = ChoroplethDefaultProps.fill,
     }) => {
         const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
         const { graticule, path, getBorderWidth, getBorderColor } = useGeoMap({

--- a/packages/geo/src/GeoMapFeature.js
+++ b/packages/geo/src/GeoMapFeature.js
@@ -24,7 +24,7 @@ const GeoMapFeature = memo(
         return (
             <path
                 key={feature.id}
-                fill={fillColor}
+                fill={feature?.fill ?? fillColor}
                 strokeWidth={borderWidth}
                 stroke={borderColor}
                 strokeLinejoin="bevel"

--- a/packages/geo/src/props.js
+++ b/packages/geo/src/props.js
@@ -106,7 +106,7 @@ const commonDefaultProps = {
     legends: [],
 
     fill: [],
-    defs: []
+    defs: [],
 }
 
 export const GeoMapDefaultProps = {

--- a/packages/geo/src/props.js
+++ b/packages/geo/src/props.js
@@ -104,6 +104,9 @@ const commonDefaultProps = {
 
     layers: ['graticule', 'features'],
     legends: [],
+
+    fill: [],
+    defs: []
 }
 
 export const GeoMapDefaultProps = {

--- a/website/src/pages/choropleth/index.tsx
+++ b/website/src/pages/choropleth/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import omit from 'lodash/omit'
-import { patternDotsDef, patternLinesDef } from '@nivo/core'
+import { patternDotsDef, patternLinesDef, linearGradientDef } from '@nivo/core'
 import { ResponsiveChoropleth, ChoroplethDefaultProps } from '@nivo/geo'
 import { ComponentTemplate } from '../../components/components/ComponentTemplate'
 import meta from '../../data/components/choropleth/meta.yml'
@@ -61,11 +61,16 @@ const initialProperties = {
             lineWidth: 6,
             spacing: 10,
         }),
+        linearGradientDef('gradient', [
+            { offset: 0, color: '#000' },
+            { offset: 100, color: 'inherit' },
+        ])
       ],
 
       fill:[
         { match: { id: 'CAN' }, id: 'dots' },
         { match: { id: 'CHN' }, id: 'lines' },
+        { match: { id: 'ATA' }, id: 'gradient' },
       ],
 
     legends: [

--- a/website/src/pages/choropleth/index.tsx
+++ b/website/src/pages/choropleth/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import omit from 'lodash/omit'
+import { patternDotsDef, patternLinesDef } from '@nivo/core'
 import { ResponsiveChoropleth, ChoroplethDefaultProps } from '@nivo/geo'
 import { ComponentTemplate } from '../../components/components/ComponentTemplate'
 import meta from '../../data/components/choropleth/meta.yml'
@@ -44,6 +45,28 @@ const initialProperties = {
     isInteractive: true,
     'custom tooltip example': false,
     tooltip: null,
+
+    defs: [
+        patternDotsDef('dots', {
+            background: 'inherit',
+            color: '#38bcb2',
+            size: 4,
+            padding: 1,
+            stagger: true,
+        }),
+        patternLinesDef('lines', {
+            background: 'inherit',
+            color: '#eed312',
+            rotation: -45,
+            lineWidth: 6,
+            spacing: 10,
+        }),
+      ],
+
+      fill:[
+        { match: { id: 'CAN' }, id: 'dots' },
+        { match: { id: 'CHN' }, id: 'lines' },
+      ],
 
     legends: [
         {

--- a/website/src/pages/choropleth/index.tsx
+++ b/website/src/pages/choropleth/index.tsx
@@ -64,14 +64,14 @@ const initialProperties = {
         linearGradientDef('gradient', [
             { offset: 0, color: '#000' },
             { offset: 100, color: 'inherit' },
-        ])
-      ],
+        ]),
+    ],
 
-      fill:[
+    fill: [
         { match: { id: 'CAN' }, id: 'dots' },
         { match: { id: 'CHN' }, id: 'lines' },
         { match: { id: 'ATA' }, id: 'gradient' },
-      ],
+    ],
 
     legends: [
         {


### PR DESCRIPTION
## Background

Event if it's in the [documentation](https://nivo.rocks/choropleth/), the usage of `defs` and `fill` was missing its implementation in the Choropleth Map component.

This PR adds this features, addressing issues #2068 (and the old #864) and, with a little workaround, also the first question of #2064 (it's enough to define a gradient with the same starting and ending color to achieve what was asked).

## Changelog

As was done in other components, now the Choropleth component read the `defs` and `fill`, uses the `bindDefs` method to bind them to the data, and pass them to the `SvgWrapper` component.
Then, each map `features` check is there's a `fill` property defined. If so it uses as fill color, otherwise it uses the calculated color.

## Example

This PR also adds three example patterns to the Nivo Website:

```javascript
defs: [
  patternDotsDef('dots', {
      background: 'inherit',
      color: '#38bcb2',
      size: 4,
      padding: 1,
      stagger: true,
  }),
  patternLinesDef('lines', {
      background: 'inherit',
      color: '#eed312',
      rotation: -45,
      lineWidth: 6,
      spacing: 10,
  }),
  linearGradientDef('gradient', [
      { offset: 0, color: '#000' },
      { offset: 100, color: 'inherit' },
  ]),
],

fill: [
  { match: { id: 'CAN' }, id: 'dots' },
  { match: { id: 'CHN' }, id: 'lines' },
  { match: { id: 'ATA' }, id: 'gradient' },
]
```
![Schermata del 2022-07-11 15-48-15](https://user-images.githubusercontent.com/11871906/178280929-88bf8a71-eb51-459a-9ef3-260800e71c17.png)

