### PR TITLE
Fix arcLinkLabelsOffset for pie chart

### DIFF
--- a/packages/arcs/src/arc_link_labels/useArcLinkLabelsTransition.ts
+++ b/packages/arcs/src/arc_link_labels/useArcLinkLabelsTransition.ts
@@ -78,7 +78,7 @@ const useTransitionPhases = <Datum extends DatumWithArcAndColor>({
                 opacity: 0,
             }),
         }),
-        [diagonalLength, straightLength, textOffset, getLinkColor, getTextColor]
+        [diagonalLength, straightLength, textOffset, getLinkColor, getTextColor, offset]
     )
 
 const interpolateLink = (

--- a/packages/pie/src/Pie.tsx
+++ b/packages/pie/src/Pie.tsx
@@ -122,30 +122,10 @@ const InnerPie = <RawDatum extends MayHaveLabel>({
     const boundDefs = bindDefs(defs, dataWithArc, fill)
 
     const layerById: Record<PieLayerId, ReactNode> = {
-        arcLinkLabels: null,
         arcs: null,
+        arcLinkLabels: null,
         arcLabels: null,
         legends: null,
-    }
-
-    if (enableArcLinkLabels && layers.includes('arcLinkLabels')) {
-        layerById.arcLinkLabels = (
-            <ArcLinkLabelsLayer<ComputedDatum<RawDatum>>
-                key="arcLinkLabels"
-                center={[centerX, centerY]}
-                data={dataWithArc}
-                label={arcLinkLabel}
-                skipAngle={arcLinkLabelsSkipAngle}
-                offset={arcLinkLabelsOffset}
-                diagonalLength={arcLinkLabelsDiagonalLength}
-                straightLength={arcLinkLabelsStraightLength}
-                strokeWidth={arcLinkLabelsThickness}
-                textOffset={arcLinkLabelsTextOffset}
-                textColor={arcLinkLabelsTextColor}
-                linkColor={arcLinkLabelsColor}
-                component={arcLinkLabelComponent}
-            />
-        )
     }
 
     if (layers.includes('arcs')) {
@@ -165,6 +145,26 @@ const InnerPie = <RawDatum extends MayHaveLabel>({
                 setActiveId={setActiveId}
                 tooltip={tooltip}
                 transitionMode={transitionMode}
+            />
+        )
+    }
+
+    if (enableArcLinkLabels && layers.includes('arcLinkLabels')) {
+        layerById.arcLinkLabels = (
+            <ArcLinkLabelsLayer<ComputedDatum<RawDatum>>
+                key="arcLinkLabels"
+                center={[centerX, centerY]}
+                data={dataWithArc}
+                label={arcLinkLabel}
+                skipAngle={arcLinkLabelsSkipAngle}
+                offset={arcLinkLabelsOffset}
+                diagonalLength={arcLinkLabelsDiagonalLength}
+                straightLength={arcLinkLabelsStraightLength}
+                strokeWidth={arcLinkLabelsThickness}
+                textOffset={arcLinkLabelsTextOffset}
+                textColor={arcLinkLabelsTextColor}
+                linkColor={arcLinkLabelsColor}
+                component={arcLinkLabelComponent}
             />
         )
     }

--- a/packages/pie/src/props.ts
+++ b/packages/pie/src/props.ts
@@ -10,7 +10,7 @@ export const defaultProps = {
     padAngle: 0,
     cornerRadius: 0,
 
-    layers: ['arcLinkLabels', 'arcs', 'arcLabels', 'legends'],
+    layers: ['arcs', 'arcLinkLabels', 'arcLabels', 'legends'],
 
     // layout
     startAngle: 0,


### PR DESCRIPTION
Noticed the `arcLinkLabelsOffset` control wasn't doing anything on the [pie chart demo](https://nivo.rocks/pie/).

Tracked it down to a couple of issues:

1. In the default props, the `arcLinkLabels` layer came before the `arcs` layer so arcs were being rendered over the top of the arc link labels.
2. The `offset` was not being included in the dependency array for `useTransitionPhases` so changing the `arcLinkLabelsOffset` required another prop to change before the offset would update in the UI.

### Before
<img width="730" alt="Screenshot 2023-06-20 at 3 14 41 PM" src="https://github.com/plouc/nivo/assets/20647694/6f329c4d-71cc-4003-8232-4d9e36dc4146">

### After
<img width="680" alt="Screenshot 2023-06-20 at 3 13 22 PM" src="https://github.com/plouc/nivo/assets/20647694/1c2359b0-fda2-479f-91b1-13981c46cf0e">