### PR TITLE
Apply AriaAttributes to Sunburst chart

### DIFF
--- a/packages/sunburst/src/Sunburst.tsx
+++ b/packages/sunburst/src/Sunburst.tsx
@@ -57,6 +57,9 @@ const InnerSunburst = <RawDatum,>({
     onMouseMove,
     tooltip = defaultProps.tooltip,
     role = defaultProps.role,
+    ariaLabel,
+    ariaLabelledBy,
+    ariaDescribedBy,
     forwardedRef,
 }: InnerSunburstProps<RawDatum>) => {
     const { innerHeight, innerWidth, margin, outerHeight, outerWidth } = useDimensions(
@@ -146,6 +149,9 @@ const InnerSunburst = <RawDatum,>({
             defs={boundDefs}
             margin={margin}
             role={role}
+            ariaLabel={ariaLabel}
+            ariaLabelledBy={ariaLabelledBy}
+            ariaDescribedBy={ariaDescribedBy}
             ref={forwardedRef}
         >
             {layers.map((layer, i) => {

--- a/packages/sunburst/src/types.ts
+++ b/packages/sunburst/src/types.ts
@@ -1,3 +1,4 @@
+import { AriaAttributes } from 'react'
 import { Arc, ArcGenerator, ArcLabelsProps, ArcTransitionMode } from '@nivo/arcs'
 import { OrdinalColorScaleConfig, InheritedColorConfig } from '@nivo/colors'
 import { Box, ValueFormat, SvgDefsAndFill, MotionProps, PropertyAccessor } from '@nivo/core'
@@ -68,6 +69,9 @@ export type SunburstCommonProps<RawDatum> = {
     enableArcLabels: boolean
     layers: SunburstLayer<RawDatum>[]
     role: string
+    ariaLabel?: AriaAttributes['aria-label']
+    ariaLabelledBy?: AriaAttributes['aria-labelledby']
+    ariaDescribedBy?: AriaAttributes['aria-describedby']
     renderWrapper: boolean
     transitionMode: ArcTransitionMode
     isInteractive: boolean

--- a/packages/sunburst/tests/Sunburst.test.tsx
+++ b/packages/sunburst/tests/Sunburst.test.tsx
@@ -641,4 +641,25 @@ describe('Sunburst', () => {
             expect(customLayer.prop('radius')).toEqual(200)
         })
     })
+
+    describe('accessibility', () => {
+        it('should forward root aria properties to the SVG element', () => {
+            const wrapper = mount(
+                <Sunburst
+                    width={400}
+                    height={400}
+                    data={sampleData}
+                    ariaLabel="AriaLabel"
+                    ariaLabelledBy="AriaLabelledBy"
+                    ariaDescribedBy="AriaDescribedBy"
+                />
+            )
+
+            const svg = wrapper.find('svg')
+
+            expect(svg.prop('aria-label')).toBe('AriaLabel')
+            expect(svg.prop('aria-labelledby')).toBe('AriaLabelledBy')
+            expect(svg.prop('aria-describedby')).toBe('AriaDescribedBy')
+        })
+    })
 })


### PR DESCRIPTION
Follow-up to #2823, which added `ariaLabel` / `ariaLabelledBy` / `ariaDescribedBy` to the Pie chart.

`Sunburst` defaults `role` to `'img'` but doesn't accept the aria props, so the rendered `<svg role="img">` has no way to receive an accessible name. `SvgWrapper` already forwards these attributes for the other charts (Bar, Line, Radar, Pie, etc.); Sunburst just wasn't passing them through.

This wires the same three props from `InnerSunburst` to `SvgWrapper`, matching the existing charts.

- `packages/sunburst/src/types.ts`: add the three optional props to `SunburstCommonProps`
- `packages/sunburst/src/Sunburst.tsx`: forward them to `SvgWrapper`
- `packages/sunburst/tests/Sunburst.test.tsx`: assert they reach the root `<svg>` (same shape as the Radar accessibility test)
