### PR TITLE
shiftArray in calendar/src/compute/timeRange.ts should not mutate its argument

### DIFF
--- a/packages/calendar/src/compute/timeRange.ts
+++ b/packages/calendar/src/compute/timeRange.ts
@@ -184,12 +184,8 @@ const getTimeInterval = (firstWeekday: Weekday) => {
 function shiftArray<T>(arr: T[], x: number): T[] {
     if (!arr.length || !x) return arr
 
-    for (let i = 0; i < x; i++) {
-        const shifted = arr.shift() as T
-        arr.push(shifted)
-    }
-
-    return arr
+    x = x % arr.length
+    return arr.slice(x, arr.length).concat(arr.slice(0, x))
 }
 
 function computeGrid({


### PR DESCRIPTION
This is a proposed fix for https://github.com/plouc/nivo/issues/2419

The function `shiftArray` mutates `ARRAY_OF_WEEKDAYS` which results in a wrong week day display in certain situations. 