### PR TITLE
fix:(tooltip): set default value for useSpring

### DIFF
--- a/packages/tooltip/src/TooltipWrapper.tsx
+++ b/packages/tooltip/src/TooltipWrapper.tsx
@@ -79,7 +79,7 @@ export const TooltipWrapper = memo<PropsWithChildren<TooltipWrapperProps>>(
         const style = {
             ...tooltipStyle,
             ...theme.tooltip,
-            transform: animatedProps.transform ?? translate(x, y),
+            transform: animatedProps?.transform ?? translate(x, y),
         }
 
         return (


### PR DESCRIPTION
Sets the TooltipWrapper components animateProps variable to a default value in case useSpring returns undefined