### PR TITLE
perf: faster getDistance calculations

### DIFF
--- a/packages/core/src/lib/interactivity/detect.js
+++ b/packages/core/src/lib/interactivity/detect.js
@@ -7,8 +7,7 @@
  * @param {number} y2
  * @return {number}
  */
-export const getDistance = (x1, y1, x2, y2) =>
-  Math.sqrt(((x2 - x1) ** 2) + ((y2 - y1) ** 2));
+export const getDistance = (x1, y1, x2, y2) => Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
 
 /**
  * Computes angle (radians) between two points.
@@ -20,10 +19,10 @@ export const getDistance = (x1, y1, x2, y2) =>
  * @return {number}
  */
 export const getAngle = (x1, y1, x2, y2) => {
-  const angle = Math.atan2(y2 - y1, x2 - x1) - Math.PI / 2;
+    const angle = Math.atan2(y2 - y1, x2 - x1) - Math.PI / 2
 
-  return angle > 0 ? angle : Math.PI * 2 + angle;
-};
+    return angle > 0 ? angle : Math.PI * 2 + angle
+}
 
 /**
  * Check if cursor is in given rectangle.
@@ -37,4 +36,4 @@ export const getAngle = (x1, y1, x2, y2) => {
  * @return {boolean}
  */
 export const isCursorInRect = (x, y, width, height, cursorX, cursorY) =>
-  x <= cursorX && cursorX <= x + width && y <= cursorY && cursorY <= y + height;
+    x <= cursorX && cursorX <= x + width && y <= cursorY && cursorY <= y + height

--- a/packages/core/src/lib/interactivity/detect.js
+++ b/packages/core/src/lib/interactivity/detect.js
@@ -7,15 +7,8 @@
  * @param {number} y2
  * @return {number}
  */
-export const getDistance = (x1, y1, x2, y2) => {
-    let deltaX = x2 - x1
-    let deltaY = y2 - y1
-
-    deltaX *= deltaX
-    deltaY *= deltaY
-
-    return Math.sqrt(deltaX + deltaY)
-}
+export const getDistance = (x1, y1, x2, y2) =>
+  Math.sqrt(((x2 - x1) ** 2) + ((y2 - y1) ** 2));
 
 /**
  * Computes angle (radians) between two points.
@@ -27,10 +20,10 @@ export const getDistance = (x1, y1, x2, y2) => {
  * @return {number}
  */
 export const getAngle = (x1, y1, x2, y2) => {
-    const angle = Math.atan2(y2 - y1, x2 - x1) - Math.PI / 2
+  const angle = Math.atan2(y2 - y1, x2 - x1) - Math.PI / 2;
 
-    return angle > 0 ? angle : Math.PI * 2 + angle
-}
+  return angle > 0 ? angle : Math.PI * 2 + angle;
+};
 
 /**
  * Check if cursor is in given rectangle.
@@ -44,4 +37,4 @@ export const getAngle = (x1, y1, x2, y2) => {
  * @return {boolean}
  */
 export const isCursorInRect = (x, y, width, height, cursorX, cursorY) =>
-    x <= cursorX && cursorX <= x + width && y <= cursorY && cursorY <= y + height
+  x <= cursorX && cursorX <= x + width && y <= cursorY && cursorY <= y + height;


### PR DESCRIPTION
This PR brings to the table some performance improvement for `getDistance` calculations. The performance improvement is more evident in Chrome, whereas in Safari the ops/s gains look minimal.

Here's a quick benchmark: https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJ3N25aUzVrc2hScHBzSlRoTldIMGgiLCJjb2RlIjoiREFUQS5mb3JFYWNoKCh7IHgyLCB4MSwgeTIsIHkxLCB9KSA9PiAgTWF0aC5zcXJ0KCgoeDIgLSB4MSkgKiogMikgKyAoKHkyIC0geTEpICoqIDIpKSkiLCJuYW1lIjoiSW5saW5lIiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6IlpaSjZycGo0NFhSOFdHZVdraXMtdiIsImNvZGUiOiJEQVRBLmZvckVhY2goKHsgeDIsIHgxLCB5MiwgeTEsIH0pID0-IHtcbiAgICBsZXQgZGVsdGFYID0geDIgLSB4MVxuICAgIGxldCBkZWx0YVkgPSB5MiAtIHkxXG5cbiAgICBkZWx0YVggKj0gZGVsdGFYXG4gICAgZGVsdGFZICo9IGRlbHRhWVxuXG4gICAgcmV0dXJuIE1hdGguc3FydChkZWx0YVggKyBkZWx0YVkpXG59KSIsIm5hbWUiOiJMZXQiLCJkZXBlbmRlbmNpZXMiOltdLCJhc3luYyI6ZmFsc2V9XSwiY29uZmlnIjp7Im5hbWUiOiJOaXZvIGdldERpc3RhbmNlIiwicGFyYWxsZWwiOnRydWUsImdsb2JhbFRlc3RDb25maWciOnsiZGVwZW5kZW5jaWVzIjpbXX0sImRhdGFDb2RlIjoicmV0dXJuIEFycmF5LmZyb20oeyBsZW5ndGg6IDFfMDAwIH0sIChfLCBpKSA9PiAoe1xuICB4MjogaSsxLFxuICB4MTogaSsyLFxuICB5MjogaSszLFxuICB5MTogaSs0XG59KSkifX0


While, as I said, the perf increase is neglibile in Safari, the numbers look nice in Chrome where I measured a 204% increase in ops/s, as shown in the screenshow below:
<img width="428" alt="image" src="https://github.com/user-attachments/assets/eaccd891-7ea6-4fac-a945-8561905b5a2e" />

Even if this translates in marginal QOL enhancements in real life use-cases, it's still a free win.