### PR TITLE
fix:removing forwardLegendDataRef from hook dependency

### DIFF
--- a/packages/pie/src/hooks.ts
+++ b/packages/pie/src/hooks.ts
@@ -180,7 +180,7 @@ export const usePieArcs = <RawDatum>({
     useEffect(() => {
         if (typeof forwardLegendDataRef.current !== 'function') return
         forwardLegendDataRef.current(legendData)
-    }, [forwardLegendDataRef, legendData])
+    }, [legendData])
 
     return result
 }


### PR DESCRIPTION
**Related to issue #2591 #2569** 

This fix should remove the infinite re-renders when creating a custom Legend for responsive pies.

**forwardLegendDataRef** is not needed in the dependency of the useEffect hook