### PR TITLE
Allow for actual motionConfig proptypes on <Container />

### DIFF
--- a/packages/core/src/components/Container.js
+++ b/packages/core/src/components/Container.js
@@ -2,7 +2,7 @@ import { useRef } from 'react'
 import PropTypes from 'prop-types'
 import { TooltipProvider, Tooltip } from '@nivo/tooltip'
 import { ThemeProvider } from '../theming'
-import { MotionConfigProvider } from '../motion'
+import { MotionConfigProvider, motionPropTypes } from '../motion'
 import { ConditionalWrapper } from './ConditionalWrapper'
 
 const containerStyle = {
@@ -43,7 +43,7 @@ Container.propTypes = {
     renderWrapper: PropTypes.bool,
     theme: PropTypes.object,
     animate: PropTypes.bool,
-    motionConfig: PropTypes.string,
+    motionConfig: PropTypes.oneOfType([PropTypes.string, motionPropTypes.motionConfig]),
 }
 
 export default Container

--- a/packages/core/src/components/LegacyContainer.js
+++ b/packages/core/src/components/LegacyContainer.js
@@ -8,7 +8,7 @@ import {
 } from '@nivo/tooltip'
 import noop from '../lib/noop'
 import { ThemeProvider } from '../theming'
-import { MotionConfigProvider } from '../motion'
+import { MotionConfigProvider, motionPropTypes } from '../motion'
 import { ConditionalWrapper } from './ConditionalWrapper'
 
 const containerStyle = {
@@ -72,5 +72,5 @@ LegacyContainer.propTypes = {
     renderWrapper: PropTypes.bool,
     theme: PropTypes.object.isRequired,
     animate: PropTypes.bool.isRequired,
-    motionConfig: PropTypes.string,
+    motionConfig: PropTypes.oneOfType([PropTypes.string, motionPropTypes.motionConfig]),
 }


### PR DESCRIPTION
Notably fixes a warning we encounter regularly using this package.