### PR TITLE
chore(core): add package support metadata

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,10 @@
         "url": "https://github.com/plouc/nivo.git",
         "directory": "packages/core"
     },
+    "bugs": {
+        "url": "https://github.com/plouc/nivo/issues"
+    },
+    "homepage": "https://nivo.rocks",
     "main": "./dist/nivo-core.cjs.js",
     "module": "./dist/nivo-core.mjs",
     "types": "./index.d.ts",


### PR DESCRIPTION
## Summary\n- add npm support metadata for @nivo/core\n- point bugs.url to the public GitHub issue tracker\n- add the Nivo homepage URL\n\nMicrobounty reference: charles-openclaw/charles-microbounties#666\n\n## Validation\n- node -e "const p=require('./packages/core/package.json'); if (p.bugs?.url !== 'https://github.com/plouc/nivo/issues') { console.error(p.bugs); process.exit(1) } if (p.homepage !== 'https://nivo.rocks') { console.error(p.homepage); process.exit(1) }"\n- npm pack --dry-run --ignore-scripts ./packages/core\n- git diff --check