### PR TITLE
Fix: No longer require legendOffsetX, legendOffsetY and legendOrientation props in Markers 

### DIFF
--- a/packages/core/src/components/cartesian/markers/CartesianMarkersItem.js
+++ b/packages/core/src/components/cartesian/markers/CartesianMarkersItem.js
@@ -252,9 +252,9 @@ CartesianMarkersItem.propTypes = {
         'bottom-left',
         'left',
     ]),
-    legendOffsetX: PropTypes.number.isRequired,
-    legendOffsetY: PropTypes.number.isRequired,
-    legendOrientation: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
+    legendOffsetX: PropTypes.number,
+    legendOffsetY: PropTypes.number,
+    legendOrientation: PropTypes.oneOf(['horizontal', 'vertical']),
 }
 
 export default memo(CartesianMarkersItem)


### PR DESCRIPTION
Came across [this issue](https://github.com/plouc/nivo/issues/2077#issuecomment-2747598791) while looking for some information on it as I am seeing these warnings in the browser console in my use case. 