### PR TITLE
fix(calendar): compute cell positions missing end date

### DIFF
--- a/packages/calendar/src/compute/timeRange.ts
+++ b/packages/calendar/src/compute/timeRange.ts
@@ -1,17 +1,17 @@
 import {
-    timeDays,
     timeDay,
-    timeMonday,
-    timeTuesday,
-    timeWednesday,
-    timeThursday,
+    timeDays,
     timeFriday,
+    timeMonday,
     timeSaturday,
     timeSunday,
+    timeThursday,
+    timeTuesday,
+    timeWednesday,
 } from 'd3-time'
 import { timeFormat } from 'd3-time-format'
-import { DateOrString, Weekday } from '../types'
 import isDate from 'lodash/isDate'
+import { DateOrString, Weekday } from '../types'
 
 // Interfaces
 interface ComputeBaseProps {
@@ -246,8 +246,12 @@ export const computeCellPositions = ({
     // we need to determine whether we need to add days to move to correct position
     const start = from ? from : data[0].date
     const end = to ? to : data[data.length - 1].date
-    const startDate = isDate(start) ? start : new Date(start)
-    const endDate = isDate(end) ? end : new Date(end)
+
+    // The timeDays function's endDate is exclusive, so we need to add one day
+    // Also we need to reset the hours using timeDay to fix locale issue
+    const startDate = timeDay(isDate(start) ? start : new Date(start))
+    const endDate = timeDay.offset(timeDay(isDate(end) ? end : new Date(end)), 1)
+
     const dateRange = timeDays(startDate, endDate).map(dayDate => {
         return {
             date: dayDate,

--- a/packages/generators/src/index.ts
+++ b/packages/generators/src/index.ts
@@ -1,8 +1,8 @@
-import range from 'lodash/range'
-import random from 'lodash/random'
-import shuffle from 'lodash/shuffle'
-import { timeDays } from 'd3-time'
+import { timeDay, timeDays } from 'd3-time'
 import { timeFormat } from 'd3-time-format'
+import random from 'lodash/random'
+import range from 'lodash/range'
+import shuffle from 'lodash/shuffle'
 import * as color from './color'
 import * as sets from './sets'
 
@@ -105,7 +105,10 @@ export const generateCountriesPopulation = (size: number) => {
 }
 
 export const generateOrderedDayCounts = (from: Date, to: Date) => {
-    const days = timeDays(from, to)
+    const startDate = timeDay(from)
+    const endDate = timeDay.offset(timeDay(to), 1)
+
+    const days = timeDays(startDate, endDate)
     const dayFormat = timeFormat('%Y-%m-%d')
 
     return days.map(day => {


### PR DESCRIPTION
The issue this fixes is that `timeDays` end date is exclusive, and the locale was also effecting the result

Often the end date was missing, but in some locations (Germany) it was included but missing in the UK for example

I'm using timeDay to reset the hours and applying an offset on the end date so that is always included

fixes #2333