### PR TITLE
Add getColor to props provided to custom layers

### DIFF
--- a/packages/bar/src/Bar.tsx
+++ b/packages/bar/src/Bar.tsx
@@ -250,6 +250,8 @@ const InnerBar = <RawDatum extends BarDatum>({
         () => ({
             borderRadius,
             borderWidth,
+            colorBy,
+            colors,
             enableLabel,
             isInteractive,
             labelSkipWidth,
@@ -269,6 +271,8 @@ const InnerBar = <RawDatum extends BarDatum>({
         [
             borderRadius,
             borderWidth,
+            colorBy,
+            colors,
             enableLabel,
             getTooltipLabel,
             isInteractive,

--- a/packages/bar/src/Bar.tsx
+++ b/packages/bar/src/Bar.tsx
@@ -133,6 +133,7 @@ const InnerBar = <RawDatum extends BarDatum>({
         toggleSerie,
         legendsWithData,
         barTotals,
+        getColor,
     } = useBar<RawDatum>({
         indexBy,
         label,
@@ -250,8 +251,6 @@ const InnerBar = <RawDatum extends BarDatum>({
         () => ({
             borderRadius,
             borderWidth,
-            colorBy,
-            colors,
             enableLabel,
             isInteractive,
             labelSkipWidth,
@@ -271,8 +270,6 @@ const InnerBar = <RawDatum extends BarDatum>({
         [
             borderRadius,
             borderWidth,
-            colorBy,
-            colors,
             enableLabel,
             getTooltipLabel,
             isInteractive,
@@ -413,6 +410,7 @@ const InnerBar = <RawDatum extends BarDatum>({
             onClick,
             onMouseEnter,
             onMouseLeave,
+            getColor,
         }),
         [
             commonProps,
@@ -431,6 +429,7 @@ const InnerBar = <RawDatum extends BarDatum>({
             onClick,
             onMouseEnter,
             onMouseLeave,
+            getColor,
         ]
     )
 

--- a/packages/bar/src/BarCanvas.tsx
+++ b/packages/bar/src/BarCanvas.tsx
@@ -218,6 +218,7 @@ const InnerBarCanvas = <RawDatum extends BarDatum>({
         shouldRenderBarLabel,
         legendsWithData,
         barTotals,
+        getColor,
     } = useBar<RawDatum>({
         indexBy,
         label,
@@ -292,6 +293,7 @@ const InnerBarCanvas = <RawDatum extends BarDatum>({
             onClick,
             onMouseEnter,
             onMouseLeave,
+            getColor,
         }),
         [
             borderRadius,
@@ -314,6 +316,7 @@ const InnerBarCanvas = <RawDatum extends BarDatum>({
             onClick,
             onMouseEnter,
             onMouseLeave,
+            getColor,
         ]
     )
 

--- a/packages/bar/src/types.ts
+++ b/packages/bar/src/types.ts
@@ -124,6 +124,7 @@ interface BarCustomLayerBaseProps<RawDatum>
 
     xScale: AnyScale
     yScale: AnyScale
+    getColor: OrdinalColorScaleConfig<ComputedDatum<RawDatum>>
 }
 
 export interface BarCustomLayerProps<RawDatum>

--- a/packages/bar/src/types.ts
+++ b/packages/bar/src/types.ts
@@ -12,7 +12,7 @@ import {
     Theme,
     ValueFormat,
 } from '@nivo/core'
-import { InheritedColorConfig, OrdinalColorScaleConfig } from '@nivo/colors'
+import { InheritedColorConfig, OrdinalColorScale, OrdinalColorScaleConfig } from '@nivo/colors'
 import { LegendProps } from '@nivo/legends'
 import { AnyScale, ScaleSpec, ScaleBandSpec } from '@nivo/scales'
 import { SpringValues } from '@react-spring/web'
@@ -124,7 +124,7 @@ interface BarCustomLayerBaseProps<RawDatum>
 
     xScale: AnyScale
     yScale: AnyScale
-    getColor: OrdinalColorScaleConfig<ComputedDatum<RawDatum>>
+    getColor: OrdinalColorScale<ComputedDatum<RawDatum>>
 }
 
 export interface BarCustomLayerProps<RawDatum>


### PR DESCRIPTION
I was creating a custom layer for my bar chart and didn't find a way to access the colours passed to the chart.

Figured that the most correct approach is to actually pass `colors` and `colorBy` props to the layer so I could use `const getColor = useOrdinalColorScale(colors, colorBy)` in my custom layer.