### PR TITLE
fix:(axes): set default value for useSpring

### DIFF
--- a/packages/axes/src/components/Axis.tsx
+++ b/packages/axes/src/components/Axis.tsx
@@ -95,13 +95,14 @@ const Axis = <Value extends ScaleValue>({
 
     const { animate, config: springConfig } = useMotionConfig()
 
-    const animatedProps = useSpring({
-        transform: `translate(${x},${y})`,
-        lineX2: axis === 'x' ? length : 0,
-        lineY2: axis === 'x' ? 0 : length,
-        config: springConfig,
-        immediate: !animate,
-    })
+    const animatedProps =
+        useSpring({
+            transform: `translate(${x},${y})`,
+            lineX2: axis === 'x' ? length : 0,
+            lineY2: axis === 'x' ? 0 : length,
+            config: springConfig,
+            immediate: !animate,
+        }) || {}
 
     const transition = useTransition<
         typeof ticks[0],


### PR DESCRIPTION
Sets the Axes components animateProps variable to a default value in case useSpring returns undefined