### PR TITLE
bugfix: fix CustomLayerProps lineGenerator type by removing unnecessary Array type

### DIFF
--- a/packages/line/index.d.ts
+++ b/packages/line/index.d.ts
@@ -69,7 +69,7 @@ declare module '@nivo/line' {
     export interface CustomLayerProps extends Omit<LineSvgProps, 'xScale' | 'yScale'> {
         innerHeight: number
         innerWidth: number
-        lineGenerator: D3Line<Array<ComputedDatum['position']>>
+        lineGenerator: D3Line<ComputedDatum['position']>
         points: Point[]
         series: ComputedSerie[]
         xScale: Scale<unknown, unknown>


### PR DESCRIPTION
Fixes #1604