### PR TITLE
feat(calendar): added prop, weekdayLegend, which allows consumers to customize the weekday labels (proof of concept)

### DIFF
--- a/packages/calendar/src/CalendarWeekdayLegends.tsx
+++ b/packages/calendar/src/CalendarWeekdayLegends.tsx
@@ -1,0 +1,21 @@
+import { memo } from 'react'
+import { CalendarWeekdayLegendsProps } from './types'
+
+export const CalendarWeekdayLegends = memo(({ weekdays, legend, theme }: CalendarWeekdayLegendsProps) => {
+    return (
+        <>
+            {weekdays.map((weekday, weekdayIndex) => {
+                return (
+                    <text
+                        key={weekday.value}
+                        transform={`translate(${weekday.x},${weekday.y}) rotate(${weekday.rotation})`}
+                        textAnchor="left"
+                        style={theme.labels.text}
+                    >
+                        {legend(weekdayIndex)}
+                    </text>
+                )
+            })}
+        </>
+    )
+})

--- a/packages/calendar/src/TimeRange.tsx
+++ b/packages/calendar/src/TimeRange.tsx
@@ -11,6 +11,7 @@ import {
 import { useMonthLegends, useColorScale } from './hooks'
 import { TimeRangeDay } from './TimeRangeDay'
 import { CalendarMonthLegends } from './CalendarMonthLegends'
+import { CalendarWeekdayLegends } from "./CalendarWeekdayLegends"
 import { TimeRangeSvgProps } from './types'
 import { timeRangeDefaultProps } from './props'
 
@@ -36,6 +37,7 @@ const InnerTimeRange = ({
     monthLegendOffset = timeRangeDefaultProps.monthLegendOffset,
     monthLegendPosition = timeRangeDefaultProps.monthLegendPosition,
 
+    weekdayLegend = timeRangeDefaultProps.weekdayLegend,
     weekdayLegendOffset = timeRangeDefaultProps.weekdayLegendOffset,
     weekdayTicks,
 
@@ -131,16 +133,7 @@ const InnerTimeRange = ({
 
     return (
         <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} role={role}>
-            {weekdayLegends.map(legend => (
-                <text
-                    key={legend.value}
-                    transform={`translate(${legend.x},${legend.y}) rotate(${legend.rotation})`}
-                    textAnchor="left"
-                    style={theme.labels.text}
-                >
-                    {legend.value}
-                </text>
-            ))}
+            <CalendarWeekdayLegends weekdays={weekdayLegends} legend={weekdayLegend} theme={theme} />
             {days.map(d => {
                 return (
                     <TimeRangeDay

--- a/packages/calendar/src/props.ts
+++ b/packages/calendar/src/props.ts
@@ -1,6 +1,6 @@
 import { timeFormat } from 'd3-time-format'
-import { CalendarLegendProps } from './types'
 import { CalendarTooltip } from './CalendarTooltip'
+import { CalendarLegendProps } from './types'
 
 const monthLabelFormat = timeFormat('%b')
 
@@ -52,4 +52,5 @@ export const timeRangeDefaultProps = {
     dayRadius: 0,
     square: true,
     weekdayLegendOffset: 75,
+    weekdayLegend: (weekday: number) => ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][weekday],
 } as const

--- a/packages/calendar/src/types.ts
+++ b/packages/calendar/src/types.ts
@@ -66,6 +66,17 @@ export type CalendarMonthLegendsProps = {
     theme: CompleteTheme
 }
 
+export type CalendarWeekdayLegendsProps = {
+    legend: (weekdayIndex: number) => string | number
+    weekdays: {
+        value: string;
+        rotation: number;
+        y: number;
+        x: number;
+    }[];
+    theme: CompleteTheme
+}
+
 export type CalendarTooltipProps = {
     value: string
     day: string
@@ -212,6 +223,7 @@ export type TimeRangeSvgProps = Dimensions & { data: CalendarDatum[] } & Partial
                 role: string
                 weekdayLegendOffset: number
                 weekdayTicks: Array<0 | 1 | 2 | 3 | 4 | 5 | 6>
+                weekdayLegend: (weekdayIndex: number) => string | number
             }
     >
 


### PR DESCRIPTION
Relates to #2213 .

**Note**: I was not able to setup the local dev environment properly on my machine, so this code is _untested_. It's really just a proof of concept to open up the discussion around the related issue.

- [x] Added new prop on TimeRange: `weekdayLegend` (`(weekdayIndex: number) => string | number`)
- [x] Moved weekday legend mapping to a new component, `CalendarWeekdayLegends`
- [x] Implemented `weekdayLegend` prop on new `CalendarWeekdayLegends` component
- [x] Added default fallback value for `weekdayLegend` prop.
- [x] Updated interfaces
 
Consider this PR a draft. Requirements being:

* Owner needs to approve issue/feature request
* PR needs to be tested and code-approved
* `CalendarWeekdayLegends` should probably also be implemented in `Calendar` component, for consistency. 
* Documentation needs to be updated (?)

