### PR TITLE
fix: add types to geo package

### DIFF
--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -22,6 +22,7 @@
     ],
     "main": "./dist/nivo-geo.cjs.js",
     "module": "./dist/nivo-geo.mjs",
+    "types": "./index.d.ts",
     "files": [
         "README.md",
         "LICENSE.md",
@@ -45,6 +46,7 @@
     },
     "exports": {
         ".": {
+            "types": "./index.d.ts",
             "import": "./dist/nivo-geo.mjs",
             "require": "./dist/nivo-geo.cjs.js"
         }


### PR DESCRIPTION
This solves an issue where the types for the `@nivo/geo` package was not included.

I tested it by opening `website/src/pages/choropleth/index.tsx` on master and on this branch. Where I did get an error about missing types in my editor on master, the error was not present on this branch.

To solve it, I copied the way it was done in `@nivo/line`, which seems to be one of the few places where an `index.d.ts` is used as well.