### PR TITLE
make nice optional for createLogScale

### DIFF
--- a/packages/scales/src/logScale.ts
+++ b/packages/scales/src/logScale.ts
@@ -2,7 +2,7 @@ import { scaleLog } from 'd3-scale'
 import { ComputedSerieAxis, ScaleAxis, ScaleLog, ScaleLogSpec } from './types'
 
 export const createLogScale = (
-    { base = 10, min = 'auto', max = 'auto' }: ScaleLogSpec,
+    { base = 10, min = 'auto', max = 'auto', nice = false }: ScaleLogSpec,
     data: ComputedSerieAxis<number>,
     size: number,
     axis: ScaleAxis
@@ -47,9 +47,8 @@ export const createLogScale = (
         .domain([minValue, maxValue])
         .rangeRound(axis === 'x' ? [0, size] : [size, 0])
         .base(base)
-        .nice()
 
-    const typedScale = scale as ScaleLog
+    const typedScale = (nice ? scale.nice():scale) as ScaleLog
     typedScale.type = 'log'
 
     return typedScale

--- a/packages/scales/src/types.ts
+++ b/packages/scales/src/types.ts
@@ -66,6 +66,8 @@ export interface ScaleLogSpec {
     min?: 'auto' | number
     // default to `auto`
     max?: 'auto' | number
+    // default to `false`
+    nice?: boolean
 }
 export interface ScaleLog extends D3ScaleLogarithmic<number, number> {
     type: 'log'

--- a/storybook/stories/line/Line.stories.tsx
+++ b/storybook/stories/line/Line.stories.tsx
@@ -282,6 +282,7 @@ export const LogarithmicScale: Story = {
                 type: 'log',
                 base: 2,
                 max: 'auto',
+                min: 6
             }}
             axisBottom={{
                 legend: 'logarithmic scale (base: 2)',


### PR DESCRIPTION
Similar to what was done for https://github.com/plouc/nivo/issues/2685 but this would be for regular log scales. I can make `nice` default to true to keep it consistent.