### PR TITLE
Remove fill property in BarTotals.tsx

### DIFF
--- a/packages/bar/src/BarTotals.tsx
+++ b/packages/bar/src/BarTotals.tsx
@@ -61,7 +61,6 @@ export const BarTotals = <RawDatum extends BarDatum>({
             style={{
                 ...theme.labels.text,
                 pointerEvents: 'none',
-                fill: theme.text.fill,
             }}
             fontWeight="bold"
             fontSize={theme.labels.text.fontSize}


### PR DESCRIPTION
Hey there 👋🏻,

I recently noticed that the color of the total label in stacked bar charts is being overridden by 'fill: theme.text.fill'. 
It seems more logical to use the 'theme.labels.text' props instead, since it's specifically for labels. 

What are your thoughts on this @plouc?