### PR TITLE
Add day labels to calendar and timerange

### DIFF
--- a/packages/calendar/src/Calendar.tsx
+++ b/packages/calendar/src/Calendar.tsx
@@ -6,7 +6,16 @@ import { CalendarMonthPath } from './CalendarMonthPath'
 import { CalendarMonthLegends } from './CalendarMonthLegends'
 import { CalendarDay } from './CalendarDay'
 import { calendarDefaultProps } from './props'
-import { useMonthLegends, useYearLegends, useCalendarLayout, useDays, useColorScale } from './hooks'
+import {
+    useMonthLegends,
+    useYearLegends,
+    useCalendarLayout,
+    useDays,
+    useColorScale,
+    useFontSize,
+    useColorFormatter,
+    useDayLabels,
+} from './hooks'
 
 const InnerCalendar = ({
     margin: partialMargin,
@@ -41,6 +50,11 @@ const InnerCalendar = ({
     dayBorderColor = calendarDefaultProps.dayBorderColor,
     dayBorderWidth = calendarDefaultProps.dayBorderWidth,
     daySpacing = calendarDefaultProps.daySpacing,
+
+    dayLabel = calendarDefaultProps.dayLabel,
+    dayLabelFormat,
+    dayLabelColor = calendarDefaultProps.dayLabelColor,
+    dayLabelStyle = calendarDefaultProps.dayLabelStyle,
 
     isInteractive = calendarDefaultProps.isInteractive,
     tooltip = calendarDefaultProps.tooltip,
@@ -81,6 +95,11 @@ const InnerCalendar = ({
     const formatLegend = useValueFormatter(legendFormat)
     const formatValue = useValueFormatter(valueFormat)
 
+    const formatDayLabel = useValueFormatter(dayLabelFormat)
+    const dayLabels = useDayLabels(data, formatDayLabel)
+    const dayLabelFontSize = useFontSize(dayLabels)
+    const setLabelColor = useColorFormatter(dayLabelColor)
+
     return (
         <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} role={role}>
             {days.map(d => (
@@ -96,6 +115,11 @@ const InnerCalendar = ({
                     onMouseEnter={onMouseEnter}
                     onMouseLeave={onMouseLeave}
                     onMouseMove={onMouseMove}
+                    displayLabel={dayLabel}
+                    label={dayLabels[d.day]}
+                    labelSize={dayLabelFontSize}
+                    labelColor={setLabelColor}
+                    labelStyle={dayLabelStyle}
                     isInteractive={isInteractive}
                     tooltip={tooltip}
                     onClick={onClick}

--- a/packages/calendar/src/CalendarCanvas.tsx
+++ b/packages/calendar/src/CalendarCanvas.tsx
@@ -12,7 +12,16 @@ import {
 } from '@nivo/core'
 import { renderLegendToCanvas } from '@nivo/legends'
 import { calendarCanvasDefaultProps } from './props'
-import { useCalendarLayout, useColorScale, useMonthLegends, useYearLegends, useDays } from './hooks'
+import {
+    useCalendarLayout,
+    useColorScale,
+    useMonthLegends,
+    useYearLegends,
+    useDays,
+    useFontSize,
+    useColorFormatter,
+    useDayLabels,
+} from './hooks'
 import { useTooltip } from '@nivo/tooltip'
 import { CalendarCanvasProps } from './types'
 
@@ -74,6 +83,11 @@ const InnerCalendarCanvas = memo(
         dayBorderWidth = calendarCanvasDefaultProps.dayBorderWidth,
         daySpacing = calendarCanvasDefaultProps.daySpacing,
 
+        dayLabel = calendarCanvasDefaultProps.dayLabel,
+        dayLabelFormat,
+        dayLabelColor = calendarCanvasDefaultProps.dayLabelColor,
+        dayLabelFontWeight = calendarCanvasDefaultProps.dayLabelFontWeight,
+
         isInteractive = calendarCanvasDefaultProps.isInteractive,
         tooltip = calendarCanvasDefaultProps.tooltip,
         onClick,
@@ -121,6 +135,11 @@ const InnerCalendarCanvas = memo(
         const formatValue = useValueFormatter(valueFormat)
         const formatLegend = useValueFormatter(legendFormat)
 
+        const formatDayLabel = useValueFormatter(dayLabelFormat)
+        const dayLabels = useDayLabels(data, formatDayLabel)
+        const dayLabelFontSize = useFontSize(dayLabels)
+        const setLabelColor = useColorFormatter(dayLabelColor)
+
         const { showTooltipFromEvent, hideTooltip } = useTooltip()
 
         useEffect(() => {
@@ -139,6 +158,9 @@ const InnerCalendarCanvas = memo(
             ctx.fillRect(0, 0, outerWidth, outerHeight)
             ctx.translate(margin.left, margin.top)
 
+            ctx.textAlign = 'center'
+            ctx.textBaseline = 'middle'
+
             days.forEach(day => {
                 ctx.fillStyle = day.color
                 if (dayBorderWidth > 0) {
@@ -150,13 +172,24 @@ const InnerCalendarCanvas = memo(
                 ctx.rect(day.x, day.y, day.size, day.size)
                 ctx.fill()
 
+                if (dayLabel && dayLabels[day.day] && 'data' in day) {
+                    ctx.font = `${dayLabelFontWeight} ${dayLabelFontSize(
+                        day.size - dayBorderWidth,
+                        day.size - dayBorderWidth
+                    )} ${theme.labels.text.fontFamily}`
+                    ctx.fillStyle = setLabelColor(day.data)
+                    ctx.fillText(
+                        dayLabels[day.day],
+                        day.x + dayBorderWidth / 2 + (day.size - dayBorderWidth) / 2,
+                        day.y + dayBorderWidth / 2 + (day.size - dayBorderWidth) / 2
+                    )
+                }
+
                 if (dayBorderWidth > 0) {
                     ctx.stroke()
                 }
             })
 
-            ctx.textAlign = 'center'
-            ctx.textBaseline = 'middle'
             ctx.fillStyle = theme.labels.text.fill ?? ''
             ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily}`
 
@@ -202,6 +235,11 @@ const InnerCalendarCanvas = memo(
             days,
             dayBorderColor,
             dayBorderWidth,
+            dayLabel,
+            setLabelColor,
+            dayLabelFontSize,
+            dayLabelFontWeight,
+            formatDayLabel,
             colorScale,
             yearLegend,
             yearLegends,

--- a/packages/calendar/src/CalendarDay.tsx
+++ b/packages/calendar/src/CalendarDay.tsx
@@ -12,6 +12,11 @@ export const CalendarDay = memo(
         color,
         borderWidth,
         borderColor,
+        displayLabel,
+        label,
+        labelSize,
+        labelColor,
+        labelStyle,
         isInteractive,
         tooltip,
         onMouseEnter,
@@ -71,21 +76,39 @@ export const CalendarDay = memo(
         )
 
         return (
-            <rect
-                x={x}
-                y={y}
-                width={size}
-                height={size}
-                style={{
-                    fill: color,
-                    strokeWidth: borderWidth,
-                    stroke: borderColor,
-                }}
-                onMouseEnter={isInteractive ? handleMouseEnter : undefined}
-                onMouseMove={isInteractive ? handleMouseMove : undefined}
-                onMouseLeave={isInteractive ? handleMouseLeave : undefined}
-                onClick={isInteractive ? handleClick : undefined}
-            />
+            <>
+                <rect
+                    x={x}
+                    y={y}
+                    width={size}
+                    height={size}
+                    style={{
+                        fill: color,
+                        strokeWidth: borderWidth,
+                        stroke: borderColor,
+                    }}
+                    onMouseEnter={isInteractive ? handleMouseEnter : undefined}
+                    onMouseMove={isInteractive ? handleMouseMove : undefined}
+                    onMouseLeave={isInteractive ? handleMouseLeave : undefined}
+                    onClick={isInteractive ? handleClick : undefined}
+                />
+                {displayLabel && label && 'value' in data && (
+                    <text
+                        x={x + size / 2}
+                        y={y + size / 2}
+                        width={size}
+                        height={size}
+                        dy={(size - borderWidth) * 0.05}
+                        dominantBaseline="middle"
+                        textAnchor="middle"
+                        fill={labelColor(data)}
+                        fontSize={labelSize(size - borderWidth, size - borderWidth)}
+                        style={{ pointerEvents: 'none', ...labelStyle }}
+                    >
+                        {label}
+                    </text>
+                )}
+            </>
         )
     }
 )

--- a/packages/calendar/src/TimeRange.tsx
+++ b/packages/calendar/src/TimeRange.tsx
@@ -8,7 +8,13 @@ import {
     computeMonthLegends,
     computeTotalDays,
 } from './compute/timeRange'
-import { useMonthLegends, useColorScale } from './hooks'
+import {
+    useMonthLegends,
+    useColorScale,
+    useFontSize,
+    useColorFormatter,
+    useDayLabels,
+} from './hooks'
 import { TimeRangeDay } from './TimeRangeDay'
 import { CalendarMonthLegends } from './CalendarMonthLegends'
 import { TimeRangeSvgProps } from './types'
@@ -43,6 +49,11 @@ const InnerTimeRange = ({
     dayBorderWidth = timeRangeDefaultProps.dayBorderWidth,
     daySpacing = timeRangeDefaultProps.daySpacing,
     dayRadius = timeRangeDefaultProps.dayRadius,
+
+    dayLabel = timeRangeDefaultProps.dayLabel,
+    dayLabelFormat,
+    dayLabelColor = timeRangeDefaultProps.dayLabelColor,
+    dayLabelStyle = timeRangeDefaultProps.dayLabelStyle,
 
     isInteractive = timeRangeDefaultProps.isInteractive,
     tooltip = timeRangeDefaultProps.tooltip,
@@ -133,6 +144,11 @@ const InnerTimeRange = ({
     const formatValue = useValueFormatter(valueFormat)
     const formatLegend = useValueFormatter(legendFormat)
 
+    const formatDayLabel = useValueFormatter(dayLabelFormat)
+    const dayLabels = useDayLabels(data, formatDayLabel)
+    const dayLabelFontSize = useFontSize(dayLabels)
+    const setLabelColor = useColorFormatter(dayLabelColor)
+
     return (
         <SvgWrapper width={outerWidth} height={outerHeight} margin={margin} role={role}>
             {weekdayLegends.map(legend => (
@@ -159,6 +175,11 @@ const InnerTimeRange = ({
                         color={d.color}
                         borderWidth={dayBorderWidth}
                         borderColor={dayBorderColor}
+                        displayLabel={dayLabel}
+                        label={dayLabels[d.day]}
+                        labelSize={dayLabelFontSize}
+                        labelColor={setLabelColor}
+                        labelStyle={dayLabelStyle}
                         onMouseEnter={onMouseEnter}
                         onMouseLeave={onMouseLeave}
                         onMouseMove={onMouseMove}

--- a/packages/calendar/src/TimeRangeDay.tsx
+++ b/packages/calendar/src/TimeRangeDay.tsx
@@ -14,6 +14,11 @@ export const TimeRangeDay = memo(
         color,
         borderWidth,
         borderColor,
+        displayLabel,
+        label,
+        labelSize,
+        labelColor,
+        labelStyle,
         isInteractive,
         tooltip,
         onMouseEnter,
@@ -71,23 +76,41 @@ export const TimeRangeDay = memo(
         )
 
         return (
-            <rect
-                x={x}
-                y={y}
-                rx={rx}
-                ry={ry}
-                width={width}
-                height={height}
-                style={{
-                    fill: color,
-                    strokeWidth: borderWidth,
-                    stroke: borderColor,
-                }}
-                onMouseEnter={isInteractive ? handleMouseEnter : undefined}
-                onMouseMove={isInteractive ? handleMouseMove : undefined}
-                onMouseLeave={isInteractive ? handleMouseLeave : undefined}
-                onClick={isInteractive ? handleClick : undefined}
-            />
+            <>
+                <rect
+                    x={x}
+                    y={y}
+                    rx={rx}
+                    ry={ry}
+                    width={width}
+                    height={height}
+                    style={{
+                        fill: color,
+                        strokeWidth: borderWidth,
+                        stroke: borderColor,
+                    }}
+                    onMouseEnter={isInteractive ? handleMouseEnter : undefined}
+                    onMouseMove={isInteractive ? handleMouseMove : undefined}
+                    onMouseLeave={isInteractive ? handleMouseLeave : undefined}
+                    onClick={isInteractive ? handleClick : undefined}
+                />
+                {displayLabel && label && 'value' in data && (
+                    <text
+                        x={x + width / 2}
+                        y={y + height / 2}
+                        width={width}
+                        height={height}
+                        dy={(height - borderWidth) * 0.05}
+                        dominantBaseline="middle"
+                        textAnchor="middle"
+                        fill={labelColor(data)}
+                        fontSize={labelSize(width - borderWidth, height - borderWidth)}
+                        style={{ pointerEvents: 'none', ...labelStyle }}
+                    >
+                        {label}
+                    </text>
+                )}
+            </>
         )
     }
 )

--- a/packages/calendar/src/compute/calendar.ts
+++ b/packages/calendar/src/compute/calendar.ts
@@ -5,7 +5,7 @@ import { alignBox } from '@nivo/core'
 import { timeFormat } from 'd3-time-format'
 import { timeDays, timeWeek, timeWeeks, timeMonths, timeYear } from 'd3-time'
 import { ScaleQuantize } from 'd3-scale'
-import { BBox, CalendarSvgProps, ColorScale, Datum, Year } from '../types'
+import { BBox, CalendarDatum, CalendarSvgProps, ColorScale, Datum, Year } from '../types'
 
 /**
  * Compute min/max values.
@@ -465,4 +465,33 @@ export const computeMonthLegendPositions = <Month extends { bbox: BBox }>({
             rotation,
         }
     })
+}
+
+export const computeMaxLabelLength = (labels: string[]): number => {
+    return labels.reduce((max, label) => {
+        return Math.max(label.length, max)
+    }, 0)
+}
+
+export const createFontSizeCalculator = (maxLength: number) => {
+    const cache = { width: 0, height: 0, fontSize: '0px' }
+    return (width: number, height: number) => {
+        if (width != cache.width || height != cache.height) {
+            cache.fontSize = `${Math.max(Math.min(width / (0.5 + maxLength * 0.5), height), 0)}px`
+            cache.height = height
+            cache.width = width
+        }
+        return cache.fontSize
+    }
+}
+
+export const computeDayLabels = (
+    data: CalendarDatum[],
+    format: (value: number, day: CalendarDatum) => string
+): { [day: string]: string } => {
+    const dayLabelPairs: { [day: string]: string } = {}
+    data.forEach(day => {
+        dayLabelPairs[day.day] = format(day.value, day)
+    })
+    return dayLabelPairs
 }

--- a/packages/calendar/src/hooks.ts
+++ b/packages/calendar/src/hooks.ts
@@ -6,8 +6,11 @@ import {
     computeMonthLegendPositions,
     bindDaysData,
     computeLayout,
+    computeMaxLabelLength,
+    computeDayLabels,
+    createFontSizeCalculator,
 } from './compute/calendar'
-import { BBox, CalendarSvgProps, ColorScale, Year } from './types'
+import { BBox, CalendarSvgProps, ColorScale, Year, CalendarDatum } from './types'
 
 export const useCalendarLayout = ({
     width,
@@ -125,3 +128,18 @@ export const useDays = ({
             }),
         [days, data, colorScale, emptyColor]
     )
+
+export const useFontSize = (labels: { [key: string]: string }) => {
+    const maxLength = useMemo(() => computeMaxLabelLength(Object.values(labels)), [labels])
+
+    return useMemo(() => createFontSizeCalculator(maxLength), [maxLength])
+}
+
+export const useColorFormatter = (format: string | ((data: CalendarDatum) => string)) =>
+    useMemo(() => (typeof format === 'function' ? format : () => format), [format])
+
+export const useDayLabels = (
+    data: CalendarDatum[],
+    dayLabelFormatter: (value: number, day: CalendarDatum) => string
+): { [day: string]: string } =>
+    useMemo(() => computeDayLabels(data, dayLabelFormatter), [data, dayLabelFormatter])

--- a/packages/calendar/src/props.ts
+++ b/packages/calendar/src/props.ts
@@ -30,6 +30,9 @@ const commonDefaultProps = {
     dayBorderWidth: 1,
     dayBorderColor: '#000',
 
+    dayLabel: false,
+    dayLabelColor: '#000000',
+
     isInteractive: true,
 
     legends: [] as CalendarLegendProps[],
@@ -38,11 +41,13 @@ const commonDefaultProps = {
 
 export const calendarDefaultProps = {
     ...commonDefaultProps,
+    dayLabelStyle: {},
     role: 'img',
 } as const
 
 export const calendarCanvasDefaultProps = {
     ...commonDefaultProps,
+    dayLabelFontWeight: '',
     pixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio ?? 1 : 1,
 } as const
 

--- a/packages/calendar/src/types.ts
+++ b/packages/calendar/src/types.ts
@@ -103,6 +103,11 @@ export type CalendarDayProps = {
     color: string
     borderWidth: number
     borderColor: string
+    displayLabel: boolean
+    label: string
+    labelSize: (width: number, height: number) => string
+    labelColor: (day: CalendarDatum) => string
+    labelStyle: React.CSSProperties
     isInteractive: boolean
     tooltip: React.FC<CalendarTooltipProps>
     formatValue: (value: number) => string
@@ -145,6 +150,10 @@ export type CommonCalendarProps = {
     valueFormat: ValueFormat<number>
     legendFormat: ValueFormat<number>
 
+    dayLabel: boolean
+    dayLabelFormat: ValueFormat<number, CalendarDatum>
+    dayLabelColor: string | ((day: CalendarDatum) => string)
+
     theme: Theme
 
     // interactivity
@@ -162,6 +171,7 @@ export type CalendarSvgProps = Dimensions &
         CommonCalendarProps &
             InteractivityProps<Omit<Datum, 'data' | 'value'> | Datum, SVGRectElement> & {
                 role: string
+                dayLabelStyle: React.CSSProperties
             }
     >
 
@@ -171,6 +181,8 @@ export type CalendarCanvasProps = Dimensions &
         CommonCalendarProps &
             InteractivityProps<Omit<Datum, 'data' | 'value'> | Datum, HTMLCanvasElement> & {
                 pixelRatio: number
+                dayLabelFont: string
+                dayLabelFontWeight: string
             }
     >
 
@@ -201,9 +213,10 @@ export type Weekday =
     | 'friday'
     | 'saturday'
 
-export type TimeRangeSvgProps = Dimensions & { data: CalendarDatum[] } & Partial<
-        Omit<CalendarData, 'data'>
-    > &
+export type TimeRangeSvgProps = Dimensions & {
+    data: CalendarDatum[]
+    dayLabelStyle: React.CSSProperties
+} & Partial<Omit<CalendarData, 'data'>> &
     Partial<
         Omit<
             CommonCalendarProps,
@@ -232,6 +245,11 @@ export type TimeRangeDayProps = Record<
     data: TimeRangeDayData
     color: string
     borderColor: string
+    displayLabel: boolean
+    label: string
+    labelSize: (width: number, height: number) => string
+    labelColor: (day: CalendarDatum) => string
+    labelStyle: React.CSSProperties
     isInteractive: boolean
     tooltip: React.FC<TimeRangeTooltipProps>
     formatValue: (value: number) => string

--- a/website/src/data/components/calendar/mapper.tsx
+++ b/website/src/data/components/calendar/mapper.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { settingsMapper } from '../../../lib/settings'
+import { mapFormat, settingsMapper } from '../../../lib/settings'
 
 const TooltipWrapper = styled.div`
     display: grid;
@@ -33,6 +33,7 @@ const CustomTooltip = day => {
 
 export default settingsMapper(
     {
+        dayLabelFormat: mapFormat,
         tooltip: (value, values) => {
             if (!values['custom tooltip example']) return undefined
 

--- a/website/src/data/components/calendar/props.ts
+++ b/website/src/data/components/calendar/props.ts
@@ -308,6 +308,56 @@ const props: ChartProperty[] = [
         control: { type: 'colorPicker' },
         group: 'Days',
     },
+    {
+        key: 'dayLabel',
+        help: 'enable/disable label on day cells.',
+        type: 'boolean',
+        required: false,
+        defaultValue: defaults.dayLabel,
+        flavors: ['svg', 'canvas'],
+        control: { type: 'switch' },
+        group: 'Days',
+    },
+    {
+        key: 'dayLabelColor',
+        type: 'string | Function',
+        required: false,
+        defaultValue: defaults.dayLabelColor,
+        flavors: ['svg', 'canvas'],
+        control: { type: 'colorPicker' },
+        group: 'Days',
+    },
+    {
+        key: 'dayLabelFormat',
+        group: 'Days',
+        flavors: ['svg', 'canvas'],
+        help: 'Optional formatter for values.',
+        description: `
+            The formatted value can then be used for labels & tooltips.
+
+            Under the hood, nivo uses [d3-format](https://github.com/d3/d3-format),
+            please have a look at it for available formats, you can also pass a function
+            which will receive the raw value and should return the formatted one.
+        `,
+        required: false,
+        type: 'string | Function ',
+        control: { type: 'valueFormat' },
+    },
+    {
+        key: 'dayLabelStyle',
+        flavors: ['svg'],
+        group: 'Days',
+        help: 'Pass inline styles directly to the label.',
+        type: 'React.CSSProperties',
+        required: false,
+    },
+    {
+        key: 'dayLabelFontWeight',
+        flavors: ['canvas'],
+        group: 'Days',
+        type: 'string',
+        required: false,
+    },
     isInteractive({
         flavors: ['svg', 'canvas'],
         defaultValue: defaults.isInteractive,

--- a/website/src/data/components/time-range/mapper.tsx
+++ b/website/src/data/components/time-range/mapper.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { settingsMapper } from '../../../lib/settings'
+import { settingsMapper, mapFormat } from '../../../lib/settings'
 
 const TooltipWrapper = styled.div`
     display: grid;
@@ -35,6 +35,7 @@ const CustomTooltip = day => {
 
 export default settingsMapper(
     {
+        dayLabelFormat: mapFormat,
         tooltip: (value, values) => {
             if (!values['custom tooltip example']) return undefined
 

--- a/website/src/data/components/time-range/props.ts
+++ b/website/src/data/components/time-range/props.ts
@@ -292,6 +292,49 @@ const props: ChartProperty[] = [
         control: { type: 'colorPicker' },
         group: 'Days',
     },
+    {
+        key: 'dayLabel',
+        help: 'enable/disable label on day cells.',
+        type: 'boolean',
+        required: false,
+        defaultValue: defaults.dayLabel,
+        flavors: ['svg'],
+        control: { type: 'switch' },
+        group: 'Days',
+    },
+    {
+        key: 'dayLabelColor',
+        type: 'string | Function',
+        required: false,
+        defaultValue: defaults.dayLabelColor,
+        flavors: ['svg'],
+        control: { type: 'colorPicker' },
+        group: 'Days',
+    },
+    {
+        key: 'dayLabelFormat',
+        group: 'Days',
+        flavors: ['svg', 'canvas'],
+        help: 'Optional formatter for values.',
+        description: `
+            The formatted value can then be used for labels & tooltips.
+
+            Under the hood, nivo uses [d3-format](https://github.com/d3/d3-format),
+            please have a look at it for available formats, you can also pass a function
+            which will receive the raw value and should return the formatted one.
+        `,
+        required: false,
+        type: 'string | Function',
+        control: { type: 'valueFormat' },
+    },
+    {
+        key: 'dayLabelStyle',
+        flavors: ['svg'],
+        group: 'Days',
+        help: 'Pass inline styles directly to the label.',
+        type: 'React.CSSProperties',
+        required: false,
+    },
     isInteractive({
         flavors: ['svg'],
         defaultValue: defaults.isInteractive,

--- a/website/src/pages/calendar/canvas.js
+++ b/website/src/pages/calendar/canvas.js
@@ -50,6 +50,10 @@ const initialProperties = {
     dayBorderWidth: 0,
     dayBorderColor: '#ffffff',
 
+    dayLabel: false,
+    dayLabelColor: '#000000',
+    dayLabelFormat: { format: '', enabled: false },
+
     isInteractive: true,
     'custom tooltip example': false,
 

--- a/website/src/pages/calendar/index.js
+++ b/website/src/pages/calendar/index.js
@@ -47,6 +47,10 @@ const initialProperties = {
     dayBorderWidth: 2,
     dayBorderColor: '#ffffff',
 
+    dayLabel: false,
+    dayLabelColor: '#000000',
+    dayLabelFormat: { format: '', enabled: false },
+
     isInteractive: true,
     'custom tooltip example': false,
     tooltip: null,

--- a/website/src/pages/time-range/index.js
+++ b/website/src/pages/time-range/index.js
@@ -44,6 +44,10 @@ const initialProperties = {
     dayBorderWidth: 2,
     dayBorderColor: '#ffffff',
 
+    dayLabel: false,
+    dayLabelColor: '#000000',
+    dayLabelFormat: { format: '', enabled: false },
+
     isInteractive: true,
     'custom tooltip example': false,
     tooltip: null,


### PR DESCRIPTION
Adds option to display values in day cells.

Default:
![default](https://github.com/user-attachments/assets/5eb88be1-a3f9-4b13-9397-93dfe6cb67e9)

Custom value & color formatting:
![customFormat](https://github.com/user-attachments/assets/7ca82460-6eed-4edc-b500-c8af87014143)

Timerange:
![timerange](https://github.com/user-attachments/assets/213bc88f-b579-420f-88b0-1980a3bdc2a8)

Related issue: #981
