### PR TITLE
fix: add extension for lodash imports in funnel package

### DIFF
--- a/packages/funnel/src/hooks.ts
+++ b/packages/funnel/src/hooks.ts
@@ -253,8 +253,8 @@ export const computePartsHandlers = <D extends FunnelDatum>({
         const boundOnClick =
             onClick !== undefined
                 ? (event: MouseEvent) => {
-                    onClick(part, event)
-                }
+                      onClick(part, event)
+                  }
                 : undefined
 
         return {
@@ -532,19 +532,19 @@ export const useFunnel = <D extends FunnelDatum>({
                     y: part.y1 - part.height * shapeBlending,
                 })
                 part.areaPoints.push(lastAreaPoint)
-                    ;[0, 1, 2, 3].map(index => {
-                        part.borderPoints.push({
-                            x: part.areaPoints[index].x0,
-                            y: part.areaPoints[index].y,
-                        })
+                ;[0, 1, 2, 3].map(index => {
+                    part.borderPoints.push({
+                        x: part.areaPoints[index].x0,
+                        y: part.areaPoints[index].y,
                     })
+                })
                 part.borderPoints.push(null)
-                    ;[3, 2, 1, 0].map(index => {
-                        part.borderPoints.push({
-                            x: part.areaPoints[index].x1,
-                            y: part.areaPoints[index].y,
-                        })
+                ;[3, 2, 1, 0].map(index => {
+                    part.borderPoints.push({
+                        x: part.areaPoints[index].x1,
+                        y: part.areaPoints[index].y,
                     })
+                })
             } else {
                 part.points.push({ x: part.x0, y: part.y0 })
                 if (nextPart) {
@@ -589,19 +589,19 @@ export const useFunnel = <D extends FunnelDatum>({
                     x: part.x1 - part.width * shapeBlending,
                 })
                 part.areaPoints.push(lastAreaPoint)
-                    ;[0, 1, 2, 3].map(index => {
-                        part.borderPoints.push({
-                            x: part.areaPoints[index].x,
-                            y: part.areaPoints[index].y0,
-                        })
+                ;[0, 1, 2, 3].map(index => {
+                    part.borderPoints.push({
+                        x: part.areaPoints[index].x,
+                        y: part.areaPoints[index].y0,
                     })
+                })
                 part.borderPoints.push(null)
-                    ;[3, 2, 1, 0].map(index => {
-                        part.borderPoints.push({
-                            x: part.areaPoints[index].x,
-                            y: part.areaPoints[index].y1,
-                        })
+                ;[3, 2, 1, 0].map(index => {
+                    part.borderPoints.push({
+                        x: part.areaPoints[index].x,
+                        y: part.areaPoints[index].y1,
                     })
+                })
             }
         })
 

--- a/packages/funnel/src/hooks.ts
+++ b/packages/funnel/src/hooks.ts
@@ -7,8 +7,8 @@ import { useAnnotations } from '@nivo/annotations'
 import { useTooltip, TooltipActionsContextData } from '@nivo/tooltip'
 import { svgDefaultProps as defaults } from './props'
 import { PartTooltip, PartTooltipProps } from './PartTooltip'
-import isPlainObject from 'lodash/isPlainObject'
-import get from 'lodash/get'
+import isPlainObject from 'lodash/isPlainObject.js'
+import get from 'lodash/get.js'
 import {
     FunnelDatum,
     FunnelCommonProps,
@@ -253,8 +253,8 @@ export const computePartsHandlers = <D extends FunnelDatum>({
         const boundOnClick =
             onClick !== undefined
                 ? (event: MouseEvent) => {
-                      onClick(part, event)
-                  }
+                    onClick(part, event)
+                }
                 : undefined
 
         return {
@@ -532,19 +532,19 @@ export const useFunnel = <D extends FunnelDatum>({
                     y: part.y1 - part.height * shapeBlending,
                 })
                 part.areaPoints.push(lastAreaPoint)
-                ;[0, 1, 2, 3].map(index => {
-                    part.borderPoints.push({
-                        x: part.areaPoints[index].x0,
-                        y: part.areaPoints[index].y,
+                    ;[0, 1, 2, 3].map(index => {
+                        part.borderPoints.push({
+                            x: part.areaPoints[index].x0,
+                            y: part.areaPoints[index].y,
+                        })
                     })
-                })
                 part.borderPoints.push(null)
-                ;[3, 2, 1, 0].map(index => {
-                    part.borderPoints.push({
-                        x: part.areaPoints[index].x1,
-                        y: part.areaPoints[index].y,
+                    ;[3, 2, 1, 0].map(index => {
+                        part.borderPoints.push({
+                            x: part.areaPoints[index].x1,
+                            y: part.areaPoints[index].y,
+                        })
                     })
-                })
             } else {
                 part.points.push({ x: part.x0, y: part.y0 })
                 if (nextPart) {
@@ -589,19 +589,19 @@ export const useFunnel = <D extends FunnelDatum>({
                     x: part.x1 - part.width * shapeBlending,
                 })
                 part.areaPoints.push(lastAreaPoint)
-                ;[0, 1, 2, 3].map(index => {
-                    part.borderPoints.push({
-                        x: part.areaPoints[index].x,
-                        y: part.areaPoints[index].y0,
+                    ;[0, 1, 2, 3].map(index => {
+                        part.borderPoints.push({
+                            x: part.areaPoints[index].x,
+                            y: part.areaPoints[index].y0,
+                        })
                     })
-                })
                 part.borderPoints.push(null)
-                ;[3, 2, 1, 0].map(index => {
-                    part.borderPoints.push({
-                        x: part.areaPoints[index].x,
-                        y: part.areaPoints[index].y1,
+                    ;[3, 2, 1, 0].map(index => {
+                        part.borderPoints.push({
+                            x: part.areaPoints[index].x,
+                            y: part.areaPoints[index].y1,
+                        })
                     })
-                })
             }
         })
 


### PR DESCRIPTION
This fixes what I think is a simple merge miss.

https://github.com/plouc/nivo/pull/2704 added these two imports, but https://github.com/plouc/nivo/pull/2712 did at the same time add `.js` to all lodash imports.

This causes a build error in one of my projects.