### PR TITLE
Align d3-shape version on bar with other packages

### DIFF
--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -37,7 +37,7 @@
     "@nivo/tooltip": "0.79.0",
     "@react-spring/web": "9.4.5",
     "d3-scale": "^3.2.3",
-    "d3-shape": "^1.2.2",
+    "d3-shape": "^1.3.5",
     "lodash": "^4.17.21"
   },
   "devDependencies": {


### PR DESCRIPTION
I've been facing hoisting issues while using nivo on a monorepo app with Lerna / Yarn workspaces, leading to runtime errors due to an incorrect React context, probably because the `@nivo/core` module was duplicated at the root of the app and inside each project.

Wondering if that could be because `@nivo/bar` is not using the same minor version for `d3-shape` as other packages.