### PR TITLE
fix(stream): fix stream diagram overflowing

### DIFF
--- a/packages/stream/src/hooks.ts
+++ b/packages/stream/src/hooks.ts
@@ -101,7 +101,7 @@ export const useStream = <RawDatum extends StreamDatum>({
             width
         )
         const yScale = createLinearScale(
-            { type: 'linear' },
+            { type: 'linear', min: minValue },
             { all: [minValue, maxValue], min: minValue, max: maxValue },
             height,
             'y'


### PR DESCRIPTION
The stream diagram was overflowing. Particularly in the "silhouette" mode. This was introduced in d53681b439d3bac08e978491a56518b3fe9c98b5 where the d3 scale was replaced with the nivo equivalent. While ignoring that the min value might be negative thus must be put into the first parameter.

This closes: #2391