### PR TITLE
Check if ResizeObserver is defined instead of checking window object

### DIFF
--- a/packages/core/src/hooks/useMeasure.js
+++ b/packages/core/src/hooks/useMeasure.js
@@ -11,10 +11,9 @@ export const useMeasure = () => {
     })
 
     const [observer] = useState(() => {
-        // Check if window is defined (so if in the browser or in node.js).
-        const isBrowser = typeof window !== 'undefined'
-        if (!isBrowser) return null
-
+        // Check if ResizeObserver is defined in current env (could be browser, node.js, jsdom etc.).
+        if (typeof ResizeObserver === 'undefined') return null        
+        
         return new ResizeObserver(([entry]) => setBounds(entry.contentRect))
     })
 

--- a/packages/core/src/hooks/useMeasure.js
+++ b/packages/core/src/hooks/useMeasure.js
@@ -12,8 +12,8 @@ export const useMeasure = () => {
 
     const [observer] = useState(() => {
         // Check if ResizeObserver is defined in current env (could be browser, node.js, jsdom etc.).
-        if (typeof ResizeObserver === 'undefined') return null        
-        
+        if (typeof ResizeObserver === 'undefined') return null
+
         return new ResizeObserver(([entry]) => setBounds(entry.contentRect))
     })
 


### PR DESCRIPTION
**ResizeObserver** is not implemented in all environments, for example, [jsdom](https://github.com/jsdom/jsdom/issues/3368).
This forces nivo library consumers to mock or add polyfils, for example [jest.setup.js](https://github.com/plouc/nivo/blob/1867b606111ad1253cadb7e3cbcab2663c3275c5/packages/jest.setup.js).

Checking for global ResizeObserver removes the need to have it on the global window object.