### PR TITLE
fix tooltip default color

### DIFF
--- a/website/src/components/guides/theming/defaults.ts
+++ b/website/src/components/guides/theming/defaults.ts
@@ -110,7 +110,7 @@ const annotationsDefaults: CompleteTheme['annotations'] = {
 const tooltipDefaults: CompleteTheme['tooltip'] = {
     container: {
         background: '#ffffff',
-        color: "#000000",
+        color: extendedTheme.text.fill,
         fontSize: 12,
     },
     basic: {},

--- a/website/src/components/guides/theming/defaults.ts
+++ b/website/src/components/guides/theming/defaults.ts
@@ -110,7 +110,7 @@ const annotationsDefaults: CompleteTheme['annotations'] = {
 const tooltipDefaults: CompleteTheme['tooltip'] = {
     container: {
         background: '#ffffff',
-        color: extendedTheme.textColor,
+        color: "#000000",
         fontSize: 12,
     },
     basic: {},


### PR DESCRIPTION
This PR will the error appearing on the website when trying to expand tooltip.container in "/guides/theming/"

It should solve the issue #2520 

<img width="766" alt="image" src="https://github.com/plouc/nivo/assets/22681512/623dabc8-9e94-443d-a720-b742d80914a4">
