### PR TITLE
fix: RadialBarTooltipComponent type

### DIFF
--- a/packages/radial-bar/src/types.ts
+++ b/packages/radial-bar/src/types.ts
@@ -56,7 +56,7 @@ export type RadialBarCustomLayer = FunctionComponent<RadialBarCustomLayerProps>
 export interface RadialBarTooltipProps<D extends RadialBarDatum = RadialBarDatum> {
     bar: ComputedBar<D>
 }
-export type RadialBarTooltipComponent = FunctionComponent<RadialBarTooltipProps>
+export type RadialBarTooltipComponent<D extends RadialBarDatum = RadialBarDatum> = FunctionComponent<RadialBarTooltipProps<D>>
 
 export interface RadialBarTrackDatum {
     id: string
@@ -101,7 +101,7 @@ export type RadialBarCommonProps<D extends RadialBarDatum = RadialBarDatum> = {
     labelsTextColor: ArcLabelsProps<ComputedBar<D>>['arcLabelsTextColor']
 
     isInteractive: boolean
-    tooltip: RadialBarTooltipComponent
+    tooltip: RadialBarTooltipComponent<D>
     onClick: (bar: ComputedBar<D>, event: MouseEvent) => void
     onMouseEnter: (bar: ComputedBar<D>, event: MouseEvent) => void
     onMouseMove: (bar: ComputedBar<D>, event: MouseEvent) => void

--- a/packages/radial-bar/src/types.ts
+++ b/packages/radial-bar/src/types.ts
@@ -56,7 +56,8 @@ export type RadialBarCustomLayer = FunctionComponent<RadialBarCustomLayerProps>
 export interface RadialBarTooltipProps<D extends RadialBarDatum = RadialBarDatum> {
     bar: ComputedBar<D>
 }
-export type RadialBarTooltipComponent<D extends RadialBarDatum = RadialBarDatum> = FunctionComponent<RadialBarTooltipProps<D>>
+export type RadialBarTooltipComponent<D extends RadialBarDatum = RadialBarDatum> =
+ FunctionComponent<RadialBarTooltipProps<D>>
 
 export interface RadialBarTrackDatum {
     id: string


### PR DESCRIPTION
Added a generic to RadialBarTooltipComponent, to better enforce the datum type.