### PR TITLE
refactor default props to fix error message

### DIFF
--- a/packages/core/src/components/cartesian/markers/CartesianMarkersItem.js
+++ b/packages/core/src/components/cartesian/markers/CartesianMarkersItem.js
@@ -171,10 +171,10 @@ const CartesianMarkersItem = ({
     lineStyle,
     textStyle,
     legend,
-    legendPosition,
-    legendOffsetX,
-    legendOffsetY,
-    legendOrientation,
+    legendPosition = 'top-right',
+    legendOffsetX = 14,
+    legendOffsetY = 14,
+    legendOrientation = 'horizontal',
 }) => {
     const theme = useTheme()
 
@@ -255,12 +255,6 @@ CartesianMarkersItem.propTypes = {
     legendOffsetX: PropTypes.number.isRequired,
     legendOffsetY: PropTypes.number.isRequired,
     legendOrientation: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
-}
-CartesianMarkersItem.defaultProps = {
-    legendPosition: 'top-right',
-    legendOffsetX: 14,
-    legendOffsetY: 14,
-    legendOrientation: 'horizontal',
 }
 
 export default memo(CartesianMarkersItem)

--- a/packages/core/src/components/defs/patterns/PatternDots.js
+++ b/packages/core/src/components/defs/patterns/PatternDots.js
@@ -1,7 +1,20 @@
 import { memo } from 'react'
 import PropTypes from 'prop-types'
 
-export const PatternDots = memo(({ id, background, color, size, padding, stagger }) => {
+export const PatternDotsDefaultProps = {
+    color: '#000000',
+    background: '#ffffff',
+    size: 4,
+    padding: 4,
+    stagger: false,
+}
+
+export const PatternDots = memo(props => {
+    const { id, background, color, size, padding, stagger } = {
+        ...PatternDotsDefaultProps,
+        ...props,
+    }
+
     let fullSize = size + padding
     const radius = size / 2
     const halfPadding = padding / 2
@@ -33,14 +46,6 @@ PatternDots.propTypes = {
     size: PropTypes.number.isRequired,
     padding: PropTypes.number.isRequired,
     stagger: PropTypes.bool.isRequired,
-}
-
-PatternDots.defaultProps = {
-    color: '#000000',
-    background: '#ffffff',
-    size: 4,
-    padding: 4,
-    stagger: false,
 }
 
 export const patternDotsDef = (id, options = {}) => ({

--- a/packages/core/src/components/defs/patterns/PatternDots.js
+++ b/packages/core/src/components/defs/patterns/PatternDots.js
@@ -10,10 +10,14 @@ export const PatternDotsDefaultProps = {
 }
 
 export const PatternDots = memo(props => {
-    const { id, background, color, size, padding, stagger } = {
-        ...PatternDotsDefaultProps,
-        ...props,
-    }
+    const {
+        id,
+        background = PatternDotsDefaultProps.background,
+        color = PatternDotsDefaultProps.color,
+        size = PatternDotsDefaultProps.size,
+        padding = PatternDotsDefaultProps.padding,
+        stagger = PatternDotsDefaultProps.stagger,
+    } = props
 
     let fullSize = size + padding
     const radius = size / 2

--- a/packages/core/src/components/defs/patterns/PatternLines.js
+++ b/packages/core/src/components/defs/patterns/PatternLines.js
@@ -2,8 +2,23 @@ import { memo } from 'react'
 import PropTypes from 'prop-types'
 import { degreesToRadians } from '../../../lib/polar'
 
+export const PatternLinesDefaultProps = {
+    spacing: 5,
+    rotation: 0,
+    background: '#000000',
+    color: '#ffffff',
+    lineWidth: 2,
+}
+
 export const PatternLines = memo(
-    ({ id, spacing: _spacing, rotation: _rotation, background, color, lineWidth }) => {
+    ({
+        id,
+        spacing: _spacing = PatternLinesDefaultProps.spacing,
+        rotation: _rotation = PatternLinesDefaultProps.rotation,
+        background = PatternLinesDefaultProps.background,
+        color = PatternLinesDefaultProps.color,
+        lineWidth = PatternLinesDefaultProps.lineWidth,
+    }) => {
         let rotation = Math.round(_rotation) % 360
         const spacing = Math.abs(_spacing)
 
@@ -68,13 +83,6 @@ PatternLines.propTypes = {
     background: PropTypes.string.isRequired,
     color: PropTypes.string.isRequired,
     lineWidth: PropTypes.number.isRequired,
-}
-PatternLines.defaultProps = {
-    spacing: 5,
-    rotation: 0,
-    color: '#000000',
-    background: '#ffffff',
-    lineWidth: 2,
 }
 
 export const patternLinesDef = (id, options = {}) => ({

--- a/packages/core/src/components/defs/patterns/PatternSquares.js
+++ b/packages/core/src/components/defs/patterns/PatternSquares.js
@@ -10,10 +10,14 @@ export const PatternSquaresDefaultProps = {
 }
 
 export const PatternSquares = memo(props => {
-    const { id, color, background, size, padding, stagger } = {
-        ...PatternSquaresDefaultProps,
-        ...props,
-    }
+    const {
+        id,
+        color = PatternSquaresDefaultProps.color,
+        background = PatternSquaresDefaultProps.background,
+        size = PatternSquaresDefaultProps.size,
+        padding = PatternSquaresDefaultProps.padding,
+        stagger = PatternSquaresDefaultProps.stagger,
+    } = props
 
     let fullSize = size + padding
     const halfPadding = padding / 2

--- a/packages/core/src/components/defs/patterns/PatternSquares.js
+++ b/packages/core/src/components/defs/patterns/PatternSquares.js
@@ -1,7 +1,20 @@
 import { memo } from 'react'
 import PropTypes from 'prop-types'
 
-export const PatternSquares = memo(({ id, background, color, size, padding, stagger }) => {
+export const PatternSquaresDefaultProps = {
+    color: '#000000',
+    background: '#ffffff',
+    size: 4,
+    padding: 4,
+    stagger: false,
+}
+
+export const PatternSquares = memo(props => {
+    const { id, color, background, size, padding, stagger } = {
+        ...PatternSquaresDefaultProps,
+        ...props,
+    }
+
     let fullSize = size + padding
     const halfPadding = padding / 2
     if (stagger === true) {
@@ -33,13 +46,6 @@ PatternSquares.propTypes = {
     size: PropTypes.number.isRequired,
     padding: PropTypes.number.isRequired,
     stagger: PropTypes.bool.isRequired,
-}
-PatternSquares.defaultProps = {
-    color: '#000000',
-    background: '#ffffff',
-    size: 4,
-    padding: 4,
-    stagger: false,
 }
 
 export const patternSquaresDef = (id, options = {}) => ({

--- a/packages/core/src/motion/context.js
+++ b/packages/core/src/motion/context.js
@@ -11,7 +11,7 @@ export const motionDefaultProps = {
 }
 
 export const MotionConfigProvider = props => {
-    const { children, animate, config } = { ...motionDefaultProps, ...props }
+    const { children, animate = true, config = 'default' } = props
 
     const value = useMemo(() => {
         const reactSpringConfig = isString(config) ? presets[config] : config

--- a/packages/core/src/motion/context.js
+++ b/packages/core/src/motion/context.js
@@ -5,7 +5,14 @@ import { config as presets } from '@react-spring/web'
 
 export const motionConfigContext = createContext()
 
-export const MotionConfigProvider = ({ children, animate, config }) => {
+export const motionDefaultProps = {
+    animate: true,
+    config: 'default',
+}
+
+export const MotionConfigProvider = props => {
+    const { children, animate, config } = { ...motionDefaultProps, ...props }
+
     const value = useMemo(() => {
         const reactSpringConfig = isString(config) ? presets[config] : config
 
@@ -40,10 +47,3 @@ MotionConfigProvider.propTypes = {
     animate: motionPropTypes.animate,
     config: motionPropTypes.motionConfig,
 }
-
-export const motionDefaultProps = {
-    animate: true,
-    config: 'default',
-}
-
-MotionConfigProvider.defaultProps = motionDefaultProps

--- a/packages/funnel/src/props.tsx
+++ b/packages/funnel/src/props.tsx
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { MotionConfigProvider } from '@nivo/core'
+import { motionDefaultProps } from '@nivo/core'
 import { FunnelLayerId } from './types'
 
 export const svgDefaultProps = {
@@ -34,6 +34,6 @@ export const svgDefaultProps = {
 
     role: 'img',
 
-    animate: MotionConfigProvider.defaultProps.animate,
-    motionConfig: MotionConfigProvider.defaultProps.config,
+    animate: motionDefaultProps.animate,
+    motionConfig: motionDefaultProps.config,
 }

--- a/packages/geo/src/Choropleth.js
+++ b/packages/geo/src/Choropleth.js
@@ -10,10 +10,11 @@ import { memo, Fragment, useCallback } from 'react'
 import { SvgWrapper, withContainer, useDimensions, useTheme, bindDefs } from '@nivo/core'
 import { BoxLegendSvg } from '@nivo/legends'
 import { useTooltip } from '@nivo/tooltip'
-import { ChoroplethPropTypes, ChoroplethDefaultProps } from './props'
+import { ChoroplethPropTypes } from './props'
 import GeoGraticule from './GeoGraticule'
 import GeoMapFeature from './GeoMapFeature'
 import { useGeoMap, useChoropleth } from './hooks'
+import ChoroplethTooltip from './ChoroplethTooltip'
 
 const Choropleth = memo(props => {
     const {
@@ -22,31 +23,31 @@ const Choropleth = memo(props => {
         margin: partialMargin,
         features,
         data,
-        match,
-        label,
-        value,
+        match = 'id',
+        label = 'id',
+        value = 'value',
         valueFormat,
-        projectionType,
-        projectionScale,
-        projectionTranslation,
-        projectionRotation,
-        colors,
+        projectionType = 'mercator',
+        projectionScale = 100,
+        projectionTranslation = [0.5, 0.5],
+        projectionRotation = [0, 0, 0],
+        colors = 'PuBuGn',
         domain,
-        unknownColor,
-        borderWidth,
-        borderColor,
-        enableGraticule,
-        graticuleLineWidth,
-        graticuleLineColor,
-        layers,
-        legends,
-        isInteractive,
-        onClick,
-        tooltip: Tooltip,
-        role,
-        defs,
-        fill,
-    } = { ...ChoroplethDefaultProps, ...props }
+        unknownColor = '#999',
+        borderWidth = 0,
+        borderColor = '#000000',
+        enableGraticule = false,
+        graticuleLineWidth = 0.5,
+        graticuleLineColor = '#999999',
+        layers = ['graticule', 'features', 'legends'],
+        legends = [],
+        isInteractive = true,
+        onClick = () => {},
+        tooltip: Tooltip = ChoroplethTooltip,
+        role = 'img',
+        defs = [],
+        fill = [],
+    } = props
 
     const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
     const { graticule, path, getBorderWidth, getBorderColor } = useGeoMap({

--- a/packages/geo/src/ChoroplethCanvas.js
+++ b/packages/geo/src/ChoroplethCanvas.js
@@ -11,8 +11,9 @@ import { geoContains } from 'd3-geo'
 import { getRelativeCursor, withContainer, useDimensions, useTheme } from '@nivo/core'
 import { renderLegendToCanvas } from '@nivo/legends'
 import { useTooltip } from '@nivo/tooltip'
-import { ChoroplethCanvasDefaultProps, ChoroplethCanvasPropTypes } from './props'
+import { ChoroplethCanvasPropTypes } from './props'
 import { useGeoMap, useChoropleth } from './hooks'
+import ChoroplethTooltip from './ChoroplethTooltip'
 
 const getFeatureFromMouseEvent = (event, el, features, projection) => {
     const [x, y] = getRelativeCursor(el, event)
@@ -25,32 +26,32 @@ const ChoroplethCanvas = memo(props => {
         width,
         height,
         margin: partialMargin,
-        pixelRatio,
+        pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
         features,
         data,
-        match,
-        label,
-        value,
+        match = 'id',
+        label = 'id',
+        value = 'value',
         valueFormat,
-        projectionType,
-        projectionScale,
-        projectionTranslation,
-        projectionRotation,
-        colors,
+        projectionType = 'mercator',
+        projectionScale = 100,
+        projectionTranslation = [0.5, 0.5],
+        projectionRotation = [0, 0, 0],
+        colors = 'PuBuGn',
         domain,
-        unknownColor,
-        borderWidth,
-        borderColor,
-        enableGraticule,
-        graticuleLineWidth,
-        graticuleLineColor,
-        layers,
-        legends,
-        isInteractive,
-        onClick,
-        onMouseMove,
-        tooltip: Tooltip,
-    } = { ...ChoroplethCanvasDefaultProps, ...props }
+        unknownColor = '#999',
+        borderWidth = 0,
+        borderColor = '#000000',
+        enableGraticule = false,
+        graticuleLineWidth = 0.5,
+        graticuleLineColor = '#999999',
+        layers = ['graticule', 'features', 'legends'],
+        legends = [],
+        isInteractive = true,
+        onClick = () => {},
+        onMouseMove = () => {},
+        tooltip: Tooltip = ChoroplethTooltip,
+    } = props
     const canvasEl = useRef(null)
     const theme = useTheme()
     const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)

--- a/packages/geo/src/ChoroplethCanvas.js
+++ b/packages/geo/src/ChoroplethCanvas.js
@@ -20,8 +20,8 @@ const getFeatureFromMouseEvent = (event, el, features, projection) => {
     return features.find(f => geoContains(f, projection.invert([x, y])))
 }
 
-const ChoroplethCanvas = memo(
-    ({
+const ChoroplethCanvas = memo(props => {
+    const {
         width,
         height,
         margin: partialMargin,
@@ -50,172 +50,170 @@ const ChoroplethCanvas = memo(
         onClick,
         onMouseMove,
         tooltip: Tooltip,
-    }) => {
-        const canvasEl = useRef(null)
-        const theme = useTheme()
-        const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
-        const { projection, graticule, path, getBorderWidth, getBorderColor } = useGeoMap({
-            width,
-            height,
-            projectionType,
-            projectionScale,
-            projectionTranslation,
-            projectionRotation,
-            fillColor: () => {},
-            borderWidth,
-            borderColor,
-        })
-        const { getFillColor, boundFeatures, legendData } = useChoropleth({
-            features,
-            data,
-            match,
-            label,
-            value,
-            valueFormat,
-            colors,
-            unknownColor,
-            domain,
-        })
+    } = { ...ChoroplethCanvasDefaultProps, ...props }
+    const canvasEl = useRef(null)
+    const theme = useTheme()
+    const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
+    const { projection, graticule, path, getBorderWidth, getBorderColor } = useGeoMap({
+        width,
+        height,
+        projectionType,
+        projectionScale,
+        projectionTranslation,
+        projectionRotation,
+        fillColor: () => {},
+        borderWidth,
+        borderColor,
+    })
+    const { getFillColor, boundFeatures, legendData } = useChoropleth({
+        features,
+        data,
+        match,
+        label,
+        value,
+        valueFormat,
+        colors,
+        unknownColor,
+        domain,
+    })
 
-        useEffect(() => {
-            if (!canvasEl) return
+    useEffect(() => {
+        if (!canvasEl) return
 
-            canvasEl.current.width = outerWidth * pixelRatio
-            canvasEl.current.height = outerHeight * pixelRatio
+        canvasEl.current.width = outerWidth * pixelRatio
+        canvasEl.current.height = outerHeight * pixelRatio
 
-            const ctx = canvasEl.current.getContext('2d')
+        const ctx = canvasEl.current.getContext('2d')
 
-            ctx.scale(pixelRatio, pixelRatio)
+        ctx.scale(pixelRatio, pixelRatio)
 
-            ctx.fillStyle = theme.background
-            ctx.fillRect(0, 0, outerWidth, outerHeight)
-            ctx.translate(margin.left, margin.top)
+        ctx.fillStyle = theme.background
+        ctx.fillRect(0, 0, outerWidth, outerHeight)
+        ctx.translate(margin.left, margin.top)
 
-            path.context(ctx)
+        path.context(ctx)
 
-            layers.forEach(layer => {
-                if (layer === 'graticule') {
-                    if (enableGraticule === true) {
-                        ctx.lineWidth = graticuleLineWidth
-                        ctx.strokeStyle = graticuleLineColor
-                        ctx.beginPath()
-                        path(graticule())
+        layers.forEach(layer => {
+            if (layer === 'graticule') {
+                if (enableGraticule === true) {
+                    ctx.lineWidth = graticuleLineWidth
+                    ctx.strokeStyle = graticuleLineColor
+                    ctx.beginPath()
+                    path(graticule())
+                    ctx.stroke()
+                }
+            } else if (layer === 'features') {
+                boundFeatures.forEach(feature => {
+                    ctx.beginPath()
+                    path(feature)
+                    ctx.fillStyle = getFillColor(feature)
+                    ctx.fill()
+
+                    const borderWidth = getBorderWidth(feature)
+                    if (borderWidth > 0) {
+                        ctx.strokeStyle = getBorderColor(feature)
+                        ctx.lineWidth = borderWidth
                         ctx.stroke()
                     }
-                } else if (layer === 'features') {
-                    boundFeatures.forEach(feature => {
-                        ctx.beginPath()
-                        path(feature)
-                        ctx.fillStyle = getFillColor(feature)
-                        ctx.fill()
-
-                        const borderWidth = getBorderWidth(feature)
-                        if (borderWidth > 0) {
-                            ctx.strokeStyle = getBorderColor(feature)
-                            ctx.lineWidth = borderWidth
-                            ctx.stroke()
-                        }
+                })
+            } else if (layer === 'legends') {
+                legends.forEach(legend => {
+                    renderLegendToCanvas(ctx, {
+                        ...legend,
+                        data: legendData,
+                        containerWidth: width,
+                        containerHeight: height,
+                        theme,
                     })
-                } else if (layer === 'legends') {
-                    legends.forEach(legend => {
-                        renderLegendToCanvas(ctx, {
-                            ...legend,
-                            data: legendData,
-                            containerWidth: width,
-                            containerHeight: height,
-                            theme,
-                        })
-                    })
-                } else {
-                    // layer(ctx, {})
-                }
-            })
-        }, [
-            canvasEl,
-            outerWidth,
-            outerHeight,
-            margin,
-            pixelRatio,
-            theme,
-            path,
-            graticule,
-            getFillColor,
-            getBorderWidth,
-            getBorderColor,
-            boundFeatures,
-            legends,
-            layers,
-        ])
+                })
+            } else {
+                // layer(ctx, {})
+            }
+        })
+    }, [
+        canvasEl,
+        outerWidth,
+        outerHeight,
+        margin,
+        pixelRatio,
+        theme,
+        path,
+        graticule,
+        getFillColor,
+        getBorderWidth,
+        getBorderColor,
+        boundFeatures,
+        legends,
+        layers,
+    ])
 
-        const { showTooltipFromEvent, hideTooltip } = useTooltip()
-        const handleMouseMove = useCallback(
-            event => {
-                if (!isInteractive || !Tooltip) return
+    const { showTooltipFromEvent, hideTooltip } = useTooltip()
+    const handleMouseMove = useCallback(
+        event => {
+            if (!isInteractive || !Tooltip) return
 
-                const feature = getFeatureFromMouseEvent(
-                    event,
-                    canvasEl.current,
-                    boundFeatures,
-                    projection
-                )
-                if (feature) {
-                    showTooltipFromEvent(<Tooltip feature={feature} />, event)
-                } else {
-                    hideTooltip()
-                }
-                onMouseMove && onMouseMove(feature || null, event)
-            },
-            [
-                showTooltipFromEvent,
-                hideTooltip,
-                isInteractive,
-                Tooltip,
-                canvasEl,
+            const feature = getFeatureFromMouseEvent(
+                event,
+                canvasEl.current,
                 boundFeatures,
-                projection,
-            ]
-        )
-        const handleMouseLeave = useCallback(
-            () => isInteractive && hideTooltip(),
-            [isInteractive, hideTooltip]
-        )
-        const handleClick = useCallback(
-            event => {
-                if (!isInteractive || !onClick) return
+                projection
+            )
+            if (feature) {
+                showTooltipFromEvent(<Tooltip feature={feature} />, event)
+            } else {
+                hideTooltip()
+            }
+            onMouseMove && onMouseMove(feature || null, event)
+        },
+        [
+            showTooltipFromEvent,
+            hideTooltip,
+            isInteractive,
+            Tooltip,
+            canvasEl,
+            boundFeatures,
+            projection,
+        ]
+    )
+    const handleMouseLeave = useCallback(
+        () => isInteractive && hideTooltip(),
+        [isInteractive, hideTooltip]
+    )
+    const handleClick = useCallback(
+        event => {
+            if (!isInteractive || !onClick) return
 
-                const feature = getFeatureFromMouseEvent(
-                    event,
-                    canvasEl.current,
-                    boundFeatures,
-                    projection
-                )
-                if (feature) {
-                    onClick(feature, event)
-                }
-            },
-            [isInteractive, canvasEl, boundFeatures, projection, onClick]
-        )
+            const feature = getFeatureFromMouseEvent(
+                event,
+                canvasEl.current,
+                boundFeatures,
+                projection
+            )
+            if (feature) {
+                onClick(feature, event)
+            }
+        },
+        [isInteractive, canvasEl, boundFeatures, projection, onClick]
+    )
 
-        return (
-            <canvas
-                ref={canvasEl}
-                width={outerWidth * pixelRatio}
-                height={outerHeight * pixelRatio}
-                style={{
-                    width: outerWidth,
-                    height: outerHeight,
-                    cursor: isInteractive ? 'auto' : 'normal',
-                }}
-                onMouseMove={handleMouseMove}
-                onMouseLeave={handleMouseLeave}
-                onClick={handleClick}
-            />
-        )
-    }
-)
+    return (
+        <canvas
+            ref={canvasEl}
+            width={outerWidth * pixelRatio}
+            height={outerHeight * pixelRatio}
+            style={{
+                width: outerWidth,
+                height: outerHeight,
+                cursor: isInteractive ? 'auto' : 'normal',
+            }}
+            onMouseMove={handleMouseMove}
+            onMouseLeave={handleMouseLeave}
+            onClick={handleClick}
+        />
+    )
+})
 
 ChoroplethCanvas.displayName = 'ChoroplethCanvas'
 ChoroplethCanvas.propTypes = ChoroplethCanvasPropTypes
-ChoroplethCanvas.defaultProps = ChoroplethCanvasDefaultProps
 
 export default withContainer(ChoroplethCanvas)

--- a/packages/geo/src/GeoMap.js
+++ b/packages/geo/src/GeoMap.js
@@ -9,7 +9,7 @@
 import { Fragment, useCallback, memo } from 'react'
 import { SvgWrapper, withContainer, useDimensions, useTheme } from '@nivo/core'
 import { useTooltip } from '@nivo/tooltip'
-import { GeoMapPropTypes, GeoMapDefaultProps } from './props'
+import { GeoMapPropTypes } from './props'
 import GeoGraticule from './GeoGraticule'
 import GeoMapFeature from './GeoMapFeature'
 import { useGeoMap } from './hooks'
@@ -20,22 +20,22 @@ const GeoMap = memo(props => {
         height,
         margin: partialMargin,
         features,
-        layers,
-        projectionType,
-        projectionScale,
-        projectionTranslation,
-        projectionRotation,
-        fillColor,
-        borderWidth,
-        borderColor,
-        enableGraticule,
-        graticuleLineWidth,
-        graticuleLineColor,
-        isInteractive,
-        onClick,
+        layers = ['graticule', 'features'],
+        projectionType = 'mercator',
+        projectionScale = 100,
+        projectionTranslation = [0.5, 0.5],
+        projectionRotation = [0, 0, 0],
+        fillColor = '#dddddd',
+        borderWidth = 0,
+        borderColor = '#000000',
+        enableGraticule = false,
+        graticuleLineWidth = 0.5,
+        graticuleLineColor = '#999999',
+        isInteractive = true,
+        onClick = () => {},
         tooltip: Tooltip,
-        role,
-    } = { ...GeoMapDefaultProps, ...props }
+        role = 'img',
+    } = props
     const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
     const { graticule, path, getFillColor, getBorderWidth, getBorderColor } = useGeoMap({
         width,

--- a/packages/geo/src/GeoMap.js
+++ b/packages/geo/src/GeoMap.js
@@ -35,7 +35,7 @@ const GeoMap = memo(props => {
         onClick,
         tooltip: Tooltip,
         role,
-    } = props
+    } = { ...GeoMapDefaultProps, ...props }
     const { margin, outerWidth, outerHeight } = useDimensions(width, height, partialMargin)
     const { graticule, path, getFillColor, getBorderWidth, getBorderColor } = useGeoMap({
         width,
@@ -122,6 +122,5 @@ const GeoMap = memo(props => {
 
 GeoMap.displayName = 'GeoMap'
 GeoMap.propTypes = GeoMapPropTypes
-GeoMap.defaultProps = GeoMapDefaultProps
 
 export default withContainer(GeoMap)

--- a/packages/geo/src/GeoMapCanvas.js
+++ b/packages/geo/src/GeoMapCanvas.js
@@ -10,7 +10,7 @@ import { memo, useRef, useEffect, useCallback } from 'react'
 import { geoContains } from 'd3-geo'
 import { getRelativeCursor, withContainer, useDimensions, useTheme } from '@nivo/core'
 import { useTooltip } from '@nivo/tooltip'
-import { GeoMapCanvasDefaultProps, GeoMapCanvasPropTypes } from './props'
+import { GeoMapCanvasPropTypes } from './props'
 import { useGeoMap } from './hooks'
 
 const getFeatureFromMouseEvent = (event, el, features, projection) => {
@@ -24,28 +24,28 @@ const GeoMapCanvas = memo(props => {
         width,
         height,
         margin: partialMargin,
-        pixelRatio,
+        pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
         features,
         layers,
 
-        projectionType,
-        projectionScale,
-        projectionTranslation,
-        projectionRotation,
+        projectionType = 'mercator',
+        projectionScale = 100,
+        projectionTranslation = [0.5, 0.5],
+        projectionRotation = [0, 0, 0],
 
-        fillColor,
-        borderWidth,
-        borderColor,
+        fillColor = '#dddddd',
+        borderWidth = 0,
+        borderColor = '#000000',
 
-        enableGraticule,
-        graticuleLineWidth,
-        graticuleLineColor,
+        enableGraticule = false,
+        graticuleLineWidth = 0.5,
+        graticuleLineColor = '#999999',
 
-        isInteractive,
-        onClick,
-        onMouseMove,
+        isInteractive = true,
+        onClick = () => {},
+        onMouseMove = () => {},
         tooltip: Tooltip,
-    } = { ...GeoMapCanvasDefaultProps, ...props }
+    } = props
 
     const canvasEl = useRef(null)
     const theme = useTheme()

--- a/packages/geo/src/GeoMapCanvas.js
+++ b/packages/geo/src/GeoMapCanvas.js
@@ -45,7 +45,7 @@ const GeoMapCanvas = memo(props => {
         onClick,
         onMouseMove,
         tooltip: Tooltip,
-    } = props
+    } = { ...GeoMapCanvasDefaultProps, ...props }
 
     const canvasEl = useRef(null)
     const theme = useTheme()
@@ -173,6 +173,5 @@ const GeoMapCanvas = memo(props => {
 
 GeoMapCanvas.displatName = 'GeoMapCanvas'
 GeoMapCanvas.propTypes = GeoMapCanvasPropTypes
-GeoMapCanvas.defaultProps = GeoMapCanvasDefaultProps
 
 export default withContainer(GeoMapCanvas)

--- a/packages/line/src/Line.js
+++ b/packages/line/src/Line.js
@@ -95,7 +95,7 @@ const Line = props => {
         crosshairType,
 
         role,
-    } = props
+    } = { ...LineDefaultProps, ...props }
 
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
@@ -331,6 +331,5 @@ const Line = props => {
 }
 
 Line.propTypes = LinePropTypes
-Line.defaultProps = LineDefaultProps
 
 export default withContainer(Line)

--- a/packages/line/src/Line.js
+++ b/packages/line/src/Line.js
@@ -20,25 +20,42 @@ import { Axes, Grid } from '@nivo/axes'
 import { BoxLegendSvg } from '@nivo/legends'
 import { Crosshair } from '@nivo/tooltip'
 import { useLine } from './hooks'
-import { LinePropTypes, LineDefaultProps } from './props'
+import { LinePropTypes } from './props'
 import Areas from './Areas'
 import Lines from './Lines'
 import Slices from './Slices'
 import Points from './Points'
 import Mesh from './Mesh'
+import PointTooltip from './PointTooltip'
+import SliceTooltip from './SliceTooltip'
 
 const Line = props => {
     const {
         data,
-        xScale: xScaleSpec,
+        xScale: xScaleSpec = { type: 'point' },
         xFormat,
-        yScale: yScaleSpec,
+        yScale: yScaleSpec = {
+            type: 'linear',
+            min: 0,
+            max: 'auto',
+        },
         yFormat,
-        layers,
-        curve,
-        areaBaselineValue,
+        layers = [
+            'grid',
+            'markers',
+            'axes',
+            'areas',
+            'crosshair',
+            'lines',
+            'points',
+            'slices',
+            'mesh',
+            'legends',
+        ],
+        curve = 'linear',
+        areaBaselineValue = 0,
 
-        colors,
+        colors = { scheme: 'nivo' },
 
         margin: partialMargin,
         width,
@@ -46,56 +63,56 @@ const Line = props => {
 
         axisTop,
         axisRight,
-        axisBottom,
-        axisLeft,
-        enableGridX,
-        enableGridY,
+        axisBottom = {},
+        axisLeft = {},
+        enableGridX = true,
+        enableGridY = true,
         gridXValues,
         gridYValues,
 
-        lineWidth,
-        enableArea,
-        areaOpacity,
-        areaBlendMode,
+        lineWidth = 2,
+        enableArea = false,
+        areaOpacity = 0.2,
+        areaBlendMode = 'normal',
 
-        enablePoints,
+        enablePoints = true,
         pointSymbol,
-        pointSize,
-        pointColor,
-        pointBorderWidth,
-        pointBorderColor,
-        enablePointLabel,
-        pointLabel,
+        pointSize = 6,
+        pointColor = { from: 'color' },
+        pointBorderWidth = 0,
+        pointBorderColor = { theme: 'background' },
+        enablePointLabel = false,
+        pointLabel = 'yFormatted',
         pointLabelYOffset,
 
-        defs,
-        fill,
+        defs = [],
+        fill = [],
 
         markers,
 
-        legends,
+        legends = [],
 
-        isInteractive,
+        isInteractive = true,
 
-        useMesh,
-        debugMesh,
+        useMesh = false,
+        debugMesh = false,
 
         onMouseEnter,
         onMouseMove,
         onMouseLeave,
         onClick,
 
-        tooltip,
+        tooltip = PointTooltip,
 
-        enableSlices,
-        debugSlices,
-        sliceTooltip,
+        enableSlices = false,
+        debugSlices = false,
+        sliceTooltip = SliceTooltip,
 
-        enableCrosshair,
-        crosshairType,
+        enableCrosshair = true,
+        crosshairType = 'bottom-left',
 
-        role,
-    } = { ...LineDefaultProps, ...props }
+        role = 'img',
+    } = props
 
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,

--- a/packages/line/src/LineCanvas.js
+++ b/packages/line/src/LineCanvas.js
@@ -21,56 +21,56 @@ import { useVoronoiMesh, renderVoronoiToCanvas, renderVoronoiCellToCanvas } from
 import { LineCanvasPropTypes, LineCanvasDefaultProps } from './props'
 import { useLine } from './hooks'
 
-const LineCanvas = ({
-    width,
-    height,
-    margin: partialMargin,
-    pixelRatio,
-
-    data,
-    xScale: xScaleSpec,
-    xFormat,
-    yScale: yScaleSpec,
-    yFormat,
-    curve,
-
-    layers,
-
-    colors,
-    lineWidth,
-
-    enableArea,
-    areaBaselineValue,
-    areaOpacity,
-
-    enablePoints,
-    pointSize,
-    pointColor,
-    pointBorderWidth,
-    pointBorderColor,
-
-    enableGridX,
-    gridXValues,
-    enableGridY,
-    gridYValues,
-    axisTop,
-    axisRight,
-    axisBottom,
-    axisLeft,
-
-    legends,
-
-    isInteractive,
-    debugMesh,
-    //onMouseEnter,
-    //onMouseMove,
-    onMouseLeave,
-    onClick,
-    tooltip,
-
-    canvasRef,
-}) => {
+const LineCanvas = props => {
     const canvasEl = useRef(null)
+    const {
+        width,
+        height,
+        margin: partialMargin,
+        pixelRatio,
+
+        data,
+        xScale: xScaleSpec,
+        xFormat,
+        yScale: yScaleSpec,
+        yFormat,
+        curve,
+
+        layers,
+
+        colors,
+        lineWidth,
+
+        enableArea,
+        areaBaselineValue,
+        areaOpacity,
+
+        enablePoints,
+        pointSize,
+        pointColor,
+        pointBorderWidth,
+        pointBorderColor,
+
+        enableGridX,
+        gridXValues,
+        enableGridY,
+        gridYValues,
+        axisTop,
+        axisRight,
+        axisBottom,
+        axisLeft,
+
+        legends,
+
+        isInteractive,
+        debugMesh,
+        //onMouseEnter,
+        //onMouseMove,
+        onMouseLeave,
+        onClick,
+        tooltip,
+        canvasRef,
+    } = { ...LineCanvasDefaultProps, ...props }
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
         height,
@@ -330,7 +330,6 @@ const LineCanvas = ({
 }
 
 LineCanvas.propTypes = LineCanvasPropTypes
-LineCanvas.defaultProps = LineCanvasDefaultProps
 
 const LineCanvasWithContainer = withContainer(LineCanvas)
 

--- a/packages/line/src/LineCanvas.js
+++ b/packages/line/src/LineCanvas.js
@@ -18,8 +18,9 @@ import { renderAxesToCanvas, renderGridLinesToCanvas } from '@nivo/axes'
 import { renderLegendToCanvas } from '@nivo/legends'
 import { useTooltip } from '@nivo/tooltip'
 import { useVoronoiMesh, renderVoronoiToCanvas, renderVoronoiCellToCanvas } from '@nivo/voronoi'
-import { LineCanvasPropTypes, LineCanvasDefaultProps } from './props'
+import { LineCanvasPropTypes } from './props'
 import { useLine } from './hooks'
+import PointTooltip from './PointTooltip'
 
 const LineCanvas = props => {
     const canvasEl = useRef(null)
@@ -27,50 +28,65 @@ const LineCanvas = props => {
         width,
         height,
         margin: partialMargin,
-        pixelRatio,
+        pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
 
         data,
-        xScale: xScaleSpec,
+        xScale: xScaleSpec = { type: 'point' },
         xFormat,
-        yScale: yScaleSpec,
+        yScale: yScaleSpec = {
+            type: 'linear',
+            min: 0,
+            max: 'auto',
+        },
         yFormat,
-        curve,
+        curve = 'linear',
 
-        layers,
+        layers = [
+            'grid',
+            'markers',
+            'axes',
+            'areas',
+            'crosshair',
+            'lines',
+            'points',
+            'slices',
+            'mesh',
+            'legends',
+        ],
 
-        colors,
-        lineWidth,
+        colors = { scheme: 'nivo' },
+        lineWidth = 2,
 
-        enableArea,
-        areaBaselineValue,
-        areaOpacity,
+        enableArea = false,
+        areaBaselineValue = 0,
+        areaOpacity = 0.2,
 
-        enablePoints,
-        pointSize,
-        pointColor,
-        pointBorderWidth,
-        pointBorderColor,
+        enablePoints = true,
+        pointSize = 6,
+        pointColor = { from: 'color' },
+        pointBorderWidth = 0,
+        pointBorderColor = { theme: 'background' },
 
-        enableGridX,
+        enableGridX = true,
         gridXValues,
-        enableGridY,
+        enableGridY = true,
         gridYValues,
         axisTop,
         axisRight,
-        axisBottom,
-        axisLeft,
+        axisBottom = {},
+        axisLeft = {},
 
-        legends,
+        legends = [],
 
-        isInteractive,
-        debugMesh,
+        isInteractive = true,
+        debugMesh = false,
         //onMouseEnter,
         //onMouseMove,
         onMouseLeave,
         onClick,
-        tooltip,
+        tooltip = PointTooltip,
         canvasRef,
-    } = { ...LineCanvasDefaultProps, ...props }
+    } = props
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
         width,
         height,

--- a/website/src/components/guides/patterns/PatternsDotsDemo.tsx
+++ b/website/src/components/guides/patterns/PatternsDotsDemo.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Defs, patternDotsDef, PatternDots } from '@nivo/core'
+import { Defs, patternDotsDef, PatternDotsDefaultProps } from '@nivo/core'
 import { ChartProperty } from '../../../types'
 import { GuideDemoBlock } from '../GuideDemoBlock'
 
-const defaults = (PatternDots as unknown as any).defaultProps as Settings
+const defaults = PatternDotsDefaultProps as Settings
 const SAMPLE_SIZE = 120
 const patternId = 'dots-pattern'
 

--- a/website/src/components/guides/patterns/PatternsLinesDemo.tsx
+++ b/website/src/components/guides/patterns/PatternsLinesDemo.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Defs, PatternLines, patternLinesDef } from '@nivo/core'
+import { Defs, patternLinesDef, PatternLinesDefaultProps } from '@nivo/core'
 import { ChartProperty } from '../../../types'
 import { GuideDemoBlock } from '../GuideDemoBlock'
 
-const defaults = (PatternLines as unknown as any).defaultProps as Settings
+const defaults = PatternLinesDefaultProps as Settings
 const SAMPLE_SIZE = 120
 const patternId = 'lines-pattern'
 

--- a/website/src/components/guides/patterns/PatternsSquaresDemo.tsx
+++ b/website/src/components/guides/patterns/PatternsSquaresDemo.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Defs, patternSquaresDef, PatternSquares } from '@nivo/core'
+import { Defs, patternSquaresDef, PatternSquaresDefaultProps } from '@nivo/core'
 import { ChartProperty } from '../../../types'
 import { GuideDemoBlock } from '../GuideDemoBlock'
 
-const defaults = (PatternSquares as unknown as any).defaultProps as Settings
+const defaults = PatternSquaresDefaultProps as Settings
 const SAMPLE_SIZE = 120
 const patternId = 'squares-pattern'
 


### PR DESCRIPTION
### This PR is related to issue #2415.
Refactor default props declared like:
```
Component.defaultProps = {
    prop1: 0,
    prop2: 1,
    // ....
}
```
Now, the default props are defined directly inside the component
```
export const Component = props => {
    const {
      prop1 = 0,
      prop2 = 1,
      // ...
    } = props
    // ...
}
```

The given solution is based in the issue from another repository:
- chakra-ui/chakra-ui#7057
