### PR TITLE
Add custom node type typing and expose state modification functions for custom nodes in Sankey diagrams

### DIFF
--- a/packages/sankey/src/Sankey.tsx
+++ b/packages/sankey/src/Sankey.tsx
@@ -131,6 +131,12 @@ const InnerSankey = <N extends DefaultNode, L extends DefaultLink>({
         height,
         outerWidth,
         outerHeight,
+        nodeTooltip,
+        linkTooltip,
+        currentNode,
+        setCurrentNode,
+        currentLink,
+        setCurrentLink,
     }
 
     const layerById: Record<SankeyLayerId, ReactNode> = {

--- a/packages/sankey/src/Sankey.tsx
+++ b/packages/sankey/src/Sankey.tsx
@@ -14,6 +14,7 @@ import {
     SankeyLinkDatum,
     SankeyNodeDatum,
     SankeySvgProps,
+    LayerProps,
 } from './types'
 
 type InnerSankeyProps<N extends DefaultNode, L extends DefaultLink> = Omit<
@@ -137,7 +138,7 @@ const InnerSankey = <N extends DefaultNode, L extends DefaultLink>({
         setCurrentNode,
         currentLink,
         setCurrentLink,
-    }
+    } as unknown as LayerProps<N, L>
 
     const layerById: Record<SankeyLayerId, ReactNode> = {
         links: null,

--- a/packages/sankey/src/props.ts
+++ b/packages/sankey/src/props.ts
@@ -3,6 +3,7 @@ import { SankeyLayerId, SankeyNodeDatum, SankeyAlignType } from './types'
 import { InheritedColorConfig } from '@nivo/colors'
 import { SankeyNodeTooltip } from './SankeyNodeTooltip'
 import { SankeyLinkTooltip } from './SankeyLinkTooltip'
+import { LayerProps } from './types'
 
 export const sankeyAlignmentPropMapping = {
     center: sankeyCenter,
@@ -56,7 +57,10 @@ export const svgDefaultProps = {
 
     legends: [],
 
-    layers: ['links', 'nodes', 'labels', 'legends'] as SankeyLayerId[],
+    layers: ['links', 'nodes', 'labels', 'legends'] as (
+        | SankeyLayerId
+        | React.FunctionComponent<LayerProps<any, any>>
+    )[],
 
     role: 'img',
 

--- a/packages/sankey/src/types.ts
+++ b/packages/sankey/src/types.ts
@@ -8,6 +8,7 @@ import {
     MotionProps,
     PropertyAccessor,
     ValueFormat,
+    Margin,
 } from '@nivo/core'
 import { InheritedColorConfig, OrdinalColorScaleConfig } from '@nivo/colors'
 import { LegendProps } from '@nivo/legends'
@@ -102,6 +103,22 @@ export type SankeySortFunction<N extends DefaultNode, L extends DefaultLink> = (
     b: SankeyNodeDatum<N, L>
 ) => number
 
+export interface LayerProps<N extends DefaultNode, L extends DefaultLink> {
+    links: SankeyLinkDatum<N, L>[]
+    nodes: SankeyNodeDatum<N, L>[]
+    margin: Margin
+    width: SankeySvgProps<N, L>
+    height: SankeySvgProps<N, L>
+    outerWidth: number
+    outerHeight: number
+    nodeTooltip: SankeySvgProps<N, L>
+    linkTooltip: SankeySvgProps<N, L>
+    currentNode: SankeyNodeDatum<N, L>
+    setCurrentNode: (node: SankeyNodeDatum<N, L>) => void
+    currentLink: SankeyLinkDatum<N, L>
+    setCurrentLink: (node: SankeyLinkDatum<N, L>) => void
+}
+
 export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink> {
     // formatting for link value
     valueFormat: ValueFormat<number>
@@ -110,7 +127,7 @@ export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink>
     align: SankeyAlignType | SankeyAlignFunction
     sort: SankeySortType | SankeySortFunction<N, L>
 
-    layers: SankeyLayerId[]
+    layers: (SankeyLayerId | ((props: LayerProps<N, L>) => React.ReactNode))[]
 
     margin: Box
 

--- a/packages/sankey/src/types.ts
+++ b/packages/sankey/src/types.ts
@@ -107,8 +107,8 @@ export interface LayerProps<N extends DefaultNode, L extends DefaultLink> {
     links: SankeyLinkDatum<N, L>[]
     nodes: SankeyNodeDatum<N, L>[]
     margin: Margin
-    width: SankeySvgProps<N, L>
-    height: SankeySvgProps<N, L>
+    width: number
+    height: number
     outerWidth: number
     outerHeight: number
     nodeTooltip: SankeySvgProps<N, L>
@@ -127,7 +127,7 @@ export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink>
     align: SankeyAlignType | SankeyAlignFunction
     sort: SankeySortType | SankeySortFunction<N, L>
 
-    layers: (SankeyLayerId | ((props: LayerProps<N, L>) => React.ReactNode))[]
+    layers: (SankeyLayerId | React.FunctionComponent<LayerProps<N, L>>)[]
 
     margin: Box
 


### PR DESCRIPTION
This PR introduces two key enhancements to the Nivo Sankey component:

1. **Custom Node Type Typing**: Added type definitions for custom node types, providing better type safety and developer experience when customizing nodes.

2. **State Exposure for Custom Nodes**: Exposed useful state and state modification functions to custom nodes, allowing for more dynamic and interactive visualizations. This change enables developers to easily manipulate node states, such as highlighting or toggling, directly from custom node implementations.

These features aim to provide greater flexibility and control when working with Sankey diagrams in Nivo, improving the overall customization and interactivity of the visualizations.
