### PR TITLE
@nivo/line a11y improvements

### DIFF
--- a/cypress/src/components/line/Line.cy.tsx
+++ b/cypress/src/components/line/Line.cy.tsx
@@ -1,0 +1,69 @@
+import { Line } from '@nivo/line'
+
+describe('<Line />', () => {
+    beforeEach(() => {
+        cy.viewport(600, 500)
+    })
+
+    it('should support focusable points', () => {
+        cy.mount(
+            <Line
+                width={600}
+                height={500}
+                margin={{ top: 100, right: 50, bottom: 50, left: 50 }}
+                yScale={{ type: 'linear', stacked: true }}
+                data={[
+                    {
+                        id: 'A',
+                        data: [
+                            { x: 'V', y: 30 },
+                            { x: 'W', y: 0 },
+                            { x: 'X', y: 30 },
+                            { x: 'Y', y: 10 },
+                            { x: 'Z', y: 20 },
+                        ],
+                    },
+                    {
+                        id: 'B',
+                        data: [
+                            { x: 'V', y: 0 },
+                            { x: 'W', y: 30 },
+                            { x: 'X', y: 10 },
+                            { x: 'Y', y: 30 },
+                            { x: 'Z', y: 20 },
+                        ],
+                    },
+                ]}
+                animate={false}
+                isFocusable={true}
+            />
+        )
+
+        cy.get('[data-testid="line.point.A.0"]').should('exist')
+        cy.get('[data-testid="line.point.A.1"]').should('exist')
+        cy.get('[data-testid="line.point.A.2"]').should('exist')
+        cy.get('[data-testid="line.point.A.3"]').should('exist')
+        cy.get('[data-testid="line.point.A.4"]').should('exist')
+
+        cy.get('[data-testid="line.point.B.0"]').should('exist')
+        cy.get('[data-testid="line.point.B.1"]').should('exist')
+        cy.get('[data-testid="line.point.B.2"]').should('exist')
+        cy.get('[data-testid="line.point.B.3"]').should('exist')
+        cy.get('[data-testid="line.point.B.4"]').should('exist')
+
+        cy.get('[data-testid="line.point.A.0"]').focus()
+        cy.get('svg + div').should('exist').should('contain', `x: V, y: 30`)
+        cy.get('[data-testid="line.point.A.0"]').blur()
+        cy.get('svg + div').should('not.exist')
+
+        cy.get('[data-testid="line.point.A.2"]').focus()
+        cy.get('svg + div').should('exist').should('contain', `x: X, y: 30`)
+        cy.get('[data-testid="line.point.A.2"]').blur()
+        cy.get('svg + div').should('not.exist')
+
+        cy.get('[data-testid="line.point.B.2"]').focus()
+        cy.get('svg + div').should('exist').should('contain', `x: X, y: 10`)
+        cy.get('[data-testid="line.point.B.2"]').blur()
+        cy.get('svg + div').should('not.exist')
+    })
+})

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -647,8 +647,9 @@ export interface DotsItemProps<D = any> {
     ariaDisabled?: React.AriaAttributes['aria-disabled']
     isFocusable?: boolean
     tabIndex?: number
-    onFocus?: (event: React.FocusEvent<SVGGElement>) => void
-    onBlur?: (event: React.FocusEvent<SVGGElement>) => void
+    onFocus?: (datum: D, event: React.FocusEvent<SVGGElement>) => void
+    onBlur?: (datum: D, event: React.FocusEvent<SVGGElement>) => void
+    testId?: string
 }
 export const DotsItem: React.FunctionComponent<DotsItemProps>
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -647,6 +647,8 @@ export interface DotsItemProps<D = any> {
     ariaDisabled?: React.AriaAttributes['aria-disabled']
     isFocusable?: boolean
     tabIndex?: number
+    onFocus?: (event: React.FocusEvent<SVGGElement>) => void
+    onBlur?: (event: React.FocusEvent<SVGGElement>) => void
 }
 export const DotsItem: React.FunctionComponent<DotsItemProps>
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -619,13 +619,14 @@ export const curveFromProp: (interpolation: CurveFactoryId) => CurveFactory
 
 export const useCurveInterpolation: (interpolation: CurveFactoryId) => CurveFactory
 
-export interface DotsItemSymbolProps {
+export interface DotsItemSymbolProps<D = any> {
+    datum: D
     size: number
     color: string
     borderWidth: number
     borderColor: string
 }
-export type DotsItemSymbolComponent = React.FunctionComponent<DotsItemSymbolProps>
+export type DotsItemSymbolComponent<D = any> = React.FunctionComponent<DotsItemSymbolProps<D>>
 
 export interface DotsItemProps<D = any> {
     datum: D
@@ -638,7 +639,14 @@ export interface DotsItemProps<D = any> {
     label?: string | number
     labelTextAnchor?: 'start' | 'middle' | 'end'
     labelYOffset?: number
-    symbol?: DotsItemSymbolComponent
+    symbol?: DotsItemSymbolComponent<D>
+    ariaLabel?: React.AriaAttributes['aria-label']
+    ariaLabelledBy?: React.AriaAttributes['aria-labelledby']
+    ariaDescribedBy?: React.AriaAttributes['aria-describedby']
+    ariaHidden?: React.AriaAttributes['aria-hidden']
+    ariaDisabled?: React.AriaAttributes['aria-disabled']
+    isFocusable?: boolean
+    tabIndex?: number
 }
 export const DotsItem: React.FunctionComponent<DotsItemProps>
 

--- a/packages/core/src/components/dots/DotsItem.js
+++ b/packages/core/src/components/dots/DotsItem.js
@@ -25,6 +25,7 @@ const DotsItem = ({
     tabIndex = 0,
     onFocus,
     onBlur,
+    testId,
 }) => {
     const theme = useTheme()
 
@@ -62,6 +63,7 @@ const DotsItem = ({
             aria-hidden={ariaHidden}
             onFocus={isFocusable && onFocus ? handleFocus : undefined}
             onBlur={isFocusable && onBlur ? handleBlur : undefined}
+            data-testid={testId}
         >
             {createElement(symbol, {
                 size,

--- a/packages/core/src/components/dots/DotsItem.js
+++ b/packages/core/src/components/dots/DotsItem.js
@@ -1,4 +1,4 @@
-import { createElement, memo } from 'react'
+import { createElement, memo, useCallback } from 'react'
 import { useSpring, animated } from '@react-spring/web'
 import { useTheme, sanitizeSvgTextStyle } from '../../theming'
 import { useMotionConfig } from '../../motion'
@@ -23,6 +23,8 @@ const DotsItem = ({
     ariaDisabled,
     isFocusable = false,
     tabIndex = 0,
+    onFocus,
+    onBlur,
 }) => {
     const theme = useTheme()
 
@@ -32,6 +34,20 @@ const DotsItem = ({
         config: springConfig,
         immediate: !animate,
     })
+
+    const handleFocus = useCallback(
+        event => {
+            onFocus?.(datum, event)
+        },
+        [onFocus, datum]
+    )
+
+    const handleBlur = useCallback(
+        event => {
+            onBlur?.(datum, event)
+        },
+        [onBlur, datum]
+    )
 
     return (
         <animated.g
@@ -44,6 +60,8 @@ const DotsItem = ({
             aria-describedby={ariaDescribedBy}
             aria-disabled={ariaDisabled}
             aria-hidden={ariaHidden}
+            onFocus={isFocusable && onFocus ? handleFocus : undefined}
+            onBlur={isFocusable && onBlur ? handleBlur : undefined}
         >
             {createElement(symbol, {
                 size,

--- a/packages/core/src/components/dots/DotsItem.js
+++ b/packages/core/src/components/dots/DotsItem.js
@@ -16,6 +16,13 @@ const DotsItem = ({
     label,
     labelTextAnchor = 'middle',
     labelYOffset = -12,
+    ariaLabel,
+    ariaLabelledBy,
+    ariaDescribedBy,
+    ariaHidden,
+    ariaDisabled,
+    isFocusable = false,
+    tabIndex = 0,
 }) => {
     const theme = useTheme()
 
@@ -27,7 +34,17 @@ const DotsItem = ({
     })
 
     return (
-        <animated.g transform={animatedProps.transform} style={{ pointerEvents: 'none' }}>
+        <animated.g
+            transform={animatedProps.transform}
+            style={{ pointerEvents: 'none' }}
+            focusable={isFocusable}
+            tabIndex={isFocusable ? tabIndex : undefined}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
+            aria-describedby={ariaDescribedBy}
+            aria-disabled={ariaDisabled}
+            aria-hidden={ariaHidden}
+        >
             {createElement(symbol, {
                 size,
                 color,

--- a/packages/line/src/Line.tsx
+++ b/packages/line/src/Line.tsx
@@ -279,12 +279,15 @@ function InnerLine<Series extends LineSeries>({
                 enableLabel={enablePointLabel}
                 label={pointLabel}
                 labelYOffset={pointLabelYOffset}
+                isFocusable={isFocusable}
+                setCurrentPoint={setCurrentPoint}
+                tooltip={tooltip}
+                margin={margin}
                 ariaLabel={pointAriaLabel}
                 ariaLabelledBy={pointAriaLabelledBy}
                 ariaDescribedBy={pointAriaDescribedBy}
                 ariaHidden={pointAriaHidden}
                 ariaDisabled={pointAriaDisabled}
-                isFocusable={isFocusable}
             />
         )
     }

--- a/packages/line/src/Line.tsx
+++ b/packages/line/src/Line.tsx
@@ -41,21 +41,16 @@ function InnerLine<Series extends LineSeries>({
     yScale: yScaleSpec = svgDefaultProps.yScale,
     yFormat,
     curve = svgDefaultProps.curve as LineCurveFactoryId,
-
     margin: partialMargin,
     width,
     height,
-
     colors = svgDefaultProps.colors as OrdinalColorScaleConfig<Series>,
     lineWidth = svgDefaultProps.lineWidth as number,
-
     layers = svgDefaultProps.layers as readonly LineLayerId[],
-
     enableArea = svgDefaultProps.enableArea,
     areaBaselineValue = svgDefaultProps.areaBaselineValue as InferY<Series>,
     areaOpacity = svgDefaultProps.areaOpacity,
     areaBlendMode = svgDefaultProps.areaBlendMode,
-
     enablePoints = svgDefaultProps.enablePoints,
     pointSymbol,
     pointSize = svgDefaultProps.pointSize,
@@ -67,7 +62,6 @@ function InnerLine<Series extends LineSeries>({
     enablePointLabel = svgDefaultProps.enablePointLabel,
     pointLabel = svgDefaultProps.pointLabel as string,
     pointLabelYOffset,
-
     enableGridX = svgDefaultProps.enableGridX,
     gridXValues,
     enableGridY = svgDefaultProps.enableGridY,
@@ -76,14 +70,10 @@ function InnerLine<Series extends LineSeries>({
     axisRight,
     axisBottom = svgDefaultProps.axisBottom,
     axisLeft = svgDefaultProps.axisLeft,
-
     defs = svgDefaultProps.defs,
     fill = svgDefaultProps.fill,
-
     markers,
-
     legends = svgDefaultProps.legends,
-
     isInteractive = svgDefaultProps.isInteractive,
     useMesh = svgDefaultProps.useMesh,
     debugMesh = svgDefaultProps.debugMesh,
@@ -104,8 +94,16 @@ function InnerLine<Series extends LineSeries>({
     enableCrosshair = svgDefaultProps.enableCrosshair,
     crosshairType = svgDefaultProps.crosshairType as CrosshairType,
     enableTouchCrosshair = svgDefaultProps.enableTouchCrosshair,
-
     role = svgDefaultProps.role,
+    ariaLabel,
+    ariaLabelledBy,
+    ariaDescribedBy,
+    isFocusable = svgDefaultProps.isFocusable,
+    pointAriaLabel,
+    pointAriaLabelledBy,
+    pointAriaDescribedBy,
+    pointAriaHidden,
+    pointAriaDisabled,
     initialHiddenIds = svgDefaultProps.initialHiddenIds as InferSeriesId<Series>[],
 }: LineSvgProps<Series>) {
     const { margin, innerWidth, innerHeight, outerWidth, outerHeight } = useDimensions(
@@ -281,6 +279,12 @@ function InnerLine<Series extends LineSeries>({
                 enableLabel={enablePointLabel}
                 label={pointLabel}
                 labelYOffset={pointLabelYOffset}
+                ariaLabel={pointAriaLabel}
+                ariaLabelledBy={pointAriaLabelledBy}
+                ariaDescribedBy={pointAriaDescribedBy}
+                ariaHidden={pointAriaHidden}
+                ariaDisabled={pointAriaDisabled}
+                isFocusable={isFocusable}
             />
         )
     }
@@ -378,6 +382,10 @@ function InnerLine<Series extends LineSeries>({
             height={outerHeight}
             margin={margin}
             role={role}
+            ariaLabel={ariaLabel}
+            ariaLabelledBy={ariaLabelledBy}
+            ariaDescribedBy={ariaDescribedBy}
+            isFocusable={isFocusable}
         >
             {layers.map((layer, i) => {
                 if (typeof layer === 'function') {

--- a/packages/line/src/LineCanvas.tsx
+++ b/packages/line/src/LineCanvas.tsx
@@ -251,7 +251,7 @@ const InnerLineCanvas = <Series extends LineSeries>({
             if (layer === 'mesh' && debugMesh === true && voronoi !== undefined) {
                 renderVoronoiToCanvas(ctx, voronoi)
                 if (currentPoint) {
-                    renderVoronoiCellToCanvas(ctx, voronoi, currentPoint.index)
+                    renderVoronoiCellToCanvas(ctx, voronoi, currentPoint.absIndex)
                 }
             }
 

--- a/packages/line/src/Points.tsx
+++ b/packages/line/src/Points.tsx
@@ -12,6 +12,12 @@ const NonMemoizedPoints = <Series extends LineSeries>({
     enableLabel,
     label,
     labelYOffset,
+    isFocusable,
+    ariaLabel,
+    ariaLabelledBy,
+    ariaDescribedBy,
+    ariaHidden,
+    ariaDisabled,
 }: {
     points: readonly Point<Series>[]
     symbol: LineSvgPropsWithDefaults<Series>['pointSymbol']
@@ -20,6 +26,12 @@ const NonMemoizedPoints = <Series extends LineSeries>({
     enableLabel: LineSvgPropsWithDefaults<Series>['enablePointLabel']
     label: LineSvgPropsWithDefaults<Series>['pointLabel']
     labelYOffset: LineSvgPropsWithDefaults<Series>['pointLabelYOffset']
+    isFocusable: LineSvgPropsWithDefaults<Series>['isFocusable']
+    ariaLabel: LineSvgPropsWithDefaults<Series>['pointAriaLabel']
+    ariaLabelledBy: LineSvgPropsWithDefaults<Series>['pointAriaLabelledBy']
+    ariaDescribedBy: LineSvgPropsWithDefaults<Series>['pointAriaDescribedBy']
+    ariaHidden: LineSvgPropsWithDefaults<Series>['pointAriaHidden']
+    ariaDisabled: LineSvgPropsWithDefaults<Series>['pointAriaDisabled']
 }) => {
     const getLabel = getLabelGenerator(label)
 
@@ -31,7 +43,7 @@ const NonMemoizedPoints = <Series extends LineSeries>({
         .slice(0)
         .reverse()
         .map(point => {
-            const mappedPoint = {
+            return {
                 id: point.id,
                 x: point.x,
                 y: point.y,
@@ -39,9 +51,12 @@ const NonMemoizedPoints = <Series extends LineSeries>({
                 fill: point.color,
                 stroke: point.borderColor,
                 label: enableLabel ? getLabel(point) : null,
+                ariaLabel: ariaLabel ? ariaLabel(point) : undefined,
+                ariaLabelledBy: ariaLabelledBy ? ariaLabelledBy(point) : undefined,
+                ariaDescribedBy: ariaDescribedBy ? ariaDescribedBy(point) : undefined,
+                ariaHidden: ariaHidden ? ariaHidden(point) : undefined,
+                ariaDisabled: ariaDisabled ? ariaDisabled(point) : undefined,
             }
-
-            return mappedPoint
         })
 
     return (
@@ -59,6 +74,12 @@ const NonMemoizedPoints = <Series extends LineSeries>({
                     borderColor={point.stroke}
                     label={point.label}
                     labelYOffset={labelYOffset}
+                    ariaLabel={point.ariaLabel}
+                    ariaLabelledBy={point.ariaLabelledBy}
+                    ariaDescribedBy={point.ariaDescribedBy}
+                    ariaHidden={point.ariaHidden}
+                    ariaDisabled={point.ariaDisabled}
+                    isFocusable={isFocusable}
                 />
             ))}
         </g>

--- a/packages/line/src/Points.tsx
+++ b/packages/line/src/Points.tsx
@@ -105,6 +105,7 @@ const NonMemoizedPoints = <Series extends LineSeries>({
                     isFocusable={isFocusable}
                     onFocus={point.onFocus}
                     onBlur={point.onBlur}
+                    testId={`line.point.${point.id}`}
                 />
             ))}
         </g>

--- a/packages/line/src/defaults.ts
+++ b/packages/line/src/defaults.ts
@@ -99,6 +99,7 @@ export const svgDefaultProps: Omit<
     animate: true,
     motionConfig: 'gentle',
     role: 'img',
+    isFocusable: false,
 }
 
 export const canvasDefaultProps: Omit<

--- a/packages/line/src/hooks.ts
+++ b/packages/line/src/hooks.ts
@@ -76,18 +76,20 @@ function usePoints<Series extends LineSeries>({
     formatY: (y: InferY<Series>) => string
 }) {
     return useMemo(() => {
-        return series.reduce((acc, seriesItem) => {
+        return series.reduce((acc, seriesItem, seriesIndex) => {
             return [
                 ...acc,
                 ...seriesItem.data
                     .filter(datum => datum.position.x !== null && datum.position.y !== null)
-                    .map((datum, i) => {
+                    .map((datum, indexInSeries) => {
                         const point: Omit<Point<Series>, 'color' | 'borderColor'> & {
                             color?: string
                             borderColor?: string
                         } = {
-                            id: `${seriesItem.id}.${i}`,
-                            index: acc.length + i,
+                            id: `${seriesItem.id}.${indexInSeries}`,
+                            indexInSeries,
+                            absIndex: acc.length + indexInSeries,
+                            seriesIndex,
                             seriesId: seriesItem.id,
                             seriesColor: seriesItem.color,
                             x: datum.position.x,

--- a/packages/line/src/types.ts
+++ b/packages/line/src/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode, FunctionComponent, MouseEvent, TouchEvent, AriaAttributes } from 'react'
+import { FunctionComponent, MouseEvent, TouchEvent, AriaAttributes } from 'react'
 import { Line, Area } from 'd3-shape'
 import {
     Dimensions,
@@ -11,6 +11,7 @@ import {
     CartesianMarkerProps,
     PropertyAccessor,
     LineCurveFactoryId,
+    DotsItemSymbolComponent,
 } from '@nivo/core'
 import { AxisProps, CanvasAxisProps } from '@nivo/axes'
 import { InheritedColorConfig, OrdinalColorScaleConfig } from '@nivo/colors'
@@ -79,14 +80,6 @@ export interface Point<Series extends LineSeries> {
 export type PointColorContext<Series extends LineSeries> = {
     series: ComputedSeries<Series>
     point: Omit<Point<Series>, 'color' | 'borderColor'>
-}
-
-export interface PointSymbolProps<Series extends LineSeries> {
-    borderColor: string
-    borderWidth: number
-    color: string
-    datum: Point<Series>
-    size: number
 }
 
 export interface SliceData<Series extends LineSeries> {
@@ -198,7 +191,7 @@ export type CommonLineProps<Series extends LineSeries> = {
     colors: OrdinalColorScaleConfig<Series>
     lineWidth: number
     enablePoints: boolean
-    pointSymbol?: (props: Readonly<PointSymbolProps<Series>>) => ReactNode
+    pointSymbol?: DotsItemSymbolComponent<Point<Series>>
     pointSize: number
     pointColor: InheritedColorConfig<PointColorContext<Series>>
     pointBorderWidth: number
@@ -252,6 +245,12 @@ export interface LineSvgExtraProps<Series extends LineSeries> {
     ariaLabel?: AriaAttributes['aria-label']
     ariaLabelledBy?: AriaAttributes['aria-labelledby']
     ariaDescribedBy?: AriaAttributes['aria-describedby']
+    isFocusable: boolean
+    pointAriaLabel?: (point: Point<Series>) => AriaAttributes['aria-label']
+    pointAriaLabelledBy?: (point: Point<Series>) => AriaAttributes['aria-labelledby']
+    pointAriaDescribedBy?: (point: Point<Series>) => AriaAttributes['aria-describedby']
+    pointAriaHidden?: (point: Point<Series>) => AriaAttributes['aria-hidden']
+    pointAriaDisabled?: (point: Point<Series>) => AriaAttributes['aria-disabled']
 }
 export type LineSvgProps<Series extends LineSeries> = DataProps<Series> &
     Dimensions &

--- a/packages/line/src/types.ts
+++ b/packages/line/src/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode, FunctionComponent, MouseEvent, TouchEvent } from 'react'
+import { ReactNode, FunctionComponent, MouseEvent, TouchEvent, AriaAttributes } from 'react'
 import { Line, Area } from 'd3-shape'
 import {
     Dimensions,
@@ -249,6 +249,9 @@ export interface LineSvgExtraProps<Series extends LineSeries> {
     animate: boolean
     motionConfig: MotionProps['motionConfig']
     role: string
+    ariaLabel?: AriaAttributes['aria-label']
+    ariaLabelledBy?: AriaAttributes['aria-labelledby']
+    ariaDescribedBy?: AriaAttributes['aria-describedby']
 }
 export type LineSvgProps<Series extends LineSeries> = DataProps<Series> &
     Dimensions &

--- a/packages/line/src/types.ts
+++ b/packages/line/src/types.ts
@@ -64,7 +64,9 @@ export interface ComputedSeries<Series extends LineSeries> {
 
 export interface Point<Series extends LineSeries> {
     id: string
-    index: number
+    indexInSeries: number
+    absIndex: number
+    seriesIndex: number
     seriesId: InferSeriesId<Series>
     seriesColor: string
     x: number

--- a/packages/line/tests/Line.test.tsx
+++ b/packages/line/tests/Line.test.tsx
@@ -228,11 +228,11 @@ it('should display the label for each points', () => {
 
     const dotsItem = wrapper.find(DotsItem)
     expect(dotsItem).toHaveLength(5)
-    expect(dotsItem.at(0).prop('label')).toBe('8')
-    expect(dotsItem.at(1).prop('label')).toBe('9')
+    expect(dotsItem.at(0).prop('label')).toBe('3')
+    expect(dotsItem.at(1).prop('label')).toBe('7')
     expect(dotsItem.at(2).prop('label')).toBe('11')
-    expect(dotsItem.at(3).prop('label')).toBe('7')
-    expect(dotsItem.at(4).prop('label')).toBe('3')
+    expect(dotsItem.at(3).prop('label')).toBe('9')
+    expect(dotsItem.at(4).prop('label')).toBe('8')
 })
 
 it('should call the custom label callback for each point', () => {
@@ -269,7 +269,9 @@ it('should call the custom label callback for each point', () => {
         const currentData = serieAData[i]
         expect(pointLabelFn).toHaveBeenCalledWith({
             id: `A.${i}`,
-            index: i,
+            absIndex: i,
+            indexInSeries: i,
+            seriesIndex: 0,
             seriesId: 'A',
             seriesColor: expect.any(String),
             x: expect.any(Number),

--- a/website/src/data/components/line/generator.ts
+++ b/website/src/data/components/line/generator.ts
@@ -23,18 +23,8 @@ export const generateLightDataSet = () => {
             'skateboard',
             'others',
         ],
-        { withColors: true }
-    ).map(series => {
-        return {
-            ...series,
-            data: series.data.map(datum => {
-                return {
-                    ...datum,
-                    extra: 'HERE IT IS',
-                }
-            }),
-        }
-    }) as Array<{
+        { withColors: false }
+    ) as Array<{
         id: string
         data: Array<{ x: string; y: number }>
     }>

--- a/website/src/data/components/line/generator.ts
+++ b/website/src/data/components/line/generator.ts
@@ -23,8 +23,18 @@ export const generateLightDataSet = () => {
             'skateboard',
             'others',
         ],
-        { withColors: false }
-    ) as Array<{
+        { withColors: true }
+    ).map(series => {
+        return {
+            ...series,
+            data: series.data.map(datum => {
+                return {
+                    ...datum,
+                    extra: 'HERE IT IS',
+                }
+            }),
+        }
+    }) as Array<{
         id: string
         data: Array<{ x: string; y: number }>
     }>

--- a/website/src/data/components/line/props.ts
+++ b/website/src/data/components/line/props.ts
@@ -15,6 +15,7 @@ import {
     chartGrid,
     axes,
     isInteractive,
+    commonAccessibilityProps,
 } from '../../../lib/chart-properties'
 import { ChartProperty, Flavor } from '../../../types'
 
@@ -620,6 +621,7 @@ const props: ChartProperty[] = [
         },
     },
     ...motionProperties(['svg'], svgDefaultProps),
+    ...commonAccessibilityProps(['svg']),
 ]
 
 export const groups = groupProperties(props)

--- a/website/src/data/components/line/props.ts
+++ b/website/src/data/components/line/props.ts
@@ -621,7 +621,64 @@ const props: ChartProperty[] = [
         },
     },
     ...motionProperties(['svg'], svgDefaultProps),
-    ...commonAccessibilityProps(['svg']),
+    {
+        key: 'isFocusable',
+        flavors: ['svg'],
+        required: false,
+        defaultValue: svgDefaultProps.isFocusable,
+        group: 'Accessibility',
+        help: 'Make the root SVG element and each point focusable, for keyboard navigation.',
+        description: `
+            If enabled, focusing will also reveal the tooltip if \`isInteractive\` is \`true\`,
+            when a point gains focus and hide it on blur.
+            
+            Also note that if this option is enabled, focusing a point will reposition the tooltip
+            at a fixed location.
+        `,
+        type: 'boolean',
+        control: { type: 'switch' },
+    },
+    ...commonAccessibilityProps(['svg'], svgDefaultProps),
+    {
+        key: 'pointAriaLabel',
+        flavors: ['svg'],
+        required: false,
+        group: 'Accessibility',
+        help: '[aria-label](https://www.w3.org/TR/wai-aria/#aria-label) for points, `enablePoints` must be `true`.',
+        type: '(point: Point) => string | undefined',
+    },
+    {
+        key: 'pointAriaLabelledBy',
+        flavors: ['svg'],
+        required: false,
+        group: 'Accessibility',
+        help: '[aria-labelledby](https://www.w3.org/TR/wai-aria/#aria-labelledby) for points, `enablePoints` must be `true`.',
+        type: '(point: Point) => string | undefined',
+    },
+    {
+        key: 'pointAriaDescribedBy',
+        flavors: ['svg'],
+        required: false,
+        group: 'Accessibility',
+        help: '[aria-describedby](https://www.w3.org/TR/wai-aria/#aria-describedby) for points, `enablePoints` must be `true`.',
+        type: '(point: Point) => string | undefined',
+    },
+    {
+        key: 'pointAriaHidden',
+        flavors: ['svg'],
+        required: false,
+        group: 'Accessibility',
+        help: '[aria-hidden](https://www.w3.org/TR/wai-aria/#aria-hidden) for points, `enablePoints` must be `true`.',
+        type: '(point: Point) => boolean | undefined',
+    },
+    {
+        key: 'pointAriaDisabled',
+        flavors: ['svg'],
+        required: false,
+        group: 'Accessibility',
+        help: '[aria-disabled](https://www.w3.org/TR/wai-aria/#aria-disabled) for points, `enablePoints` must be `true`.',
+        type: '(point: Point) => boolean | undefined',
+    },
 ]
 
 export const groups = groupProperties(props)

--- a/website/src/lib/chart-properties/accessibility.ts
+++ b/website/src/lib/chart-properties/accessibility.ts
@@ -1,44 +1,48 @@
 import { ChartProperty, Flavor } from '../../types'
 
-export const role = (flavors: Flavor[]): ChartProperty => ({
+export const role = (flavors: Flavor[], defaults?: any): ChartProperty => ({
     key: 'role',
     group: 'Accessibility',
     type: 'string',
     required: false,
     help: 'Main element role attribute.',
     flavors,
+    defaultValue: defaults ? defaults.role : undefined,
 })
 
-export const ariaLabel = (flavors: Flavor[]): ChartProperty => ({
+export const ariaLabel = (flavors: Flavor[], defaults?: any): ChartProperty => ({
     key: 'ariaLabel',
     group: 'Accessibility',
     type: 'string',
     required: false,
     help: 'Main element [aria-label](https://www.w3.org/TR/wai-aria/#aria-label).',
     flavors,
+    defaultValue: defaults ? defaults.ariaLabel : undefined,
 })
 
-export const ariaLabelledBy = (flavors: Flavor[]): ChartProperty => ({
+export const ariaLabelledBy = (flavors: Flavor[], defaults?: any): ChartProperty => ({
     key: 'ariaLabelledBy',
     group: 'Accessibility',
     type: 'string',
     required: false,
     help: 'Main element [aria-labelledby](https://www.w3.org/TR/wai-aria/#aria-labelledby).',
     flavors,
+    defaultValue: defaults ? defaults.ariaLabelledBy : undefined,
 })
 
-export const ariaDescribedBy = (flavors: Flavor[]): ChartProperty => ({
+export const ariaDescribedBy = (flavors: Flavor[], defaults?: any): ChartProperty => ({
     key: 'ariaDescribedBy',
     group: 'Accessibility',
     type: 'string',
     required: false,
     help: 'Main element [aria-describedby](https://www.w3.org/TR/wai-aria/#aria-describedby).',
     flavors,
+    defaultValue: defaults ? defaults.ariaDescribedBy : undefined,
 })
 
-export const commonAccessibilityProps = (flavors: Flavor[]): ChartProperty[] => [
-    role(flavors),
-    ariaLabel(flavors),
-    ariaLabelledBy(flavors),
-    ariaDescribedBy(flavors),
+export const commonAccessibilityProps = (flavors: Flavor[], defaults?: any): ChartProperty[] => [
+    role(flavors, defaults),
+    ariaLabel(flavors, defaults),
+    ariaLabelledBy(flavors, defaults),
+    ariaDescribedBy(flavors, defaults),
 ]

--- a/website/src/pages/line/index.tsx
+++ b/website/src/pages/line/index.tsx
@@ -49,6 +49,8 @@ const initialProperties: UnmappedLineSvgProps = {
     ],
     animate: svgDefaultProps.animate,
     motionConfig: svgDefaultProps.motionConfig,
+    role: 'application',
+    isFocusable: false,
 }
 
 const linearData: LineSampleSeries[] = [

--- a/website/src/pages/line/index.tsx
+++ b/website/src/pages/line/index.tsx
@@ -50,7 +50,7 @@ const initialProperties: UnmappedLineSvgProps = {
     animate: svgDefaultProps.animate,
     motionConfig: svgDefaultProps.motionConfig,
     role: 'application',
-    isFocusable: false,
+    isFocusable: svgDefaultProps.isFocusable,
 }
 
 const linearData: LineSampleSeries[] = [


### PR DESCRIPTION
This is a first step to try to improve this package accessibility.

Adds the following properties to the `Line` component:
- `ariaLabel`
- `ariaLabelledBy`
- `ariaDescribedBy`
- `isFocusable`
- `pointAriaLabel`
- `pointAriaLabelledBy`
- `pointAriaDescribedBy`
- `pointAriaHidden`
- `pointAriaDisabled`

We can navigate through points via the keyboard, but this doesn't work if using slices.

Also fixes https://github.com/plouc/nivo/issues/2659.