### PR TITLE
fix: waffle types missing from dist

### DIFF
--- a/tsconfig.monorepo.json
+++ b/tsconfig.monorepo.json
@@ -42,6 +42,7 @@
         { "path": "./packages/stream" },
         { "path": "./packages/swarmplot" },
         { "path": "./packages/treemap" },
+        { "path": "./packages/waffle" },
 
         // Static rendering and express middleware
         { "path": "./packages/static" },


### PR DESCRIPTION
When upgrading my app from `0.73.0` to `0.83.0`, I received the following error message:
```
Could not find a declaration file for module '@nivo/waffle'. '.../node_modules/@nivo/waffle/dist/nivo-waffle.cjs.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/nivo__waffle` if it exists or add a new declaration (.d.ts) file containing `declare module '@nivo/waffle';`
```

I used the same approach as #2351 and verified that the types are now generated when running `make init`.