### PR TITLE
fix(sankey): update onClick types in sankey chart to respect generics

### DIFF
--- a/packages/sankey/src/types.ts
+++ b/packages/sankey/src/types.ts
@@ -88,7 +88,7 @@ export interface SankeyDataProps<N extends DefaultNode, L extends DefaultLink> {
 
 export type SankeyLayerId = 'links' | 'nodes' | 'labels' | 'legends'
 
-export type SankeyMouseHandler = <N extends DefaultNode, L extends DefaultLink>(
+export type SankeyMouseHandler<N extends DefaultNode, L extends DefaultLink> = (
     data: SankeyNodeDatum<N, L> | SankeyLinkDatum<N, L>,
     event: MouseEvent
 ) => void

--- a/packages/sankey/src/types.ts
+++ b/packages/sankey/src/types.ts
@@ -142,7 +142,7 @@ export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink>
     labelTextColor: InheritedColorConfig<SankeyNodeDatum<N, L>>
 
     isInteractive: boolean
-    onClick: SankeyMouseHandler
+    onClick: SankeyMouseHandler<N, L>
     nodeTooltip: FunctionComponent<{ node: SankeyNodeDatum<N, L> }>
     linkTooltip: FunctionComponent<{ link: SankeyLinkDatum<N, L> }>
 


### PR DESCRIPTION
This PR is aimed to address a typing issue when custom types for Node and Link are not passed into the onClick handler of sankey chart and replaced with the `DefaultNode` and `DefaultLink` instead