### PR TITLE
Allow custom choice of ticksPosition

### DIFF
--- a/packages/axes/src/components/Axes.tsx
+++ b/packages/axes/src/components/Axes.tsx
@@ -36,7 +36,7 @@ export const Axes = memo(
                     if (!axis) return null
 
                     const isXAxis = position === 'top' || position === 'bottom'
-                    const ticksPosition =
+                    const ticksPosition = axis.ticksPosition ? axis.ticksPosition :
                         position === 'top' || position === 'left' ? 'before' : 'after'
 
                     return (


### PR DESCRIPTION
The `ticksPosition` value is ignored in the `Axes` class. This commit first checks to see if one is set on the axis properties and prefers that, or else defaults to the old behavior.