### PR TITLE
Fix the default value of nice in linearScale

### DIFF
--- a/packages/bullet/src/hooks.ts
+++ b/packages/bullet/src/hooks.ts
@@ -22,7 +22,7 @@ export const useEnhancedData = (
                 const min = minValue ?? Math.min(...all)
 
                 const scale = createLinearScale(
-                    { clamp: true, min, max, type: 'linear', round: true },
+                    { clamp: true, min, max, type: 'linear', round: false },
                     { all, max, min },
                     layout === 'horizontal' ? width : height,
                     layout === 'horizontal' ? (reverse ? 'y' : 'x') : reverse ? 'x' : 'y'

--- a/packages/scales/src/linearScale.ts
+++ b/packages/scales/src/linearScale.ts
@@ -9,7 +9,7 @@ export const linearScaleDefaults: Required<ScaleLinearSpec> = {
     stacked: false,
     reverse: false,
     clamp: false,
-    nice: true,
+    nice: false,
     round: false,
 }
 

--- a/packages/scales/src/linearScale.ts
+++ b/packages/scales/src/linearScale.ts
@@ -9,7 +9,7 @@ export const linearScaleDefaults: Required<ScaleLinearSpec> = {
     stacked: false,
     reverse: false,
     clamp: false,
-    nice: false,
+    nice: true,
     round: false,
 }
 


### PR DESCRIPTION
This reverts the default value of `nice` to false 

Orginally set to true in this [PR](https://github.com/plouc/nivo/commit/0e5d3672eb920ebe1adce731212277ebd67cdb8a#diff-aee0d14423c59380cbad3f23d2e15d0ecee7eb919256d94d3dcf59aa6ad36865)

This also fixes the issue #2781 where an extra section would be added to the bullet.

Before:
<img width="635" height="205" alt="image" src="https://github.com/user-attachments/assets/57a5c691-a5d2-4ded-963d-8e057d9fc49d" />

After:
<img width="635" height="205" alt="image" src="https://github.com/user-attachments/assets/f0395242-dfee-44d2-8f87-f129e3745570" />

