### PR TITLE
Bugfix/website/bar add legends fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 it's built on top of d3.
 
 Several libraries already exist for React d3 integration,
-but just a few provide server side rendering ability and fully declarative charts.
+but just a few provide server side rendering ability and fully declarative chart.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 it's built on top of d3.
 
 Several libraries already exist for React d3 integration,
-but just a few provide server side rendering ability and fully declarative chart.
+but just a few provide server side rendering ability and fully declarative charts.
 
 ## Installation
 

--- a/website/src/data/components/bar/props.ts
+++ b/website/src/data/components/bar/props.ts
@@ -506,16 +506,16 @@ const props: ChartProperty[] = [
             shouldRemove: true,
             getItemTitle: (index: number, legend: any) =>
                 `legend[${index}]: ${legend.anchor}, ${legend.direction}`,
-            svgDefaultProps: {
+            defaults: {
                 dataFrom: 'keys',
-                anchor: 'top-left',
+                anchor: 'top-right',
                 direction: 'column',
                 justify: false,
-                translateX: 0,
+                translateX: 120,
                 translateY: 0,
                 itemWidth: 100,
                 itemHeight: 20,
-                itemsSpacing: 0,
+                itemsSpacing: 2,
                 symbolSize: 20,
                 itemDirection: 'left-to-right',
                 onClick: (data: any) => {


### PR DESCRIPTION
Clicking the Add Legend button on the bar page crashes the entire website as shown bellow
![Tab-1680499869883-website](https://user-images.githubusercontent.com/36790357/230063621-2dfd145d-63dd-493c-9bde-a3547fb84660.gif)


Bellow is the error message that we see when clicking the Add Legend button on dev env.
![Tab-1680499836483-with error](https://user-images.githubusercontent.com/36790357/230063870-af5d027d-f622-4223-8b46-4dd09e8a5d0f.gif)


Idealy a new legend group should be added. This PR has the fix for that.
![Tab-1680499765293-proper](https://user-images.githubusercontent.com/36790357/230063898-dca6b728-f5cd-4a91-be84-42a82b136548.gif)

