### PR TITLE
bugfix: added string to theme.fontSize to prevent TypeScript warning

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -61,7 +61,7 @@ declare module '@nivo/core' {
         }
         background: string
         fontFamily: string
-        fontSize: number
+        fontSize: string | number
         textColor: string
         axis: {
             domain: {


### PR DESCRIPTION
Currently using strings to set the font size will raise a TypeScript warning.