### PR TITLE
feat(sankey): make it easy to use a different component for labels

### DIFF
--- a/packages/sankey/src/Sankey.tsx
+++ b/packages/sankey/src/Sankey.tsx
@@ -47,6 +47,7 @@ const InnerSankey = <N extends DefaultNode, L extends DefaultLink>({
     linkBlendMode = svgDefaultProps.linkBlendMode,
     enableLinkGradient = svgDefaultProps.enableLinkGradient,
     enableLabels = svgDefaultProps.enableLabels,
+    labelComponent = svgDefaultProps.labelComponent,
     labelPosition = svgDefaultProps.labelPosition,
     labelPadding = svgDefaultProps.labelPadding,
     labelOrientation = svgDefaultProps.labelOrientation,
@@ -229,6 +230,7 @@ const InnerSankey = <N extends DefaultNode, L extends DefaultLink>({
                 labelPadding={labelPadding}
                 labelOrientation={labelOrientation}
                 getLabelTextColor={getLabelTextColor}
+                labelComponent={labelComponent}
             />
         )
     }

--- a/packages/sankey/src/SankeyLabels.tsx
+++ b/packages/sankey/src/SankeyLabels.tsx
@@ -1,7 +1,6 @@
 import { useSprings } from '@react-spring/web'
 import { useMotionConfig } from '@nivo/core'
 import { useTheme } from '@nivo/theming'
-import { Text } from '@nivo/text'
 import { DefaultLink, DefaultNode, SankeyCommonProps, SankeyNodeDatum } from './types'
 
 interface SankeyLabelsProps<N extends DefaultNode, L extends DefaultLink> {
@@ -9,6 +8,7 @@ interface SankeyLabelsProps<N extends DefaultNode, L extends DefaultLink> {
     layout: SankeyCommonProps<N, L>['layout']
     width: number
     height: number
+    labelComponent: SankeyCommonProps<N, L>['labelComponent']
     labelPosition: SankeyCommonProps<N, L>['labelPosition']
     labelPadding: SankeyCommonProps<N, L>['labelPadding']
     labelOrientation: SankeyCommonProps<N, L>['labelOrientation']
@@ -24,6 +24,7 @@ export const SankeyLabels = <N extends DefaultNode, L extends DefaultLink>({
     labelPadding,
     labelOrientation,
     getLabelTextColor,
+    labelComponent: LabelComponent,
 }: SankeyLabelsProps<N, L>) => {
     const theme = useTheme()
 
@@ -31,7 +32,7 @@ export const SankeyLabels = <N extends DefaultNode, L extends DefaultLink>({
     const labels = nodes.map(node => {
         let x
         let y
-        let textAnchor
+        let textAnchor: 'middle' | 'start' | 'end' | undefined
         if (layout === 'horizontal') {
             y = node.y + node.height / 2
             if (node.x < width / 2) {
@@ -99,7 +100,7 @@ export const SankeyLabels = <N extends DefaultNode, L extends DefaultLink>({
                 const label = labels[index]
 
                 return (
-                    <Text
+                    <LabelComponent
                         key={label.id}
                         dominantBaseline="central"
                         textAnchor={label.textAnchor}
@@ -109,9 +110,10 @@ export const SankeyLabels = <N extends DefaultNode, L extends DefaultLink>({
                             fill: animatedProps.color,
                             pointerEvents: 'none',
                         }}
+                        node={nodes[index]}
                     >
                         {label.label}
-                    </Text>
+                    </LabelComponent>
                 )
             })}
         </>

--- a/packages/sankey/src/props.ts
+++ b/packages/sankey/src/props.ts
@@ -1,6 +1,7 @@
 import { sankeyCenter, sankeyJustify, sankeyLeft, sankeyRight } from 'd3-sankey'
 import { SankeyLayerId, SankeyNodeDatum, SankeyAlignType } from './types'
 import { InheritedColorConfig } from '@nivo/colors'
+import { Text } from '@nivo/text'
 import { SankeyNodeTooltip } from './SankeyNodeTooltip'
 import { SankeyLinkTooltip } from './SankeyLinkTooltip'
 
@@ -49,6 +50,7 @@ export const svgDefaultProps = {
     labelTextColor: { from: 'color', modifiers: [['darker', 0.8]] } as InheritedColorConfig<
         SankeyNodeDatum<any, any>
     >,
+    labelComponent: Text,
 
     isInteractive: true,
     nodeTooltip: SankeyNodeTooltip,

--- a/packages/sankey/src/types.ts
+++ b/packages/sankey/src/types.ts
@@ -8,6 +8,7 @@ import {
     PropertyAccessor,
     ValueFormat,
 } from '@nivo/core'
+import { TextProps } from '@nivo/text'
 import { PartialTheme } from '@nivo/theming'
 import { InheritedColorConfig, OrdinalColorScaleConfig } from '@nivo/colors'
 import { LegendProps } from '@nivo/legends'
@@ -108,6 +109,10 @@ export type SankeySortFunction<N extends DefaultNode, L extends DefaultLink> = (
     b: SankeyNodeDatum<N, L>
 ) => number
 
+export type SankeyLabelComponent<N extends DefaultNode, L extends DefaultLink> = FunctionComponent<
+    TextProps & { node: SankeyNodeDatum<N, L> }
+>
+
 export interface CustomSankeyLayerProps<N extends DefaultNode, L extends DefaultLink>
     extends Dimensions {
     nodes: readonly SankeyNodeDatum<N, L>[]
@@ -162,6 +167,7 @@ export interface SankeyCommonProps<N extends DefaultNode, L extends DefaultLink>
     labelPadding: number
     labelOrientation: 'horizontal' | 'vertical'
     labelTextColor: InheritedColorConfig<SankeyNodeDatum<N, L>>
+    labelComponent: SankeyLabelComponent<N, L>
 
     isInteractive: boolean
     onClick: SankeyMouseHandler<N, L>

--- a/packages/text/src/Text.tsx
+++ b/packages/text/src/Text.tsx
@@ -5,7 +5,7 @@ import { TextStyle } from '@nivo/theming'
 type GetComponentProps<T> = T extends ComponentType<infer P> ? P : never
 type AnimatedComponentProps = GetComponentProps<(typeof animated)['text']>
 
-type TextProps = PropsWithChildren<
+export type TextProps = PropsWithChildren<
     Omit<AnimatedComponentProps, 'style'> & {
         style: AnimatedComponentProps['style'] &
             Pick<TextStyle, 'outlineWidth' | 'outlineColor' | 'outlineOpacity'>


### PR DESCRIPTION
Before this change it was possible not to show the layer props and build an custom layer for labels, however the internal labels layer is pretty cool and compute a lot of useful thing. Exposing the component make it customizable when one wants only to change the render of each label