### PR TITLE
Fix rendering error on nivo-express

### DIFF
--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -25,7 +25,7 @@ forOwn(chartsMapping, ({ schema }, type: ChartType) => {
 
         storage.set(id, {
             type,
-            props,
+            props: props.value,
             url,
         })
 


### PR DESCRIPTION
The props for the chart were saved with an incorrect structure ({ value: props } instead of { props } ), making impossible to render the chart later