### PR TITLE
Feature: Add option for positioning tooltip for LineCanvas

### DIFF
--- a/packages/line/src/LineCanvas.js
+++ b/packages/line/src/LineCanvas.js
@@ -67,6 +67,7 @@ const LineCanvas = ({
     onMouseLeave,
     onClick,
     tooltip,
+    tooltipPosition = LineCanvasDefaultProps.tooltipPosition,
 
     canvasRef,
 }) => {
@@ -276,7 +277,7 @@ const LineCanvas = ({
         [canvasEl, margin, innerWidth, innerHeight, delaunay]
     )
 
-    const { showTooltipFromEvent, hideTooltip } = useTooltip()
+    const { showTooltipAt, showTooltipFromEvent, hideTooltip } = useTooltip()
 
     const handleMouseHover = useCallback(
         event => {
@@ -284,12 +285,29 @@ const LineCanvas = ({
             setCurrentPoint(point)
 
             if (point) {
-                showTooltipFromEvent(createElement(tooltip, { point }), event)
+                if (tooltipPosition === 'point') {
+                    showTooltipAt(
+                        createElement(tooltip, { point }),
+                        [point.x + margin.left, point.y + margin.top],
+                        'top'
+                    )
+                } else {
+                    showTooltipFromEvent(createElement(tooltip, { point }), event)
+                }
             } else {
                 hideTooltip()
             }
         },
-        [getPointFromMouseEvent, setCurrentPoint, showTooltipFromEvent, hideTooltip, tooltip]
+        [
+            getPointFromMouseEvent,
+            setCurrentPoint,
+            showTooltipAt,
+            showTooltipFromEvent,
+            hideTooltip,
+            tooltip,
+            tooltipPosition,
+            margin,
+        ]
     )
 
     const handleMouseLeave = useCallback(

--- a/packages/line/src/props.js
+++ b/packages/line/src/props.js
@@ -212,4 +212,5 @@ export const LineDefaultProps = {
 export const LineCanvasDefaultProps = {
     ...commonDefaultProps,
     pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
+    tooltipPostion: 'cursor',
 }

--- a/website/src/data/components/line/defaults.ts
+++ b/website/src/data/components/line/defaults.ts
@@ -89,4 +89,6 @@ export default {
 
     enableCrosshair: true,
     crosshairType: 'bottom-left',
+
+    tooltipPosition: 'cursor',
 }

--- a/website/src/data/components/line/props.ts
+++ b/website/src/data/components/line/props.ts
@@ -80,7 +80,7 @@ const props: ChartProperty[] = [
 
             If you use a time scale, you must provide a time format
             as values are converted to Date objects.
-            
+
             Under the hood, nivo uses [d3-format](https://github.com/d3/d3-format),
             please have a look at it for available formats, you can also pass a function
             which will receive the raw value and should return the formatted one.
@@ -163,7 +163,7 @@ const props: ChartProperty[] = [
 
             If you use a time scale, you must provide a time format
             as values are converted to Date objects.
-            
+
             Under the hood, nivo uses [d3-format](https://github.com/d3/d3-format),
             please have a look at it for available formats, you can also pass a function
             which will receive the raw value and should return the formatted one.
@@ -445,6 +445,28 @@ const props: ChartProperty[] = [
         help: `Custom point tooltip`,
         type: 'Function',
         required: false,
+    },
+    {
+        key: 'tooltipPosition',
+        flavors: ['canvas'],
+        group: 'Interactivity',
+        help: `Tooltip position when hovering`,
+        type: 'string',
+        required: false,
+        defaultValue: defaults.tooltipPosition,
+        control: {
+            type: 'choices',
+            choices: [
+                {
+                    label: 'cursor',
+                    value: 'cursor',
+                },
+                {
+                    label: 'point',
+                    value: 'point',
+                },
+            ],
+        },
     },
     {
         key: 'enableSlices',


### PR DESCRIPTION
The tooltip defaults to the existing behavior to be at the cursor, but optionally can be placed at the point that the data in the tooltip is representing (similar to the default for SVG Lines)


https://github.com/plouc/nivo/assets/25183171/936cad49-41d4-446e-b68d-1bad13e5b5b4

