### PR TITLE
fix(calendar): TimeRange drops the first or last day depending on timezone

### DIFF
--- a/packages/calendar/src/compute/timeRange.ts
+++ b/packages/calendar/src/compute/timeRange.ts
@@ -13,6 +13,18 @@ import { timeFormat } from 'd3-time-format'
 import { DateOrString, Weekday } from '../types'
 import isDate from 'lodash/isDate.js'
 
+// Date-only strings such as `2018-04-01` are parsed by `Date` as UTC midnight,
+// which shifts to the previous or next local day depending on the runtime's
+// timezone offset. `data` entries already dodge this (see the `T00:00:00`
+// suffix applied in TimeRange.tsx), so `from`/`to` need the same treatment to
+// stay aligned with the rest of the range, otherwise the first or last day of
+// the range can go missing depending on the client's timezone.
+const toLocalDay = (value: DateOrString): Date => {
+    if (isDate(value)) return timeDay(value)
+    const hasTimeComponent = /T\d{2}:\d{2}/.test(value)
+    return timeDay(new Date(hasTimeComponent ? value : `${value}T00:00:00`))
+}
+
 // Interfaces
 interface ComputeBaseProps {
     direction: 'horizontal' | 'vertical'
@@ -242,9 +254,11 @@ export const computeCellPositions = ({
     // we need to determine whether we need to add days to move to correct position
     const start = from ? from : data[0].date
     const end = to ? to : data[data.length - 1].date
-    const startDate = isDate(start) ? start : new Date(start)
-    const endDate = isDate(end) ? end : new Date(end)
-    const dateRange = timeDays(startDate, endDate).map(dayDate => {
+    const startDate = toLocalDay(start)
+    const endDate = toLocalDay(end)
+    // timeDays' upper bound is exclusive, so without the offset the last day
+    // of the range never makes it into the output
+    const dateRange = timeDays(startDate, timeDay.offset(endDate, 1)).map(dayDate => {
         return {
             date: dayDate,
             day: dayFormat(dayDate),
@@ -375,19 +389,11 @@ export const computeMonthLegends = ({
 }
 
 export const computeTotalDays = ({ from, to, data }: ComputeTotalDays) => {
-    let startDate
-    let endDate
-    if (from) {
-        startDate = isDate(from) ? from : new Date(from)
-    } else {
-        startDate = data[0].date
-    }
+    const startDate = toLocalDay(from ? from : data[0].date)
+    const endDate = toLocalDay(from && to ? to : data[data.length - 1].date)
 
-    if (from && to) {
-        endDate = isDate(to) ? to : new Date(to)
-    } else {
-        endDate = data[data.length - 1].date
-    }
-
-    return startDate.getDay() + timeDay.count(startDate, endDate)
+    // timeDay.count() doesn't include the end date itself, so we add 1 to keep
+    // this in sync with the number of cells computeCellPositions produces for
+    // the same range
+    return startDate.getDay() + timeDay.count(startDate, endDate) + 1
 }

--- a/packages/calendar/tests/timeRange.test.ts
+++ b/packages/calendar/tests/timeRange.test.ts
@@ -1,0 +1,100 @@
+import { computeCellPositions, computeTotalDays } from '../src/compute/timeRange'
+
+const noop = () => '#000000'
+
+describe('computeCellPositions()', () => {
+    // https://github.com/plouc/nivo/issues/2814
+    it('should include the first day of the range when from/to are date-only strings', () => {
+        const days = computeCellPositions({
+            direction: 'horizontal',
+            colorScale: noop,
+            emptyColor: '#eeeeee',
+            from: '2018-04-01',
+            to: '2018-08-12',
+            data: [],
+            cellWidth: 10,
+            cellHeight: 10,
+            daySpacing: 2,
+            offset: 0,
+            firstWeekday: 'sunday',
+        })
+
+        expect(days[0].day).toBe('2018-04-01')
+    })
+
+    // https://github.com/plouc/nivo/issues/2333
+    it('should include the last day of the range when from/to are date-only strings', () => {
+        const days = computeCellPositions({
+            direction: 'horizontal',
+            colorScale: noop,
+            emptyColor: '#eeeeee',
+            from: '2018-04-01',
+            to: '2018-08-12',
+            data: [],
+            cellWidth: 10,
+            cellHeight: 10,
+            daySpacing: 2,
+            offset: 0,
+            firstWeekday: 'sunday',
+        })
+
+        expect(days[days.length - 1].day).toBe('2018-08-12')
+    })
+
+    it('should render a single-day range instead of an empty one', () => {
+        const days = computeCellPositions({
+            direction: 'horizontal',
+            colorScale: noop,
+            emptyColor: '#eeeeee',
+            from: '2026-02-01',
+            to: '2026-02-01',
+            data: [],
+            cellWidth: 10,
+            cellHeight: 10,
+            daySpacing: 2,
+            offset: 0,
+            firstWeekday: 'sunday',
+        })
+
+        expect(days.map(day => day.day)).toEqual(['2026-02-01'])
+    })
+})
+
+describe('computeTotalDays()', () => {
+    it('should count both endpoints as inclusive days', () => {
+        // 2018-04-01 is a Sunday, so the leading weekday padding is 0 and
+        // this reduces to a plain inclusive day count between the two dates
+        const totalDays = computeTotalDays({
+            from: '2018-04-01',
+            to: '2018-08-12',
+            data: [],
+        })
+
+        expect(totalDays).toBe(134)
+    })
+
+    it('should stay in sync with the number of cells computeCellPositions renders', () => {
+        const from = '2018-04-01'
+        const to = '2018-08-12'
+
+        const totalDays = computeTotalDays({ from, to, data: [] })
+        const days = computeCellPositions({
+            direction: 'horizontal',
+            colorScale: noop,
+            emptyColor: '#eeeeee',
+            from,
+            to,
+            data: [],
+            cellWidth: 10,
+            cellHeight: 10,
+            daySpacing: 2,
+            offset: 0,
+            firstWeekday: 'sunday',
+        })
+
+        // computeTotalDays pads the count with `startDate.getDay()` leading
+        // empty cells to align the first day under its weekday column, so it
+        // will be >= the actual number of days in range, never less.
+        expect(totalDays).toBeGreaterThanOrEqual(days.length)
+    })
+})


### PR DESCRIPTION
`from`/`to` strings like `2018-04-01` get parsed as UTC midnight, which lands on the wrong local day once the browser isn't in UTC — and `timeDays`' upper bound being exclusive compounds it. Together this makes `TimeRange` silently drop the first day west of UTC, or the last day everywhere else (a single-day range disappears entirely). You can see it live on the nivo docs' own `/time-range/` demo — hover the first cell and it shows the second day of the range instead of the first.

Fixes #2814 and #2333, which are really the same bug showing up on opposite ends depending on the viewer's timezone.

Parsing `from`/`to` the same local-time-safe way the `data` array is already parsed in `TimeRange.tsx`, and closing the exclusive bound on `timeDays`, fixes both. `computeTotalDays` gets the same date handling so the grid size stays in sync with the actual number of cells. Added tests for both directions plus the single-day edge case — verified they fail against the old code and pass with the fix, in UTC, GMT+7 and Pacific.