### PR TITLE
feat (sankey): provide additional 'layerProps' for the custom layers

### DIFF
--- a/packages/sankey/src/Sankey.tsx
+++ b/packages/sankey/src/Sankey.tsx
@@ -1,4 +1,4 @@
-import { createElement, Fragment, ReactNode } from 'react'
+import { createElement, Fragment, ReactNode, useMemo } from 'react'
 import uniq from 'lodash/uniq'
 import { SvgWrapper, useDimensions, Container } from '@nivo/core'
 import { BoxLegendSvg } from '@nivo/legends'
@@ -96,42 +96,77 @@ const InnerSankey = <N extends DefaultNode, L extends DefaultLink>({
         labelTextColor,
     })
 
-    let isCurrentNode: (node: SankeyNodeDatum<N, L>) => boolean = () => false
-    let isCurrentLink: (link: SankeyLinkDatum<N, L>) => boolean = () => false
+    const { isCurrentNode, isCurrentLink } = useMemo(() => {
+        let isCurrentNode: (node: SankeyNodeDatum<N, L>) => boolean = () => false
+        let isCurrentLink: (link: SankeyLinkDatum<N, L>) => boolean = () => false
 
-    if (currentLink) {
-        isCurrentNode = ({ id }: SankeyNodeDatum<N, L>) =>
-            id === currentLink.source.id || id === currentLink.target.id
-        isCurrentLink = ({ source, target }: SankeyLinkDatum<N, L>) =>
-            source.id === currentLink.source.id && target.id === currentLink.target.id
-    }
+        if (currentLink) {
+            isCurrentNode = ({ id }) => id === currentLink.source.id || id === currentLink.target.id
+            isCurrentLink = ({ source, target }) =>
+                source.id === currentLink.source.id && target.id === currentLink.target.id
+        }
 
-    if (currentNode) {
-        let currentNodeIds = [currentNode.id]
-        links
-            .filter(
-                ({ source, target }) => source.id === currentNode.id || target.id === currentNode.id
-            )
-            .forEach(({ source, target }) => {
-                currentNodeIds.push(source.id)
-                currentNodeIds.push(target.id)
-            })
+        if (currentNode) {
+            let currentNodeIds = [currentNode.id]
+            links
+                .filter(
+                    ({ source, target }) =>
+                        source.id === currentNode.id || target.id === currentNode.id
+                )
+                .forEach(({ source, target }) => {
+                    currentNodeIds.push(source.id)
+                    currentNodeIds.push(target.id)
+                })
+            currentNodeIds = uniq(currentNodeIds)
 
-        currentNodeIds = uniq(currentNodeIds)
-        isCurrentNode = ({ id }) => currentNodeIds.includes(id)
-        isCurrentLink = ({ source, target }) =>
-            source.id === currentNode.id || target.id === currentNode.id
-    }
+            isCurrentNode = ({ id }) => currentNodeIds.includes(id)
+            isCurrentLink = ({ source, target }) =>
+                source.id === currentNode.id || target.id === currentNode.id
+        }
 
-    const layerProps = {
-        links,
-        nodes,
-        margin,
-        width,
-        height,
-        outerWidth,
-        outerHeight,
-    }
+        return {
+            isCurrentNode,
+            isCurrentLink,
+        }
+    }, [currentLink, currentNode, links])
+
+    const layerProps = useMemo(
+        () => ({
+            links,
+            nodes,
+            margin,
+            width,
+            height,
+            outerWidth,
+            outerHeight,
+            meta: {
+                currentNode,
+                isCurrentNode,
+                setCurrentNode,
+
+                currentLink,
+                isCurrentLink,
+                setCurrentLink,
+            },
+            isInteractive,
+        }),
+        [
+            links,
+            nodes,
+            margin,
+            width,
+            height,
+            outerWidth,
+            outerHeight,
+            currentNode,
+            isCurrentNode,
+            setCurrentNode,
+            currentLink,
+            isCurrentLink,
+            setCurrentLink,
+            isInteractive,
+        ]
+    )
 
     const layerById: Record<SankeyLayerId, ReactNode> = {
         links: null,

--- a/packages/sankey/src/Sankey.tsx
+++ b/packages/sankey/src/Sankey.tsx
@@ -139,15 +139,12 @@ const InnerSankey = <N extends DefaultNode, L extends DefaultLink>({
             height,
             outerWidth,
             outerHeight,
-            meta: {
-                currentNode,
-                isCurrentNode,
-                setCurrentNode,
-
-                currentLink,
-                isCurrentLink,
-                setCurrentLink,
-            },
+            currentNode,
+            isCurrentNode,
+            setCurrentNode,
+            currentLink,
+            isCurrentLink,
+            setCurrentLink,
             isInteractive,
         }),
         [

--- a/packages/sankey/src/hooks.ts
+++ b/packages/sankey/src/hooks.ts
@@ -48,9 +48,9 @@ export const computeNodeAndLinks = <N extends DefaultNode, L extends DefaultLink
 }) => {
     const sankey = d3Sankey()
         .nodeAlign(alignFunction)
-        // @ts-ignore: this method signature is incorrect in current @types/d3-sankey
+        // @ts-expect-error: this method signature is incorrect in current @types/d3-sankey
         .nodeSort(sortFunction)
-        // @ts-ignore: this method is not available in current @types/d3-sankey
+        // @ts-expect-error: this method is not available in current @types/d3-sankey
         .linkSort(linkSortMode)
         .nodeWidth(nodeThickness)
         .nodePadding(nodeSpacing)
@@ -94,17 +94,17 @@ export const computeNodeAndLinks = <N extends DefaultNode, L extends DefaultLink
     data.links.forEach(link => {
         link.formattedValue = formatValue(link.value)
         link.color = link.source.color
-        // @ts-ignore
+        // @ts-expect-error: @types/d3-sankey
         link.pos0 = link.y0
-        // @ts-ignore
+        // @ts-expect-error: @types/d3-sankey
         link.pos1 = link.y1
-        // @ts-ignore
+        // @ts-expect-error: @types/d3-sankey
         link.thickness = link.width
-        // @ts-ignore
+        // @ts-expect-error: @types/d3-sankey
         delete link.y0
-        // @ts-ignore
+        // @ts-expect-error: @types/d3-sankey
         delete link.y1
-        // @ts-ignore
+        // @ts-expect-error: @types/d3-sankey
         delete link.width
     })
 

--- a/packages/sankey/src/types.ts
+++ b/packages/sankey/src/types.ts
@@ -86,13 +86,13 @@ export interface SankeyDataProps<N extends DefaultNode, L extends DefaultLink> {
     }
 }
 
-export type SankeyLayerCustom<N extends DefaultNode, L extends DefaultLink> = FunctionComponent<
+export type SankeyCustomLayer<N extends DefaultNode, L extends DefaultLink> = FunctionComponent<
     CustomSankeyLayerProps<N, L>
 >
 export type SankeyLayerId = 'links' | 'nodes' | 'labels' | 'legends'
 export type SankeyLayer<N extends DefaultNode, L extends DefaultLink> =
     | SankeyLayerId
-    | SankeyLayerCustom<N, L>
+    | SankeyCustomLayer<N, L>
 
 export type SankeyMouseHandler<N extends DefaultNode, L extends DefaultLink> = (
     data: SankeyNodeDatum<N, L> | SankeyLinkDatum<N, L>,
@@ -108,15 +108,6 @@ export type SankeySortFunction<N extends DefaultNode, L extends DefaultLink> = (
     b: SankeyNodeDatum<N, L>
 ) => number
 
-export type CustomSankeyLayerMetaProps<N extends DefaultNode, L extends DefaultLink> = {
-    currentNode: SankeyNodeDatum<N, L> | null
-    isCurrentNode: (node: SankeyNodeDatum<N, L>) => boolean
-    setCurrentNode: (node: SankeyNodeDatum<N, L> | null) => void
-
-    currentLink: SankeyLinkDatum<N, L> | null
-    isCurrentLink: (link: SankeyLinkDatum<N, L>) => boolean
-    setCurrentLink: (link: SankeyLinkDatum<N, L> | null) => void
-}
 export interface CustomSankeyLayerProps<N extends DefaultNode, L extends DefaultLink>
     extends Dimensions {
     nodes: readonly SankeyNodeDatum<N, L>[]
@@ -124,7 +115,12 @@ export interface CustomSankeyLayerProps<N extends DefaultNode, L extends Default
     margin: Box
     outerWidth: number
     outerHeight: number
-    meta: CustomSankeyLayerMetaProps<N, L>
+    currentNode: SankeyNodeDatum<N, L> | null
+    isCurrentNode: (node: SankeyNodeDatum<N, L>) => boolean
+    setCurrentNode: (node: SankeyNodeDatum<N, L> | null) => void
+    currentLink: SankeyLinkDatum<N, L> | null
+    isCurrentLink: (link: SankeyLinkDatum<N, L>) => boolean
+    setCurrentLink: (link: SankeyLinkDatum<N, L> | null) => void
     isInteractive: boolean
 }
 

--- a/packages/sankey/src/types.ts
+++ b/packages/sankey/src/types.ts
@@ -86,7 +86,13 @@ export interface SankeyDataProps<N extends DefaultNode, L extends DefaultLink> {
     }
 }
 
+export type SankeyLayerCustom<N extends DefaultNode, L extends DefaultLink> = FunctionComponent<
+    CustomSankeyLayerProps<N, L>
+>
 export type SankeyLayerId = 'links' | 'nodes' | 'labels' | 'legends'
+export type SankeyLayer<N extends DefaultNode, L extends DefaultLink> =
+    | SankeyLayerId
+    | SankeyLayerCustom<N, L>
 
 export type SankeyMouseHandler<N extends DefaultNode, L extends DefaultLink> = (
     data: SankeyNodeDatum<N, L> | SankeyLinkDatum<N, L>,
@@ -102,6 +108,15 @@ export type SankeySortFunction<N extends DefaultNode, L extends DefaultLink> = (
     b: SankeyNodeDatum<N, L>
 ) => number
 
+export type CustomSankeyLayerMetaProps<N extends DefaultNode, L extends DefaultLink> = {
+    currentNode: SankeyNodeDatum<N, L> | null
+    isCurrentNode: (node: SankeyNodeDatum<N, L>) => boolean
+    setCurrentNode: (node: SankeyNodeDatum<N, L> | null) => void
+
+    currentLink: SankeyLinkDatum<N, L> | null
+    isCurrentLink: (link: SankeyLinkDatum<N, L>) => boolean
+    setCurrentLink: (link: SankeyLinkDatum<N, L> | null) => void
+}
 export interface CustomSankeyLayerProps<N extends DefaultNode, L extends DefaultLink>
     extends Dimensions {
     nodes: readonly SankeyNodeDatum<N, L>[]
@@ -109,6 +124,8 @@ export interface CustomSankeyLayerProps<N extends DefaultNode, L extends Default
     margin: Box
     outerWidth: number
     outerHeight: number
+    meta: CustomSankeyLayerMetaProps<N, L>
+    isInteractive: boolean
 }
 
 export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink> {
@@ -119,7 +136,7 @@ export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink>
     align: SankeyAlignType | SankeyAlignFunction
     sort: SankeySortType | SankeySortFunction<N, L>
 
-    layers: readonly (SankeyLayerId | FunctionComponent<CustomSankeyLayerProps<N, L>>)[]
+    layers: readonly SankeyLayer<N, L>[]
 
     margin: Box
 


### PR DESCRIPTION
Hey @plouc, thanks for your work on this library! 🤗

Some time ago I have created an [Issue#2700](https://github.com/plouc/nivo/issues/2700), where described some needed "edge case" functionality. As I got it you like an idea todo it. So I have opening the PR with those changes.

### What was done:
- `isCurrentNode` and `isCurrentLink` methods were wrapped in `useMemo` to avoid unnecessary re-rendering, due to the recalculation of the sankey chart `meta` layer props;
- `layerProps` variable is also wrapped in `useMemo` to avoid unnecessary re-renders;
- Some `@ts-ignore`'s has been replaced by `@ts-expect-error`;
- Typing adjustments to support updated `layerProps`.

### Updated `layerProps` and `layer` type:
```
type SankeyLayer = 'links' | 'nodes' | 'labels' | 'legends' | React.FC<CustomSankeyLayerProps>
```

`<Sankey ... layers={['links', 'nodes', 'labels', 'legends', (layerProps) => <></>]} />`

```
const layerProps: CustomSankeyLayerProps = {
    links,
    nodes,
    margin,
    width,
    height,
    outerWidth,
    outerHeight,
    currentNode,
    isCurrentNode,
    setCurrentNode,
    currentLink,
    isCurrentLink,
    setCurrentLink,
    isInteractive,
}
```