### PR TITLE
feat(deploy): add GitHub Actions workflow for website deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,51 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: ['master']
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued.
+concurrency:
+  group: deploy-website
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & deploy website to gh-pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build nivo packages
+        run: make pkgs-build
+
+      - name: Build the website
+        run: make website-build
+        env:
+          SITE_URL: ${{ vars.SITE_URL }}
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/public
+          publish_branch: gh-pages

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Copy Storybook into the website
         run: cp -a storybook/storybook-static website/public/storybook
 
+      # Source maps account for most of the build's weight and aren't needed
+      # in production, dropping them keeps the published site small.
+      - name: Remove source maps
+        run: find website/public -name '*.js.map' -delete
+
       # Derive the bare host (e.g. "nivo.rocks") from SITE_URL ("https://nivo.rocks")
       # so we can write a CNAME file without committing one to the repo.
       - name: Resolve CNAME host
@@ -61,4 +66,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/public
           publish_branch: gh-pages
+          # Publish as a single orphan commit so the gh-pages branch doesn't
+          # accumulate a full site snapshot on every deploy.
+          force_orphan: true
           cname: ${{ steps.cname.outputs.host }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      SITE_URL: ${{ vars.SITE_URL || 'https://nivo.rocks' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,8 +42,6 @@ jobs:
 
       - name: Build the website
         run: make website-build
-        env:
-          SITE_URL: ${{ vars.SITE_URL }}
 
       - name: Build Storybook
         run: make storybook-build
@@ -49,9 +49,16 @@ jobs:
       - name: Copy Storybook into the website
         run: cp -a storybook/storybook-static website/public/storybook
 
+      # Derive the bare host (e.g. "nivo.rocks") from SITE_URL ("https://nivo.rocks")
+      # so we can write a CNAME file without committing one to the repo.
+      - name: Resolve CNAME host
+        id: cname
+        run: echo "host=$(echo "$SITE_URL" | sed -E 's#^https?://##; s#/.*$##')" >> "$GITHUB_OUTPUT"
+
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/public
           publish_branch: gh-pages
+          cname: ${{ steps.cname.outputs.host }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -43,6 +43,12 @@ jobs:
         env:
           SITE_URL: ${{ vars.SITE_URL }}
 
+      - name: Build Storybook
+        run: make storybook-build
+
+      - name: Copy Storybook into the website
+        run: cp -a storybook/storybook-static website/public/storybook
+
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
This PR solves plouc/nivo#2815.

@FutureProg's [comment](https://github.com/plouc/nivo/issues/2815#issuecomment-3857499761)
> Is using Github pages out of the question?

This PR implements exactly that: deploy the website to GH Pages.
https://nivo.falci.me is using GitHub Pages.

@plouc's: [comment](https://github.com/plouc/nivo/issues/2815#issuecomment-4473116431)
> it was quite useful to be able to easily deploy PR branches for preview

This PR creates a new GitHub Action triggered when there's a merge to master. 
It will rebuild and update the website files, that lives in the `gh-pages` branch (it will be automatically created)
Except for the one-time setup (see below), it should require no extra step to update the website other than merging changes to master.

---

If you consider to merge this PR, there are a few settings you need to update:
1. This action will write to the `gh-pages` branch, so it will need write access. Settings → Actions → General → Workflow permissions: Read and write permissions.
2. After the first run, set Pages to serve from the `gh-pages` branch (Settings → Pages → Source: "Deploy from a branch" → gh-pages / root).
3. Update the DNS: [GitHub documentation](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site). For me it was a `nivo.falci.me CNAME falci.github.io` but for you it will be `nivo.rocks A 185.199.108.153`
4. Remove Vercel's integration.