### PR TITLE
Tooltip: avoid a flash effect and weird initial transition

### DIFF
--- a/packages/tooltip/src/TooltipWrapper.tsx
+++ b/packages/tooltip/src/TooltipWrapper.tsx
@@ -80,6 +80,7 @@ export const TooltipWrapper = memo<PropsWithChildren<TooltipWrapperProps>>(
             ...tooltipStyle,
             ...theme.tooltip,
             transform: animatedProps.transform ?? translate(x, y),
+            opacity: animatedProps.transform ? 1 : 0,
         }
 
         return (


### PR DESCRIPTION
This was fine in version [0.62.0](https://github.com/plouc/nivo/blob/v0.62.0/packages/tooltip/src/components/TooltipWrapper.js#L61) but then there was an deletion of `opacity` field [here](https://github.com/plouc/nivo/commit/f712cfaa1b75917784506989949a2483f652cd8b#diff-2f78a5f86f826d7d62620d77e404af45289179ffdade0c0f6d0f91362192afb0L75) in version [0.64.0](https://github.com/plouc/nivo/blob/v0.64.0/packages/tooltip/src/components/TooltipWrapper.js#L76) with motivation (taken from the corresponding [PR](https://github.com/plouc/nivo/pull/1185)):
> I also got rid of the opacity property since I didn't see a scenario where it should be set to 0 after this change, but let me know if I missed anything and I can add that back.

Removing the `opacity` caused the flash effect and weird initial transition of tooltip (described [here](https://github.com/plouc/nivo/blob/v0.62.0/packages/tooltip/src/components/TooltipWrapper.js#L61))

So I'm bringing it back