### PR TITLE
fix(calendar): show tooltip when valueFormat returns a string

### DIFF
--- a/packages/calendar/src/CalendarTooltip.tsx
+++ b/packages/calendar/src/CalendarTooltip.tsx
@@ -3,6 +3,6 @@ import { CalendarTooltipProps } from './types'
 import { memo } from 'react'
 
 export const CalendarTooltip = memo(({ value, day, color }: CalendarTooltipProps) => {
-    if (value === undefined || isNaN(Number(value))) return null
+    if (value === undefined) return null
     return <BasicTooltip id={day} value={value} color={color} enableChip={true} />
 })


### PR DESCRIPTION
Closes #2812

CalendarTooltip was checking `isNaN(Number(value))` before rendering, but when `valueFormat` is used, the value is already a formatted string (e.g. "1,234 items"). `Number("1,234 items")` is NaN, so the tooltip silently returned null.

Since the `value` prop is typed as `string` and already goes through `valueFormat` before reaching the tooltip, the `isNaN` check doesn't make sense here. Removed it so the tooltip renders whenever `value` is defined.