### PR TITLE
fix: Relax constraints on `@react-spring/web`

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -1,45 +1,45 @@
 {
-  "name": "@nivo/annotations",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/annotations"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "charts",
-    "annotations"
-  ],
-  "main": "./dist/nivo-annotations.cjs.js",
-  "module": "./dist/nivo-annotations.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/colors": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/annotations",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/annotations"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "charts",
+        "annotations"
+    ],
+    "main": "./dist/nivo-annotations.cjs.js",
+    "module": "./dist/nivo-annotations.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/colors": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -1,45 +1,45 @@
 {
-    "name": "@nivo/annotations",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/annotations"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "charts",
-        "annotations"
-    ],
-    "main": "./dist/nivo-annotations.cjs.js",
-    "module": "./dist/nivo-annotations.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/colors": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/annotations",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/annotations"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "charts",
+    "annotations"
+  ],
+  "main": "./dist/nivo-annotations.cjs.js",
+  "module": "./dist/nivo-annotations.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/colors": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/arcs/package.json
+++ b/packages/arcs/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "@nivo/arcs",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/arcs"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "arcs"
-  ],
-  "main": "./dist/nivo-arcs.cjs.js",
-  "module": "./dist/nivo-arcs.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/colors": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-shape": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/arcs",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/arcs"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "arcs"
+    ],
+    "main": "./dist/nivo-arcs.cjs.js",
+    "module": "./dist/nivo-arcs.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/colors": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-shape": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/arcs/package.json
+++ b/packages/arcs/package.json
@@ -1,46 +1,46 @@
 {
-    "name": "@nivo/arcs",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/arcs"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "arcs"
-    ],
-    "main": "./dist/nivo-arcs.cjs.js",
-    "module": "./dist/nivo-arcs.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/colors": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-shape": "^2.0.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/arcs",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/arcs"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "arcs"
+  ],
+  "main": "./dist/nivo-arcs.cjs.js",
+  "module": "./dist/nivo-arcs.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/colors": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-shape": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -1,48 +1,48 @@
 {
-  "name": "@nivo/axes",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/axes"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "axes"
-  ],
-  "main": "./dist/nivo-axes.cjs.js",
-  "module": "./dist/nivo-axes.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/scales": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-format": "^1.4.4",
-    "d3-time-format": "^3.0.0"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-format": "^1.4.1",
-    "@types/d3-time-format": "^2.3.1"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/axes",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/axes"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "axes"
+    ],
+    "main": "./dist/nivo-axes.cjs.js",
+    "module": "./dist/nivo-axes.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/scales": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-format": "^1.4.4",
+        "d3-time-format": "^3.0.0"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "prop-types": ">= 15.5.10 < 16.0.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "@nivo/axes",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/axes"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "axes"
-    ],
-    "main": "./dist/nivo-axes.cjs.js",
-    "module": "./dist/nivo-axes.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/scales": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-format": "^1.4.4",
-        "d3-time-format": "^3.0.0"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-format": "^1.4.1",
-        "@types/d3-time-format": "^2.3.1"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/axes",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/axes"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "axes"
+  ],
+  "main": "./dist/nivo-axes.cjs.js",
+  "module": "./dist/nivo-axes.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/scales": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-format": "^1.4.4",
+    "d3-time-format": "^3.0.0"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-format": "^1.4.1",
+    "@types/d3-time-format": "^2.3.1"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -1,53 +1,53 @@
 {
-    "name": "@nivo/bar",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/bar"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "bar-chart"
-    ],
-    "main": "./dist/nivo-bar.cjs.js",
-    "module": "./dist/nivo-bar.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-scale": "^3.2.3",
-        "d3-shape": "^1.3.5",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/bar",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/bar"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "bar-chart"
+  ],
+  "main": "./dist/nivo-bar.cjs.js",
+  "module": "./dist/nivo-bar.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/annotations": "0.80.0",
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-scale": "^3.2.3",
+    "d3-shape": "^1.3.5",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -1,53 +1,53 @@
 {
-  "name": "@nivo/bar",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/bar"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "bar-chart"
-  ],
-  "main": "./dist/nivo-bar.cjs.js",
-  "module": "./dist/nivo-bar.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/annotations": "0.80.0",
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3",
-    "d3-shape": "^1.3.5",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/bar",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/bar"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "bar-chart"
+    ],
+    "main": "./dist/nivo-bar.cjs.js",
+    "module": "./dist/nivo-bar.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/annotations": "0.80.0",
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-scale": "^3.2.3",
+        "d3-shape": "^1.3.5",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "@nivo/bullet",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/bullet"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "bullet-chart"
-    ],
-    "main": "./dist/nivo-bullet.cjs.js",
-    "module": "./dist/nivo-bullet.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/bullet",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/bullet"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "bullet-chart"
+  ],
+  "main": "./dist/nivo-bullet.cjs.js",
+  "module": "./dist/nivo-bullet.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -1,48 +1,48 @@
 {
-  "name": "@nivo/bullet",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/bullet"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "bullet-chart"
-  ],
-  "main": "./dist/nivo-bullet.cjs.js",
-  "module": "./dist/nivo-bullet.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/bullet",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/bullet"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "bullet-chart"
+    ],
+    "main": "./dist/nivo-bullet.cjs.js",
+    "module": "./dist/nivo-bullet.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -1,51 +1,51 @@
 {
-    "name": "@nivo/bump",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/bump"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "bump-chart",
-        "area-bump-chart"
-    ],
-    "main": "./dist/nivo-bump.cjs.js",
-    "module": "./dist/nivo-bump.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/bump",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/bump"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "bump-chart",
+    "area-bump-chart"
+  ],
+  "main": "./dist/nivo-bump.cjs.js",
+  "module": "./dist/nivo-bump.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -1,51 +1,51 @@
 {
-  "name": "@nivo/bump",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/bump"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "bump-chart",
-    "area-bump-chart"
-  ],
-  "main": "./dist/nivo-bump.cjs.js",
-  "module": "./dist/nivo-bump.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/bump",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/bump"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "bump-chart",
+        "area-bump-chart"
+    ],
+    "main": "./dist/nivo-bump.cjs.js",
+    "module": "./dist/nivo-bump.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -1,51 +1,51 @@
 {
-    "name": "@nivo/chord",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/chord"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "chord-diagram"
-    ],
-    "main": "./dist/nivo-chord.cjs.js",
-    "module": "./dist/nivo-chord.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/arcs": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-chord": "^1.0.6",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-chord": "^3.0.1"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/chord",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/chord"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "chord-diagram"
+  ],
+  "main": "./dist/nivo-chord.cjs.js",
+  "module": "./dist/nivo-chord.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/arcs": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-chord": "^1.0.6",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-chord": "^3.0.1"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -1,51 +1,51 @@
 {
-  "name": "@nivo/chord",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/chord"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "chord-diagram"
-  ],
-  "main": "./dist/nivo-chord.cjs.js",
-  "module": "./dist/nivo-chord.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/arcs": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-chord": "^1.0.6",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-chord": "^3.0.1"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/chord",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/chord"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "chord-diagram"
+    ],
+    "main": "./dist/nivo-chord.cjs.js",
+    "module": "./dist/nivo-chord.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/arcs": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-chord": "^1.0.6",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-chord": "^3.0.1"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -1,49 +1,49 @@
 {
-    "name": "@nivo/circle-packing",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/circle-packing"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "circle-packing"
-    ],
-    "main": "./dist/nivo-circle-packing.cjs.js",
-    "module": "./dist/nivo-circle-packing.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/colors": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-hierarchy": "^1.1.8",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-hierarchy": "^1.1.7"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/circle-packing",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/circle-packing"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "circle-packing"
+  ],
+  "main": "./dist/nivo-circle-packing.cjs.js",
+  "module": "./dist/nivo-circle-packing.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/colors": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-hierarchy": "^1.1.8",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-hierarchy": "^1.1.7"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -1,49 +1,49 @@
 {
-  "name": "@nivo/circle-packing",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/circle-packing"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "circle-packing"
-  ],
-  "main": "./dist/nivo-circle-packing.cjs.js",
-  "module": "./dist/nivo-circle-packing.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/colors": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-hierarchy": "^1.1.8",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-hierarchy": "^1.1.7"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/circle-packing",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/circle-packing"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "circle-packing"
+    ],
+    "main": "./dist/nivo-circle-packing.cjs.js",
+    "module": "./dist/nivo-circle-packing.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/colors": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-hierarchy": "^1.1.8",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-hierarchy": "^1.1.7"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "@nivo/core",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/core"
-  },
-  "main": "./dist/nivo-core.cjs.js",
-  "module": "./dist/nivo-core.es.js",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "index.d.ts",
-    "dist/"
-  ],
-  "dependencies": {
-    "@nivo/recompose": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-color": "^3.1.0",
-    "d3-format": "^1.4.4",
-    "d3-interpolate": "^2.0.1",
-    "d3-scale": "^3.2.3",
-    "d3-scale-chromatic": "^2.0.0",
-    "d3-shape": "^1.3.5",
-    "d3-time-format": "^3.0.0",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/tooltip": "0.80.0",
-    "@types/d3-shape": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@nivo/tooltip": "0.80.0",
-    "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/core",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/core"
+    },
+    "main": "./dist/nivo-core.cjs.js",
+    "module": "./dist/nivo-core.es.js",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "index.d.ts",
+        "dist/"
+    ],
+    "dependencies": {
+        "@nivo/recompose": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.3",
+        "d3-scale-chromatic": "^2.0.0",
+        "d3-shape": "^1.3.5",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/tooltip": "0.80.0",
+        "@types/d3-shape": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@nivo/tooltip": "0.80.0",
+        "prop-types": ">= 15.5.10 < 16.0.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,46 +1,46 @@
 {
-    "name": "@nivo/core",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/core"
-    },
-    "main": "./dist/nivo-core.cjs.js",
-    "module": "./dist/nivo-core.es.js",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "index.d.ts",
-        "dist/"
-    ],
-    "dependencies": {
-        "@nivo/recompose": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^2.0.1",
-        "d3-scale": "^3.2.3",
-        "d3-scale-chromatic": "^2.0.0",
-        "d3-shape": "^1.3.5",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/tooltip": "0.80.0",
-        "@types/d3-shape": "^2.0.0"
-    },
-    "peerDependencies": {
-        "@nivo/tooltip": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/core",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/core"
+  },
+  "main": "./dist/nivo-core.cjs.js",
+  "module": "./dist/nivo-core.es.js",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "index.d.ts",
+    "dist/"
+  ],
+  "dependencies": {
+    "@nivo/recompose": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-color": "^3.1.0",
+    "d3-format": "^1.4.4",
+    "d3-interpolate": "^2.0.1",
+    "d3-scale": "^3.2.3",
+    "d3-scale-chromatic": "^2.0.0",
+    "d3-shape": "^1.3.5",
+    "d3-time-format": "^3.0.0",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/tooltip": "0.80.0",
+    "@types/d3-shape": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@nivo/tooltip": "0.80.0",
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -1,49 +1,49 @@
 {
-  "name": "@nivo/funnel",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/funnel"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "funnel"
-  ],
-  "main": "./dist/nivo-funnel.cjs.js",
-  "module": "./dist/nivo-funnel.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/annotations": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/funnel",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/funnel"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "funnel"
+    ],
+    "main": "./dist/nivo-funnel.cjs.js",
+    "module": "./dist/nivo-funnel.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/annotations": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-scale": "^3.2.3",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -1,49 +1,49 @@
 {
-    "name": "@nivo/funnel",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/funnel"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "funnel"
-    ],
-    "main": "./dist/nivo-funnel.cjs.js",
-    "module": "./dist/nivo-funnel.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-scale": "^3.2.3",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/funnel",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/funnel"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "funnel"
+  ],
+  "main": "./dist/nivo-funnel.cjs.js",
+  "module": "./dist/nivo-funnel.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/annotations": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-scale": "^3.2.3",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -1,50 +1,50 @@
 {
-  "name": "@nivo/heatmap",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/heatmap"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "heatmap"
-  ],
-  "main": "./dist/nivo-heatmap.cjs.js",
-  "module": "./dist/nivo-heatmap.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/annotations": "0.80.0",
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/heatmap",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/heatmap"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "heatmap"
+    ],
+    "main": "./dist/nivo-heatmap.cjs.js",
+    "module": "./dist/nivo-heatmap.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/annotations": "0.80.0",
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-scale": "^3.2.3"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -1,50 +1,50 @@
 {
-    "name": "@nivo/heatmap",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/heatmap"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "heatmap"
-    ],
-    "main": "./dist/nivo-heatmap.cjs.js",
-    "module": "./dist/nivo-heatmap.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-scale": "^3.2.3"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/heatmap",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/heatmap"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "heatmap"
+  ],
+  "main": "./dist/nivo-heatmap.cjs.js",
+  "module": "./dist/nivo-heatmap.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/annotations": "0.80.0",
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-scale": "^3.2.3"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -1,52 +1,52 @@
 {
-    "name": "@nivo/line",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/line"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "line-chart"
-    ],
-    "main": "./dist/nivo-line.cjs.js",
-    "module": "./dist/nivo-line.es.js",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "index.d.ts",
-        "dist/"
-    ],
-    "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@nivo/voronoi": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/line",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/line"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "line-chart"
+  ],
+  "main": "./dist/nivo-line.cjs.js",
+  "module": "./dist/nivo-line.es.js",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "index.d.ts",
+    "dist/"
+  ],
+  "dependencies": {
+    "@nivo/annotations": "0.80.0",
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@nivo/voronoi": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -1,52 +1,52 @@
 {
-  "name": "@nivo/line",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/line"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "line-chart"
-  ],
-  "main": "./dist/nivo-line.cjs.js",
-  "module": "./dist/nivo-line.es.js",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "index.d.ts",
-    "dist/"
-  ],
-  "dependencies": {
-    "@nivo/annotations": "0.80.0",
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@nivo/voronoi": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/line",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/line"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "line-chart"
+    ],
+    "main": "./dist/nivo-line.cjs.js",
+    "module": "./dist/nivo-line.es.js",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "index.d.ts",
+        "dist/"
+    ],
+    "dependencies": {
+        "@nivo/annotations": "0.80.0",
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@nivo/voronoi": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "prop-types": ">= 15.5.10 < 16.0.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -1,43 +1,43 @@
 {
-    "name": "@nivo/marimekko",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/marimekko"
-    },
-    "main": "./dist/nivo-marimekko.cjs.js",
-    "module": "./dist/nivo-marimekko.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-shape": "^1.3.5",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-shape": "^2.0.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/marimekko",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/marimekko"
+  },
+  "main": "./dist/nivo-marimekko.cjs.js",
+  "module": "./dist/nivo-marimekko.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-shape": "^1.3.5",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-shape": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -1,43 +1,43 @@
 {
-  "name": "@nivo/marimekko",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/marimekko"
-  },
-  "main": "./dist/nivo-marimekko.cjs.js",
-  "module": "./dist/nivo-marimekko.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-shape": "^1.3.5",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-shape": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/marimekko",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/marimekko"
+    },
+    "main": "./dist/nivo-marimekko.cjs.js",
+    "module": "./dist/nivo-marimekko.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-shape": "^1.3.5",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-shape": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,50 +1,50 @@
 {
-  "name": "@nivo/network",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/network"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "graph",
-    "directed-layout",
-    "network"
-  ],
-  "main": "./dist/nivo-network.cjs.js",
-  "module": "./dist/nivo-network.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/annotations": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-force": "^2.0.1"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/network",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/network"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "graph",
+        "directed-layout",
+        "network"
+    ],
+    "main": "./dist/nivo-network.cjs.js",
+    "module": "./dist/nivo-network.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/annotations": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-force": "^2.0.1"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,50 +1,50 @@
 {
-    "name": "@nivo/network",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/network"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "graph",
-        "directed-layout",
-        "network"
-    ],
-    "main": "./dist/nivo-network.cjs.js",
-    "module": "./dist/nivo-network.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-force": "^2.0.1"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/network",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/network"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "graph",
+    "directed-layout",
+    "network"
+  ],
+  "main": "./dist/nivo-network.cjs.js",
+  "module": "./dist/nivo-network.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/annotations": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-force": "^2.0.1"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -1,49 +1,49 @@
 {
-    "name": "@nivo/parallel-coordinates",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/parallel-coordinates"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "parrallel-coordinates-chart"
-    ],
-    "main": "./dist/nivo-parallel-coordinates.cjs.js",
-    "module": "./dist/nivo-parallel-coordinates.es.js",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "index.d.ts",
-        "dist/"
-    ],
-    "dependencies": {
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-scale": "^3.2.3",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/parallel-coordinates",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/parallel-coordinates"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "parrallel-coordinates-chart"
+  ],
+  "main": "./dist/nivo-parallel-coordinates.cjs.js",
+  "module": "./dist/nivo-parallel-coordinates.es.js",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "index.d.ts",
+    "dist/"
+  ],
+  "dependencies": {
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-scale": "^3.2.3",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "prop-types": ">= 15.5.10 < 16.0.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -1,49 +1,49 @@
 {
-  "name": "@nivo/parallel-coordinates",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/parallel-coordinates"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "parrallel-coordinates-chart"
-  ],
-  "main": "./dist/nivo-parallel-coordinates.cjs.js",
-  "module": "./dist/nivo-parallel-coordinates.es.js",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "index.d.ts",
-    "dist/"
-  ],
-  "dependencies": {
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "prop-types": ">= 15.5.10 < 16.0.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/parallel-coordinates",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/parallel-coordinates"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "parrallel-coordinates-chart"
+    ],
+    "main": "./dist/nivo-parallel-coordinates.cjs.js",
+    "module": "./dist/nivo-parallel-coordinates.es.js",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "index.d.ts",
+        "dist/"
+    ],
+    "dependencies": {
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-scale": "^3.2.3",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "prop-types": ">= 15.5.10 < 16.0.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/polar-axes/package.json
+++ b/packages/polar-axes/package.json
@@ -1,45 +1,45 @@
 {
-    "name": "@nivo/polar-axes",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/polar-axes"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "axes",
-        "polar"
-    ],
-    "main": "./dist/nivo-polar-axes.cjs.js",
-    "module": "./dist/nivo-polar-axes.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/arcs": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@react-spring/web": "^9.4.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/polar-axes",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/polar-axes"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "axes",
+    "polar"
+  ],
+  "main": "./dist/nivo-polar-axes.cjs.js",
+  "module": "./dist/nivo-polar-axes.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/arcs": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/polar-axes/package.json
+++ b/packages/polar-axes/package.json
@@ -1,45 +1,45 @@
 {
-  "name": "@nivo/polar-axes",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/polar-axes"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "axes",
-    "polar"
-  ],
-  "main": "./dist/nivo-polar-axes.cjs.js",
-  "module": "./dist/nivo-polar-axes.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/arcs": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@react-spring/web": "9.4.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/polar-axes",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/polar-axes"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "axes",
+        "polar"
+    ],
+    "main": "./dist/nivo-polar-axes.cjs.js",
+    "module": "./dist/nivo-polar-axes.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/arcs": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@react-spring/web": "^9.4.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -1,49 +1,49 @@
 {
-    "name": "@nivo/radar",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/radar"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "radar-chart"
-    ],
-    "main": "./dist/nivo-radar.cjs.js",
-    "module": "./dist/nivo-radar.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-scale": "^3.2.3",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/radar",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/radar"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "radar-chart"
+  ],
+  "main": "./dist/nivo-radar.cjs.js",
+  "module": "./dist/nivo-radar.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-scale": "^3.2.3",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -1,49 +1,49 @@
 {
-  "name": "@nivo/radar",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/radar"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "radar-chart"
-  ],
-  "main": "./dist/nivo-radar.cjs.js",
-  "module": "./dist/nivo-radar.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/radar",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/radar"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "radar-chart"
+    ],
+    "main": "./dist/nivo-radar.cjs.js",
+    "module": "./dist/nivo-radar.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-scale": "^3.2.3",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/radial-bar/package.json
+++ b/packages/radial-bar/package.json
@@ -1,52 +1,52 @@
 {
-    "name": "@nivo/radial-bar",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/radial-bar"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "radial-bar-chart"
-    ],
-    "main": "./dist/nivo-radial-bar.cjs.js",
-    "module": "./dist/nivo-radial-bar.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/arcs": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/polar-axes": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-scale": "^3.2.3",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/radial-bar",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/radial-bar"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "radial-bar-chart"
+  ],
+  "main": "./dist/nivo-radial-bar.cjs.js",
+  "module": "./dist/nivo-radial-bar.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/arcs": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/polar-axes": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-scale": "^3.2.3",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/radial-bar/package.json
+++ b/packages/radial-bar/package.json
@@ -1,52 +1,52 @@
 {
-  "name": "@nivo/radial-bar",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/radial-bar"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "radial-bar-chart"
-  ],
-  "main": "./dist/nivo-radial-bar.cjs.js",
-  "module": "./dist/nivo-radial-bar.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/arcs": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/polar-axes": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/radial-bar",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/radial-bar"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "radial-bar-chart"
+    ],
+    "main": "./dist/nivo-radial-bar.cjs.js",
+    "module": "./dist/nivo-radial-bar.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/arcs": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/polar-axes": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-scale": "^3.2.3",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -1,51 +1,51 @@
 {
-    "name": "@nivo/sankey",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/sankey"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "sankey-diagram"
-    ],
-    "main": "./dist/nivo-sankey.cjs.js",
-    "module": "./dist/nivo-sankey.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-sankey": "^0.12.3",
-        "d3-shape": "^1.3.5",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-sankey": "^0.11.2"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/sankey",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/sankey"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "sankey-diagram"
+  ],
+  "main": "./dist/nivo-sankey.cjs.js",
+  "module": "./dist/nivo-sankey.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-sankey": "^0.12.3",
+    "d3-shape": "^1.3.5",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-sankey": "^0.11.2"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -1,51 +1,51 @@
 {
-  "name": "@nivo/sankey",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/sankey"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "sankey-diagram"
-  ],
-  "main": "./dist/nivo-sankey.cjs.js",
-  "module": "./dist/nivo-sankey.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-sankey": "^0.12.3",
-    "d3-shape": "^1.3.5",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-sankey": "^0.11.2"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/sankey",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/sankey"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "sankey-diagram"
+    ],
+    "main": "./dist/nivo-sankey.cjs.js",
+    "module": "./dist/nivo-sankey.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-sankey": "^0.12.3",
+        "d3-shape": "^1.3.5",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-sankey": "^0.11.2"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -1,56 +1,56 @@
 {
-  "name": "@nivo/scatterplot",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/scatterplot"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "scatterplot"
-  ],
-  "main": "./dist/nivo-scatterplot.cjs.js",
-  "module": "./dist/nivo-scatterplot.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/annotations": "0.80.0",
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@nivo/voronoi": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-scale": "^3.2.3",
-    "d3-shape": "^1.3.5",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-scale": "^3.2.2",
-    "@types/d3-shape": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/scatterplot",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/scatterplot"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "scatterplot"
+    ],
+    "main": "./dist/nivo-scatterplot.cjs.js",
+    "module": "./dist/nivo-scatterplot.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/annotations": "0.80.0",
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@nivo/voronoi": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-scale": "^3.2.3",
+        "d3-shape": "^1.3.5",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-scale": "^3.2.2",
+        "@types/d3-shape": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -1,56 +1,56 @@
 {
-    "name": "@nivo/scatterplot",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/scatterplot"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "scatterplot"
-    ],
-    "main": "./dist/nivo-scatterplot.cjs.js",
-    "module": "./dist/nivo-scatterplot.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@nivo/voronoi": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-scale": "^3.2.3",
-        "d3-shape": "^1.3.5",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-scale": "^3.2.2",
-        "@types/d3-shape": "^2.0.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/scatterplot",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/scatterplot"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "scatterplot"
+  ],
+  "main": "./dist/nivo-scatterplot.cjs.js",
+  "module": "./dist/nivo-scatterplot.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/annotations": "0.80.0",
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@nivo/voronoi": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-scale": "^3.2.3",
+    "d3-shape": "^1.3.5",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-scale": "^3.2.2",
+    "@types/d3-shape": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,51 +1,51 @@
 {
-    "name": "@nivo/stream",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/stream"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "stream-chart"
-    ],
-    "main": "./dist/nivo-stream.cjs.js",
-    "module": "./dist/nivo-stream.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-shape": "^1.3.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-shape": "^2.0.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/stream",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/stream"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "stream-chart"
+  ],
+  "main": "./dist/nivo-stream.cjs.js",
+  "module": "./dist/nivo-stream.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-shape": "^1.3.5"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-shape": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,51 +1,51 @@
 {
-  "name": "@nivo/stream",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/stream"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "stream-chart"
-  ],
-  "main": "./dist/nivo-stream.cjs.js",
-  "module": "./dist/nivo-stream.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-shape": "^1.3.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-shape": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/stream",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/stream"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "stream-chart"
+    ],
+    "main": "./dist/nivo-stream.cjs.js",
+    "module": "./dist/nivo-stream.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-shape": "^1.3.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-shape": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -1,57 +1,57 @@
 {
-    "name": "@nivo/swarmplot",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/swarmplot"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "force",
-        "swarmplot"
-    ],
-    "main": "./dist/nivo-swarmplot.cjs.js",
-    "module": "./dist/nivo-swarmplot.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@nivo/voronoi": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-force": "^2.0.1",
-        "d3-scale": "^3.2.3",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0",
-        "@types/d3-force": "^2.1.0",
-        "@types/d3-scale": "^3.2.2"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/swarmplot",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/swarmplot"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "force",
+    "swarmplot"
+  ],
+  "main": "./dist/nivo-swarmplot.cjs.js",
+  "module": "./dist/nivo-swarmplot.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/annotations": "0.80.0",
+    "@nivo/axes": "0.80.0",
+    "@nivo/colors": "0.80.0",
+    "@nivo/legends": "0.80.0",
+    "@nivo/scales": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@nivo/voronoi": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-force": "^2.0.1",
+    "d3-scale": "^3.2.3",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0",
+    "@types/d3-force": "^2.1.0",
+    "@types/d3-scale": "^3.2.2"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -1,57 +1,57 @@
 {
-  "name": "@nivo/swarmplot",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/swarmplot"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "force",
-    "swarmplot"
-  ],
-  "main": "./dist/nivo-swarmplot.cjs.js",
-  "module": "./dist/nivo-swarmplot.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/annotations": "0.80.0",
-    "@nivo/axes": "0.80.0",
-    "@nivo/colors": "0.80.0",
-    "@nivo/legends": "0.80.0",
-    "@nivo/scales": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@nivo/voronoi": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-force": "^2.0.1",
-    "d3-scale": "^3.2.3",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0",
-    "@types/d3-force": "^2.1.0",
-    "@types/d3-scale": "^3.2.2"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/swarmplot",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/swarmplot"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "force",
+        "swarmplot"
+    ],
+    "main": "./dist/nivo-swarmplot.cjs.js",
+    "module": "./dist/nivo-swarmplot.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/annotations": "0.80.0",
+        "@nivo/axes": "0.80.0",
+        "@nivo/colors": "0.80.0",
+        "@nivo/legends": "0.80.0",
+        "@nivo/scales": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@nivo/voronoi": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-force": "^2.0.1",
+        "d3-scale": "^3.2.3",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0",
+        "@types/d3-force": "^2.1.0",
+        "@types/d3-scale": "^3.2.2"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,35 +1,35 @@
 {
-    "name": "@nivo/tooltip",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/tooltip"
-    },
-    "main": "./dist/nivo-tooltip.cjs.js",
-    "module": "./dist/nivo-tooltip.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@react-spring/web": "^9.4.5"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/tooltip",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/tooltip"
+  },
+  "main": "./dist/nivo-tooltip.cjs.js",
+  "module": "./dist/nivo-tooltip.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@react-spring/web": "9.4.5 || ^9.7.2"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@nivo/tooltip",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/tooltip"
-  },
-  "main": "./dist/nivo-tooltip.cjs.js",
-  "module": "./dist/nivo-tooltip.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@react-spring/web": "9.4.5"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/tooltip",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/tooltip"
+    },
+    "main": "./dist/nivo-tooltip.cjs.js",
+    "module": "./dist/nivo-tooltip.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@react-spring/web": "^9.4.5"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "@nivo/treemap",
-    "version": "0.80.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/treemap"
-    },
-    "keywords": [
-        "nivo",
-        "dataviz",
-        "react",
-        "d3",
-        "charts",
-        "treemap-chart"
-    ],
-    "main": "./dist/nivo-treemap.cjs.js",
-    "module": "./dist/nivo-treemap.es.js",
-    "typings": "./dist/types/index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "dist/",
-        "!dist/tsconfig.tsbuildinfo"
-    ],
-    "dependencies": {
-        "@nivo/colors": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@react-spring/web": "^9.4.5",
-        "d3-hierarchy": "^1.1.8",
-        "lodash": "^4.17.21"
-    },
-    "devDependencies": {
-        "@nivo/core": "0.80.0"
-    },
-    "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "react": ">= 16.14.0 < 19.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@nivo/treemap",
+  "version": "0.80.0",
+  "license": "MIT",
+  "author": {
+    "name": "Raphaël Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/treemap"
+  },
+  "keywords": [
+    "nivo",
+    "dataviz",
+    "react",
+    "d3",
+    "charts",
+    "treemap-chart"
+  ],
+  "main": "./dist/nivo-treemap.cjs.js",
+  "module": "./dist/nivo-treemap.es.js",
+  "typings": "./dist/types/index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@nivo/colors": "0.80.0",
+    "@nivo/tooltip": "0.80.0",
+    "@react-spring/web": "9.4.5 || ^9.7.2",
+    "d3-hierarchy": "^1.1.8",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@nivo/core": "0.80.0"
+  },
+  "peerDependencies": {
+    "@nivo/core": "0.80.0",
+    "react": ">= 16.14.0 < 19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -1,48 +1,48 @@
 {
-  "name": "@nivo/treemap",
-  "version": "0.80.0",
-  "license": "MIT",
-  "author": {
-    "name": "Raphaël Benitte",
-    "url": "https://github.com/plouc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/plouc/nivo.git",
-    "directory": "packages/treemap"
-  },
-  "keywords": [
-    "nivo",
-    "dataviz",
-    "react",
-    "d3",
-    "charts",
-    "treemap-chart"
-  ],
-  "main": "./dist/nivo-treemap.cjs.js",
-  "module": "./dist/nivo-treemap.es.js",
-  "typings": "./dist/types/index.d.ts",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist/",
-    "!dist/tsconfig.tsbuildinfo"
-  ],
-  "dependencies": {
-    "@nivo/colors": "0.80.0",
-    "@nivo/tooltip": "0.80.0",
-    "@react-spring/web": "9.4.5",
-    "d3-hierarchy": "^1.1.8",
-    "lodash": "^4.17.21"
-  },
-  "devDependencies": {
-    "@nivo/core": "0.80.0"
-  },
-  "peerDependencies": {
-    "@nivo/core": "0.80.0",
-    "react": ">= 16.14.0 < 19.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@nivo/treemap",
+    "version": "0.80.0",
+    "license": "MIT",
+    "author": {
+        "name": "Raphaël Benitte",
+        "url": "https://github.com/plouc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/plouc/nivo.git",
+        "directory": "packages/treemap"
+    },
+    "keywords": [
+        "nivo",
+        "dataviz",
+        "react",
+        "d3",
+        "charts",
+        "treemap-chart"
+    ],
+    "main": "./dist/nivo-treemap.cjs.js",
+    "module": "./dist/nivo-treemap.es.js",
+    "typings": "./dist/types/index.d.ts",
+    "files": [
+        "README.md",
+        "LICENSE.md",
+        "dist/",
+        "!dist/tsconfig.tsbuildinfo"
+    ],
+    "dependencies": {
+        "@nivo/colors": "0.80.0",
+        "@nivo/tooltip": "0.80.0",
+        "@react-spring/web": "^9.4.5",
+        "d3-hierarchy": "^1.1.8",
+        "lodash": "^4.17.21"
+    },
+    "devDependencies": {
+        "@nivo/core": "0.80.0"
+    },
+    "peerDependencies": {
+        "@nivo/core": "0.80.0",
+        "react": ">= 16.14.0 < 19.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3792,51 +3792,51 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@react-spring/animated@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.4.5.tgz#dd9921c716a4f4a3ed29491e0c0c9f8ca0eb1a54"
-  integrity sha512-KWqrtvJSMx6Fj9nMJkhTwM9r6LIriExDRV6YHZV9HKQsaolUFppgkOXpC+rsL1JEtEvKv6EkLLmSqHTnuYjiIA==
+"@react-spring/animated@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.1.tgz#0f2d78184ee0cce703acd41abb87ea56765b5713"
+  integrity sha512-EX5KAD9y7sD43TnLeTNG1MgUVpuRO1YaSJRPawHNRgUWYfILge3s85anny4S4eTJGpdp5OoFV2kx9fsfeo0qsw==
   dependencies:
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
 
-"@react-spring/core@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.4.5.tgz#4616e1adc18dd10f5731f100ebdbe9518b89ba3c"
-  integrity sha512-83u3FzfQmGMJFwZLAJSwF24/ZJctwUkWtyPD7KYtNagrFeQKUH1I05ZuhmCmqW+2w1KDW1SFWQ43RawqfXKiiQ==
+"@react-spring/core@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.7.1.tgz#cfe176a48ee0a05545b1af5f2fbae718b50e9a99"
+  integrity sha512-8K9/FaRn5VvMa24mbwYxwkALnAAyMRdmQXrARZLcBW2vxLJ6uw9Cy3d06Z8M12kEqF2bDlccaCSDsn2bSz+Q4A==
   dependencies:
-    "@react-spring/animated" "~9.4.5"
-    "@react-spring/rafz" "~9.4.5"
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
+    "@react-spring/animated" "~9.7.1"
+    "@react-spring/rafz" "~9.7.1"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
 
-"@react-spring/rafz@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.4.5.tgz#84f809f287f2a66bbfbc66195db340482f886bd7"
-  integrity sha512-swGsutMwvnoyTRxvqhfJBtGM8Ipx6ks0RkIpNX9F/U7XmyPvBMGd3GgX/mqxZUpdlsuI1zr/jiYw+GXZxAlLcQ==
+"@react-spring/rafz@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.7.1.tgz#bdfea463fcb5ddc4e7253a8fa3870dd52ebbc59a"
+  integrity sha512-JSsrRfbEJvuE3w/uvU3mCTuWwpQcBXkwoW14lBgzK9XJhuxmscGo59AgJUpFkGOiGAVXFBGB+nEXtSinFsopgw==
 
-"@react-spring/shared@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.4.5.tgz#4c3ad817bca547984fb1539204d752a412a6d829"
-  integrity sha512-JhMh3nFKsqyag0KM5IIM8BQANGscTdd0mMv3BXsUiMZrcjQTskyfnv5qxEeGWbJGGar52qr5kHuBHtCjQOzniA==
+"@react-spring/shared@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.7.1.tgz#29611bb63d0c9e1ac18b6ced7aa4db1d48d136f3"
+  integrity sha512-R2kZ+VOO6IBeIAYTIA3C1XZ0ZVg/dDP5FKtWaY8k5akMer9iqf5H9BU0jyt3Qtxn0qQY7whQdf6MTcWtKeaawg==
   dependencies:
-    "@react-spring/rafz" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
+    "@react-spring/rafz" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
 
-"@react-spring/types@~9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.4.5.tgz#9c71e5ff866b5484a7ef3db822bf6c10e77bdd8c"
-  integrity sha512-mpRIamoHwql0ogxEUh9yr4TP0xU5CWyZxVQeccGkHHF8kPMErtDXJlxyo0lj+telRF35XNihtPTWoflqtyARmg==
+"@react-spring/types@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.1.tgz#b540752a479d210c6fb68d2b1d5ff35556df4308"
+  integrity sha512-yBcyfKUeZv9wf/ZFrQszvhSPuDx6Py6yMJzpMnS+zxcZmhXPeOCKZSHwqrUz1WxvuRckUhlgb7eNI/x5e1e8CA==
 
-"@react-spring/web@9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.4.5.tgz#b92f05b87cdc0963a59ee149e677dcaff09f680e"
-  integrity sha512-NGAkOtKmOzDEctL7MzRlQGv24sRce++0xAY7KlcxmeVkR7LRSGkoXHaIfm9ObzxPMcPHQYQhf3+X9jepIFNHQA==
+"@react-spring/web@^9.4.5":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.1.tgz#a9ee730d06c686b8432cd20f41683b1acb9b6300"
+  integrity sha512-6uUE5MyKqdrJnIJqlDN/AXf3i8PjOQzUuT26nkpsYxUGOk7c+vZVPcfrExLSoKzTb9kF0i66DcqzO5fXz/Z1AA==
   dependencies:
-    "@react-spring/animated" "~9.4.5"
-    "@react-spring/core" "~9.4.5"
-    "@react-spring/shared" "~9.4.5"
-    "@react-spring/types" "~9.4.5"
+    "@react-spring/animated" "~9.7.1"
+    "@react-spring/core" "~9.7.1"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
 
 "@rollup/plugin-babel@^5.2.0", "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3792,51 +3792,51 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@react-spring/animated@~9.7.1":
-  version "9.7.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.1.tgz#0f2d78184ee0cce703acd41abb87ea56765b5713"
-  integrity sha512-EX5KAD9y7sD43TnLeTNG1MgUVpuRO1YaSJRPawHNRgUWYfILge3s85anny4S4eTJGpdp5OoFV2kx9fsfeo0qsw==
+"@react-spring/animated@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.2.tgz#0119db8075e91d693ec45c42575541e01b104a70"
+  integrity sha512-ipvleJ99ipqlnHkz5qhSsgf/ny5aW0ZG8Q+/2Oj9cI7LCc7COdnrSO6V/v8MAX3JOoQNzfz6dye2s5Pt5jGaIA==
   dependencies:
-    "@react-spring/shared" "~9.7.1"
-    "@react-spring/types" "~9.7.1"
+    "@react-spring/shared" "~9.7.2"
+    "@react-spring/types" "~9.7.2"
 
-"@react-spring/core@~9.7.1":
-  version "9.7.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.7.1.tgz#cfe176a48ee0a05545b1af5f2fbae718b50e9a99"
-  integrity sha512-8K9/FaRn5VvMa24mbwYxwkALnAAyMRdmQXrARZLcBW2vxLJ6uw9Cy3d06Z8M12kEqF2bDlccaCSDsn2bSz+Q4A==
+"@react-spring/core@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.7.2.tgz#804ebadee45a6adff00886454d6f1c5d97ee219d"
+  integrity sha512-fF512edZT/gKVCA90ZRxfw1DmELeVwiL4OC2J6bMUlNr707C0h4QRoec6DjzG27uLX2MvS1CEatf9KRjwZR9/w==
   dependencies:
-    "@react-spring/animated" "~9.7.1"
-    "@react-spring/rafz" "~9.7.1"
-    "@react-spring/shared" "~9.7.1"
-    "@react-spring/types" "~9.7.1"
+    "@react-spring/animated" "~9.7.2"
+    "@react-spring/rafz" "~9.7.2"
+    "@react-spring/shared" "~9.7.2"
+    "@react-spring/types" "~9.7.2"
 
-"@react-spring/rafz@~9.7.1":
-  version "9.7.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.7.1.tgz#bdfea463fcb5ddc4e7253a8fa3870dd52ebbc59a"
-  integrity sha512-JSsrRfbEJvuE3w/uvU3mCTuWwpQcBXkwoW14lBgzK9XJhuxmscGo59AgJUpFkGOiGAVXFBGB+nEXtSinFsopgw==
+"@react-spring/rafz@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.7.2.tgz#77e7088c215e05cf893851cd87ceb40d89f2a7d7"
+  integrity sha512-kDWMYDQto3+flkrX3vy6DU/l9pxQ4TVW91DglQEc11iDc7shF4+WVDRJvOVLX+xoMP7zyag1dMvlIgvQ+dvA/A==
 
-"@react-spring/shared@~9.7.1":
-  version "9.7.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.7.1.tgz#29611bb63d0c9e1ac18b6ced7aa4db1d48d136f3"
-  integrity sha512-R2kZ+VOO6IBeIAYTIA3C1XZ0ZVg/dDP5FKtWaY8k5akMer9iqf5H9BU0jyt3Qtxn0qQY7whQdf6MTcWtKeaawg==
+"@react-spring/shared@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.7.2.tgz#b8485617bdcc9f6348b245922051fb534e07c566"
+  integrity sha512-6U9qkno+9DxlH5nSltnPs+kU6tYKf0bPLURX2te13aGel8YqgcpFYp5Av8DcN2x3sukinAsmzHUS/FRsdZMMBA==
   dependencies:
-    "@react-spring/rafz" "~9.7.1"
-    "@react-spring/types" "~9.7.1"
+    "@react-spring/rafz" "~9.7.2"
+    "@react-spring/types" "~9.7.2"
 
-"@react-spring/types@~9.7.1":
-  version "9.7.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.1.tgz#b540752a479d210c6fb68d2b1d5ff35556df4308"
-  integrity sha512-yBcyfKUeZv9wf/ZFrQszvhSPuDx6Py6yMJzpMnS+zxcZmhXPeOCKZSHwqrUz1WxvuRckUhlgb7eNI/x5e1e8CA==
+"@react-spring/types@~9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.2.tgz#e04dd72755d88b0e3163ba143ecd8ba78b68a5b0"
+  integrity sha512-GEflx2Ex/TKVMHq5g5MxQDNNPNhqg+4Db9m7+vGTm8ttZiyga7YQUF24shgRNebKIjahqCuei16SZga8h1pe4g==
 
-"@react-spring/web@^9.4.5":
-  version "9.7.1"
-  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.1.tgz#a9ee730d06c686b8432cd20f41683b1acb9b6300"
-  integrity sha512-6uUE5MyKqdrJnIJqlDN/AXf3i8PjOQzUuT26nkpsYxUGOk7c+vZVPcfrExLSoKzTb9kF0i66DcqzO5fXz/Z1AA==
+"@react-spring/web@9.4.5 || ^9.7.2":
+  version "9.7.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.2.tgz#76e53dd24033764c3062f9927f88b0f3194688d4"
+  integrity sha512-7qNc7/5KShu2D05x7o2Ols2nUE7mCKfKLaY2Ix70xPMfTle1sZisoQMBFgV9w/fSLZlHZHV9P0uWJqEXQnbV4Q==
   dependencies:
-    "@react-spring/animated" "~9.7.1"
-    "@react-spring/core" "~9.7.1"
-    "@react-spring/shared" "~9.7.1"
-    "@react-spring/types" "~9.7.1"
+    "@react-spring/animated" "~9.7.2"
+    "@react-spring/core" "~9.7.2"
+    "@react-spring/shared" "~9.7.2"
+    "@react-spring/types" "~9.7.2"
 
 "@rollup/plugin-babel@^5.2.0", "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"


### PR DESCRIPTION
Having a constraint on `@react-spring/web` blocking it to a very precise version (here: `9.4.5`) can push users of nivo into pulling it several times in their node_modules or bundles if they don't really check for duplicated packages. Indeed it's rather simple to have two distinct libraries requesting it at version `9.x` at the same time, and if one of them (not nivo) request something not being `9.4.5` they we would pull the library twice.

It seems that given `@react-spring/web` seems to follow semver, there is not real risk to say nivo supports `^9.4.5` instead of `9.4.5` only.