### PR TITLE
feat(sankey): enable custom layers in Sankey diagram

### DIFF
--- a/packages/sankey/src/types.ts
+++ b/packages/sankey/src/types.ts
@@ -102,6 +102,15 @@ export type SankeySortFunction<N extends DefaultNode, L extends DefaultLink> = (
     b: SankeyNodeDatum<N, L>
 ) => number
 
+export interface CustomSankeyLayerProps<N extends DefaultNode, L extends DefaultLink>
+    extends Dimensions {
+    nodes: readonly SankeyNodeDatum<N, L>[]
+    links: readonly SankeyLinkDatum<N, L>[]
+    margin: Box
+    outerWidth: number
+    outerHeight: number
+}
+
 export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink> {
     // formatting for link value
     valueFormat: ValueFormat<number>
@@ -110,7 +119,7 @@ export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink>
     align: SankeyAlignType | SankeyAlignFunction
     sort: SankeySortType | SankeySortFunction<N, L>
 
-    layers: readonly SankeyLayerId[]
+    layers: readonly (SankeyLayerId | FunctionComponent<CustomSankeyLayerProps<N, L>>)[]
 
     margin: Box
 


### PR DESCRIPTION
The code was actually already handling custom layers, this change only surfaces this capacity in the types.