### PR TITLE
fix(boxplot): transition boxes correctly when switching layout

### DIFF
--- a/packages/boxplot/src/hooks.ts
+++ b/packages/boxplot/src/hooks.ts
@@ -244,6 +244,19 @@ export const useBoxPlot = <RawDatum extends BoxPlotDatum>({
     }
 }
 
+// Compute the SVG transform used to position (and orient) a box plot item.
+//
+// Both layouts intentionally emit a `translate(…) rotate(…)` transform with the
+// same structure so that react-spring can interpolate between them when the
+// `layout` changes: a vertical item uses `rotate(0)` (a no-op) while a
+// horizontal item uses `rotate(-90)`. Without a matching structure the spring
+// cannot interpolate the string and the item stays stuck in its previous
+// orientation. See https://github.com/plouc/nivo/issues/2561
+export const getBoxPlotItemTransform = (boxPlot: ComputedBoxPlotSummary): string =>
+    boxPlot.layout === 'vertical'
+        ? `translate(${boxPlot.x + boxPlot.width / 2}, ${boxPlot.coordinates.values[2]}) rotate(0)`
+        : `translate(${boxPlot.coordinates.values[2]}, ${boxPlot.y + boxPlot.height / 2}) rotate(-90)`
+
 export const useBoxPlotTransition = ({
     boxPlots,
     getBorderColor,
@@ -271,12 +284,7 @@ export const useBoxPlotTransition = ({
         valueDistance3: boxPlot.coordinates.values[3] - boxPlot.coordinates.values[2],
         valueDistance4: boxPlot.coordinates.values[4] - boxPlot.coordinates.values[2],
         // translate to the midpoint of the median line
-        transform:
-            boxPlot.layout === 'vertical'
-                ? `translate(${boxPlot.x + boxPlot.width / 2}, ${boxPlot.coordinates.values[2]})`
-                : `translate(${boxPlot.coordinates.values[2]}, ${
-                      boxPlot.y + boxPlot.height / 2
-                  }) rotate(-90)`,
+        transform: getBoxPlotItemTransform(boxPlot),
     })
 
     return useTransition<ComputedBoxPlotSummary, BoxPlotItemProps<BoxPlotDatum>['animatedProps']>(

--- a/packages/boxplot/tests/hooks.test.ts
+++ b/packages/boxplot/tests/hooks.test.ts
@@ -1,0 +1,28 @@
+import { getBoxPlotItemTransform } from '../src/hooks'
+import { ComputedBoxPlotSummary } from '../src/types'
+
+// Minimal computed summary exposing only the fields the transform depends on.
+const makeBox = (layout: 'vertical' | 'horizontal'): ComputedBoxPlotSummary =>
+    ({
+        layout,
+        x: 100,
+        y: 40,
+        width: 30,
+        height: 20,
+        coordinates: { index: 100, values: [0, 25, 50, 75, 100] },
+    }) as unknown as ComputedBoxPlotSummary
+
+describe('getBoxPlotItemTransform', () => {
+    // Regression test for #2561: switching layout left boxes stuck in their
+    // previous orientation. The animated `transform` must have a consistent
+    // structure across layouts, otherwise react-spring cannot interpolate
+    // between `translate(...)` and `translate(...) rotate(...)` on a layout
+    // change and the box keeps its stale transform.
+    it('emits a translate + rotate transform for both layouts so the spring can interpolate (#2561)', () => {
+        const vertical = getBoxPlotItemTransform(makeBox('vertical'))
+        const horizontal = getBoxPlotItemTransform(makeBox('horizontal'))
+
+        expect(vertical).toMatch(/^translate\([^)]*\) rotate\(0\)$/)
+        expect(horizontal).toMatch(/^translate\([^)]*\) rotate\(-90\)$/)
+    })
+})


### PR DESCRIPTION
## Closes #2561

### Problem
Switching a `BoxPlot` between `vertical` and `horizontal` layouts leaves the boxes stuck in their previous orientation (the axes update, the boxes don't).

### Root cause
In `useBoxPlotTransition`, the animated `transform` had a different structure per layout:
- vertical → `translate(x, y)`
- horizontal → `translate(x, y) rotate(-90)`

react-spring cannot interpolate between two structurally-different transform strings, so on a layout change the box holds its stale `transform`.

### Fix
Emit a structurally-consistent transform for both layouts — vertical now uses an explicit `rotate(0)` (a visual no-op) so react-spring can interpolate `translate(...) rotate(...)` → `translate(...) rotate(...)`. Extracted the logic into `getBoxPlotItemTransform` and added a regression test.

### Testing
- New unit test asserting both layouts emit a consistent `translate(...) rotate(...)`.
- Full `@nivo/boxplot` suite passes (26/26).