### PR TITLE
fix: add missing metadata to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/plouc/nivo"
   },
   "author": {
-    "name": "Raphaël Benitte",
+    "name": "Rapha\u00ebl Benitte",
     "url": "https://github.com/plouc"
   },
   "keywords": [],
@@ -121,5 +121,10 @@
       "puppeteer",
       "sharp"
     ]
-  }
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/plouc/nivo/issues"
+  },
+  "homepage": "https://nivo.rocks"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,56 +1,60 @@
 {
-    "name": "@nivo/core",
-    "version": "0.99.0",
-    "license": "MIT",
-    "author": {
-        "name": "Raphaël Benitte",
-        "url": "https://github.com/plouc"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/plouc/nivo.git",
-        "directory": "packages/core"
-    },
-    "main": "./dist/nivo-core.cjs.js",
-    "module": "./dist/nivo-core.mjs",
-    "types": "./index.d.ts",
-    "files": [
-        "README.md",
-        "LICENSE.md",
-        "index.d.ts",
-        "dist/"
-    ],
-    "dependencies": {
-        "@nivo/theming": "workspace:*",
-        "@nivo/tooltip": "workspace:*",
-        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "react-virtualized-auto-sizer": "^1.0.26",
-        "use-debounce": "^10.0.4"
-    },
-    "peerDependencies": {
-        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nivo/donate"
-    },
-    "exports": {
-        ".": {
-            "types": "./index.d.ts",
-            "import": "./dist/nivo-core.mjs",
-            "require": "./dist/nivo-core.cjs.js"
-        }
+  "name": "@nivo/core",
+  "version": "0.99.0",
+  "license": "MIT",
+  "author": {
+    "name": "Rapha\u00ebl Benitte",
+    "url": "https://github.com/plouc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/plouc/nivo.git",
+    "directory": "packages/core"
+  },
+  "main": "./dist/nivo-core.cjs.js",
+  "module": "./dist/nivo-core.mjs",
+  "types": "./index.d.ts",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "index.d.ts",
+    "dist/"
+  ],
+  "dependencies": {
+    "@nivo/theming": "workspace:*",
+    "@nivo/tooltip": "workspace:*",
+    "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+    "@types/d3-shape": "^3.1.6",
+    "d3-color": "^3.1.0",
+    "d3-format": "^1.4.4",
+    "d3-interpolate": "^3.0.1",
+    "d3-scale": "^4.0.2",
+    "d3-scale-chromatic": "^3.0.0",
+    "d3-shape": "^3.2.0",
+    "d3-time-format": "^3.0.0",
+    "lodash": "^4.17.21",
+    "react-virtualized-auto-sizer": "^1.0.26",
+    "use-debounce": "^10.0.4"
+  },
+  "peerDependencies": {
+    "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/nivo/donate"
+  },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./dist/nivo-core.mjs",
+      "require": "./dist/nivo-core.cjs.js"
     }
+  },
+  "bugs": {
+    "url": "https://github.com/plouc/nivo/issues"
+  },
+  "homepage": "https://nivo.rocks"
 }


### PR DESCRIPTION
## Summary
The published npm packages `nivo@0.31.0` and `@nivo/core@0.99.0` are missing several metadata fields in their `package.json` files.

## Changes
- **Root `package.json`**: Added `license` (MIT), `bugs`, and `homepage` fields
- **`packages/core/package.json`**: Added `bugs` and `homepage` fields

## Verification
- `npm view nivo license bugs homepage --json` — license and bugs return nothing
- `npm view @nivo/core bugs homepage --json` — both return nothing
- The repository already contains `LICENSE.md`, confirming the MIT license
- No dependencies, runtime code, or build configuration affected