### PR TITLE
Radial labels in Sunburst Chart using custom layers

### DIFF
--- a/packages/sunburst/stories/sunburst.stories.tsx
+++ b/packages/sunburst/stories/sunburst.stories.tsx
@@ -236,7 +236,7 @@ stories.add('radial labels using custom layer', () => {
                     let endAngle = (nodeArc.endAngle * 180) / Math.PI
 
                     if (endAngle - startAngle < arcLabelSkip) return <></>
-                    if (startAngle === 0 && endAngle === 360) endAngle = 90
+                    if (startAngle === 0 && endAngle > 359) endAngle = 90
 
                     const radius = (nodeArc.innerRadius + nodeArc.outerRadius) / 2
                     let dName = describeArc(ctx.centerX, ctx.centerY, radius, startAngle, endAngle)
@@ -272,7 +272,7 @@ stories.add('radial labels using custom layer', () => {
         const start = polarToCartesian(x, y, radius, startAngle)
         const end = polarToCartesian(x, y, radius, endAngle)
 
-        const largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1'
+        const largeArcFlag = Math.abs(endAngle - startAngle) <= 180 ? '0' : '1'
 
         const d = [
             'M',

--- a/packages/sunburst/stories/sunburst.stories.tsx
+++ b/packages/sunburst/stories/sunburst.stories.tsx
@@ -9,7 +9,6 @@ import { generateLibTree } from '@nivo/generators'
 import { colorSchemes } from '@nivo/colors'
 // @ts-ignore
 import { Sunburst, ComputedDatum, SunburstCustomLayerProps } from '../src'
-import React from 'react'
 
 interface RawDatum {
     name: string


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
I made a custom layer for the Sunburst chart to show the labels as radial labels

Describe the solution you'd like
- I'm thinking in adding it to the storybook as an other example.
![image](https://user-images.githubusercontent.com/63461656/182962621-5908b5a6-cdf2-48f2-ab25-4d0489337415.png)

- I also included the "CenteredMetric" custom layer inside the story so it shows in the story book docs
![image](https://user-images.githubusercontent.com/63461656/182963137-e01c87c7-5023-44d6-a812-63ee992834c5.png)



This will be my first contribution :smile: 
Awesome charts!