### PR TITLE
feat(bump): prevent setting active ids when event.preventDefault() is called.

### DIFF
--- a/packages/bump/src/area-bump/hooks.ts
+++ b/packages/bump/src/area-bump/hooks.ts
@@ -277,8 +277,7 @@ export const useAreaBumpSerieHandlers = <
         event => {
             showTooltipFromEvent(createElement(tooltip, { serie }), event)
             onMouseEnter && onMouseEnter(serie, event)
-            if(!event.defaultPrevented)
-                setActiveSerieIds([serie.id])
+            if (!event.defaultPrevented) setActiveSerieIds([serie.id])
         },
         [serie, onMouseEnter, showTooltipFromEvent, setActiveSerieIds, tooltip]
     )
@@ -295,8 +294,7 @@ export const useAreaBumpSerieHandlers = <
         event => {
             hideTooltip()
             onMouseLeave && onMouseLeave(serie, event)
-            if(!event.defaultPrevented)
-                setActiveSerieIds([])
+            if (!event.defaultPrevented) setActiveSerieIds([])
         },
         [serie, onMouseLeave, hideTooltip, setActiveSerieIds]
     )

--- a/packages/bump/src/area-bump/hooks.ts
+++ b/packages/bump/src/area-bump/hooks.ts
@@ -276,8 +276,9 @@ export const useAreaBumpSerieHandlers = <
     const handleMouseEnter = useCallback(
         event => {
             showTooltipFromEvent(createElement(tooltip, { serie }), event)
-            setActiveSerieIds([serie.id])
             onMouseEnter && onMouseEnter(serie, event)
+            if(!event.defaultPrevented)
+                setActiveSerieIds([serie.id])
         },
         [serie, onMouseEnter, showTooltipFromEvent, setActiveSerieIds, tooltip]
     )
@@ -293,8 +294,9 @@ export const useAreaBumpSerieHandlers = <
     const handleMouseLeave = useCallback(
         event => {
             hideTooltip()
-            setActiveSerieIds([])
             onMouseLeave && onMouseLeave(serie, event)
+            if(!event.defaultPrevented)
+                setActiveSerieIds([])
         },
         [serie, onMouseLeave, hideTooltip, setActiveSerieIds]
     )

--- a/packages/bump/src/bump/hooks.ts
+++ b/packages/bump/src/bump/hooks.ts
@@ -330,8 +330,7 @@ export const useBumpSerieHandlers = <
         event => {
             showTooltipFromEvent(createElement(tooltip, { serie }), event)
             onMouseEnter && onMouseEnter(serie, event)
-            if(!event.defaultPrevented)
-                setActiveSerieIds([serie.id])
+            if (!event.defaultPrevented) setActiveSerieIds([serie.id])
         },
         [serie, onMouseEnter, showTooltipFromEvent, setActiveSerieIds, tooltip]
     )
@@ -348,8 +347,7 @@ export const useBumpSerieHandlers = <
         event => {
             hideTooltip()
             onMouseLeave && onMouseLeave(serie, event)
-            if(!event.defaultPrevented)
-                setActiveSerieIds([])
+            if (!event.defaultPrevented) setActiveSerieIds([])
         },
         [serie, onMouseLeave, hideTooltip, setActiveSerieIds]
     )

--- a/packages/bump/src/bump/hooks.ts
+++ b/packages/bump/src/bump/hooks.ts
@@ -329,8 +329,9 @@ export const useBumpSerieHandlers = <
     const handleMouseEnter = useCallback(
         event => {
             showTooltipFromEvent(createElement(tooltip, { serie }), event)
-            setActiveSerieIds([serie.id])
             onMouseEnter && onMouseEnter(serie, event)
+            if(!event.defaultPrevented)
+                setActiveSerieIds([serie.id])
         },
         [serie, onMouseEnter, showTooltipFromEvent, setActiveSerieIds, tooltip]
     )
@@ -346,8 +347,9 @@ export const useBumpSerieHandlers = <
     const handleMouseLeave = useCallback(
         event => {
             hideTooltip()
-            setActiveSerieIds([])
             onMouseLeave && onMouseLeave(serie, event)
+            if(!event.defaultPrevented)
+                setActiveSerieIds([])
         },
         [serie, onMouseLeave, hideTooltip, setActiveSerieIds]
     )


### PR DESCRIPTION
For bump & area bump graphs, prevent setting the activeSerieIds if you call preventDefault() on the event.

This is useful if you want to only have interactivity (hovering + highlighting) activate for only specific areas / lines, and not all of them.

So, adding something like the following to <Bump /> or <AreaBump /> will no longer cause the other serie data to go inactive, but only for the specific serie you specify.
```js
onMouseEnter={(d, e) => {
    if (d.id === `Serie 5`) e.preventDefault();
}}
```

Example:
https://codesandbox.io/s/nivo-forked-g2f5fj?file=/src/charts/Bump.tsx
