### PR TITLE
Specify CJS vs ESM exports for @nivo/colors package

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -14,6 +14,20 @@
     "main": "./dist/nivo-colors.cjs.js",
     "module": "./dist/nivo-colors.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        ".": {
+            "require": "./dist/nivo-colors.cjs.js",
+            "import": "./dist/nivo-colors.es.js"
+        },
+        "./dist/nivo-colors.cjs.js": {
+            "require": "./dist/nivo-colors.cjs.js",
+            "default": "./dist/nivo-colors.cjs.js"
+        },
+        "./dist/nivo-colors.es.js": {
+            "import": "./dist/nivo-colors.es.js",
+            "default": "./dist/nivo-colors.es.js"
+        }
+    },
     "files": [
         "README.md",
         "LICENSE.md",


### PR DESCRIPTION
TypeScript has difficulty in trying to import @nivo/colors as an ESM module. This is because `"main"` in @nivo/colors `package.json` is specified as `"./dist/nivo-colors.cjs.js"`.

This PR adds an `exports` field to the @nivo/colors `package.json` in order for TypeScript to be able to resolve the ESM module when declaring:

```ts
import { getContinuousColorScale } from '@nivo/colors';
```

If this is a welcome change, I am happy to update other Nivo packages accordingly.