### PR TITLE
fix(line): include lodash in dependencies

### DIFF
--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -47,7 +47,8 @@
         "@nivo/voronoi": "workspace:*",
         "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
         "@types/d3-shape": "^3.1.6",
-        "d3-shape": "^3.2.0"
+        "d3-shape": "^3.2.0",
+        "lodash": "^4.17.21"
     },
     "peerDependencies": {
         "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1111,6 +1111,9 @@ importers:
             d3-shape:
                 specifier: ^3.2.0
                 version: 3.2.0
+            lodash:
+                specifier: ^4.17.21
+                version: 4.17.21
             react:
                 specifier: 18.3.1
                 version: 18.3.1


### PR DESCRIPTION
Lodash is imported in packages/line/src/hooks.ts (as 'lodash/uniqueId.js') but was not included in `line`'s dependencies.

Other packages within nivo, like `bar` or `annotations`, also import from lodash, but they already include lodash in their deps.

Without this fix, I can't import the ResponsiveLine component in the nextjs project I'm working on (which already depends on lodash from elsewhere, but is not happy for `@nivo/line` to try to import lodash without declaring it as a dep).