### PR TITLE
fix(pie chart): fix overlapping labels

### DIFF
--- a/packages/arcs/src/arc_link_labels/compute.ts
+++ b/packages/arcs/src/arc_link_labels/compute.ts
@@ -1,4 +1,4 @@
-import { positionFromAngle } from '@nivo/core'
+import { positionFromAngle, radiansToDegrees } from '@nivo/core'
 import { Arc, Point } from '../types'
 import { getNormalizedAngle } from '../utils'
 import { ArcLink } from './types'
@@ -37,8 +37,14 @@ export const computeArcLink = (
     const centerAngle = getNormalizedAngle(
         arc.startAngle + (arc.endAngle - arc.startAngle) / 2 - Math.PI / 2
     )
+
+    const absSin = Math.abs(Math.sin(centerAngle))
+    const offsetReducer = Math.abs(arc.endAngle - arc.startAngle) < (Math.PI / 10) ? 1 : 2
+    const baseOffset = radiansToDegrees(Math.asin(absSin)) / offsetReducer
+    const linkDiagonalLengthOffset = baseOffset * absSin
+
     const point0: Point = positionFromAngle(centerAngle, arc.outerRadius + offset)
-    const point1: Point = positionFromAngle(centerAngle, arc.outerRadius + offset + diagonalLength)
+    const point1: Point = positionFromAngle(centerAngle, arc.outerRadius + offset + diagonalLength + linkDiagonalLengthOffset)
 
     let side: ArcLink['side']
     let point2: Point


### PR DESCRIPTION
Fix based on the solution found in the following issue: https://github.com/plouc/nivo/issues/1378

Effectively, the solution recalculates the points on the label when segments of the pie are small (π/10 radians chosen as a useful value) so that more labels are able to be displayed without interference with one another.

It's not an exhaustive solution as when the segments become very small (<1% of the pie) there can still be overlapping, but this solution should improve the general case. A more complete solution may need an awareness of the neighbouring segments and the space around the pie.
