### PR TITLE
Fix area rendering disparity of line canvas compared to line svg

### DIFF
--- a/packages/line/src/LineCanvas.js
+++ b/packages/line/src/LineCanvas.js
@@ -193,12 +193,12 @@ const LineCanvas = props => {
                 ctx.globalAlpha = areaOpacity
 
                 areaGenerator.context(ctx)
-                series.forEach(serie => {
-                    ctx.fillStyle = serie.color
+                for (let i = series.length - 1; i >= 0; i--) {
+                    ctx.fillStyle = series[i].color
                     ctx.beginPath()
-                    areaGenerator(serie.data.map(d => d.position))
+                    areaGenerator(series[i].data.map(d => d.position))
                     ctx.fill()
-                })
+                }
 
                 ctx.restore()
             }


### PR DESCRIPTION
This PR fixes the inconsistent rendering of `enableArea` when comparing SVG to Canvas, seen below is a example of the issue. The SVG line renders the area correctly when using a stacked line graph but the current implementation of the Canvas line renders it improperly.

This fix will make the canvas version conform with how the svg version is displayed.

SVG Line Area example (Current Good ✔️):
![svg-rendered-normal](https://github.com/plouc/nivo/assets/76515905/eef5cd5e-2aaf-44fa-83ca-4661b7da725e)

Canvas Line Area example (Current Not Good ❌):
![canvas-rendered-broken](https://github.com/plouc/nivo/assets/76515905/37521f29-e85b-4c2b-a7eb-b2a2083b28d9)

Canvas Line Area example (Fixed Good ✔️):
![cavas-rendered-fixed](https://github.com/plouc/nivo/assets/76515905/6169f654-188f-48d9-963e-e786739c7085)