### PR TITLE
🐛  [#2597] Prevent Line Chart from crashing when having no data

### DIFF
--- a/packages/line/tests/Line.test.js
+++ b/packages/line/tests/Line.test.js
@@ -6,11 +6,13 @@ import { LINE_UNIQUE_ID_PREFIX } from '../src/hooks'
 import SlicesItem from '../src/SlicesItem'
 import renderer from 'react-test-renderer'
 import { DotsItem } from '@nivo/core'
+import { shallow } from 'enzyme'
 
 // Handle useId mocks
 let id = 0
 beforeEach(() => {
     id = 0
+    jest.resetAllMocks()
 })
 const generateId = () => `${LINE_UNIQUE_ID_PREFIX}${++id}`
 
@@ -435,7 +437,7 @@ describe('mouse events on slices', () => {
     })
 })
 
-describe('touch events with useMesh', () => {
+describe('events with useMesh', () => {
     const data = [
         {
             id: 'A',
@@ -457,6 +459,17 @@ describe('touch events with useMesh', () => {
         enableTouchCrosshair: true,
     }
 
+    it('should not throw onMouseEnter on empty data', () => {
+        const onMouseEnter = jest.fn()
+        const wrapper = mount(<Line {...baseProps} data={[]} onMouseEnter={onMouseEnter} />)
+        expect(() =>
+            wrapper.find(`[data-ref='mesh-interceptor']`).simulate('mouseenter', {
+                clientX: 50,
+                clientY: 50,
+            })
+        ).not.toThrow()
+    })
+
     it('should call onTouchStart', () => {
         const onTouchStart = jest.fn()
         const wrapper = mount(<Line {...baseProps} onTouchStart={onTouchStart} />)
@@ -464,6 +477,7 @@ describe('touch events with useMesh', () => {
             touches: [{ clientX: 50, clientY: 50 }],
         })
         expect(onTouchStart).toHaveBeenCalledTimes(1)
+        wrapper.unmount()
     })
 
     it('should call onTouchMove', () => {
@@ -473,6 +487,7 @@ describe('touch events with useMesh', () => {
             touches: [{ clientX: 50, clientY: 50 }],
         })
         expect(onTouchMove).toHaveBeenCalledTimes(1)
+        wrapper.unmount()
     })
 
     it('should call onTouchEnd', () => {
@@ -485,6 +500,7 @@ describe('touch events with useMesh', () => {
             })
             .simulate('touchend')
         expect(onTouchEnd).toHaveBeenCalledTimes(1)
+        wrapper.unmount()
     })
 })
 

--- a/packages/line/tests/Line.test.js
+++ b/packages/line/tests/Line.test.js
@@ -6,13 +6,11 @@ import { LINE_UNIQUE_ID_PREFIX } from '../src/hooks'
 import SlicesItem from '../src/SlicesItem'
 import renderer from 'react-test-renderer'
 import { DotsItem } from '@nivo/core'
-import { shallow } from 'enzyme'
 
 // Handle useId mocks
 let id = 0
 beforeEach(() => {
     id = 0
-    jest.resetAllMocks()
 })
 const generateId = () => `${LINE_UNIQUE_ID_PREFIX}${++id}`
 
@@ -468,6 +466,7 @@ describe('events with useMesh', () => {
                 clientY: 50,
             })
         ).not.toThrow()
+        wrapper.unmount()
     })
 
     it('should call onTouchStart', () => {

--- a/packages/voronoi/src/hooks.ts
+++ b/packages/voronoi/src/hooks.ts
@@ -171,7 +171,7 @@ export const useMeshEvents = <Node, ElementType extends Element>({
 
     const findNode = useCallback(
         (event: MouseEvent<ElementType> | TouchEvent<ElementType>): null | [number, Node] => {
-            if (!elementRef.current) return null
+            if (!elementRef.current || nodes.length === 0) return null
 
             const [x, y] = getRelativeCursor(elementRef.current, event)
 


### PR DESCRIPTION
This PR fixes issue described on #2597 
The issue we had was that we are calling `delaunay.find` function on empty data, it was fixed on their side but new version was not deployed yet so we still need to make a fix around this.
The simple fix I found was to early return when we have `nodes.length === 0`.
I've also added a simple test around Line Chart