### PR TITLE
fix(geo): fix React unique-key warning in Choropleth legends

### DIFF
--- a/packages/geo/src/Choropleth.js
+++ b/packages/geo/src/Choropleth.js
@@ -138,17 +138,19 @@ const Choropleth = memo(props => {
                     )
                 }
                 if (layer === 'legends') {
-                    return legends.map((legend, i) => {
-                        return (
-                            <BoxLegendSvg
-                                key={i}
-                                containerWidth={width}
-                                containerHeight={height}
-                                data={legendData}
-                                {...legend}
-                            />
-                        )
-                    })
+                    return (
+                        <Fragment key="legends">
+                            {legends.map((legend, i) => (
+                                <BoxLegendSvg
+                                    key={i}
+                                    containerWidth={width}
+                                    containerHeight={height}
+                                    data={legendData}
+                                    {...legend}
+                                />
+                            ))}
+                        </Fragment>
+                    )
                 }
 
                 return <Fragment key={i}>{layer({})}</Fragment>

--- a/packages/geo/tests/Choropleth.test.js
+++ b/packages/geo/tests/Choropleth.test.js
@@ -1,4 +1,6 @@
+import { createElement } from 'react'
 import { mount } from 'enzyme'
+import { BoxLegendSvg } from '@nivo/legends'
 import Choropleth from '../src/Choropleth'
 
 const features = [
@@ -48,19 +50,19 @@ describe('Choropleth legends', () => {
         }
 
         const wrapper = mount(
-            <Choropleth
-                width={600}
-                height={400}
-                features={features}
-                data={data}
-                domain={[0, 100]}
-                legends={legends}
-            />
+            createElement(Choropleth, {
+                width: 600,
+                height: 400,
+                features,
+                data,
+                domain: [0, 100],
+                legends,
+            })
         )
         console.error = originalError
 
         // the legend is still rendered after wrapping the layer in a Fragment
-        expect(wrapper.find('BoxLegendSvg').length).toBe(1)
+        expect(wrapper.find(BoxLegendSvg).length).toBe(1)
 
         const keyWarning = calls.find(args => /unique "?key"?/i.test(String(args[0])))
         expect(keyWarning).toBeUndefined()

--- a/packages/geo/tests/Choropleth.test.js
+++ b/packages/geo/tests/Choropleth.test.js
@@ -1,0 +1,68 @@
+import { mount } from 'enzyme'
+import Choropleth from '../src/Choropleth'
+
+const features = [
+    {
+        type: 'Feature',
+        id: 'A',
+        properties: {},
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [0, 0],
+                    [0, 10],
+                    [10, 10],
+                    [10, 0],
+                    [0, 0],
+                ],
+            ],
+        },
+    },
+]
+const data = [{ id: 'A', value: 50 }]
+const legends = [
+    {
+        anchor: 'bottom-left',
+        direction: 'column',
+        translateX: 20,
+        translateY: -60,
+        itemsSpacing: 0,
+        itemWidth: 94,
+        itemHeight: 18,
+        itemDirection: 'left-to-right',
+        symbolSize: 18,
+    },
+]
+
+describe('Choropleth legends', () => {
+    // Regression guard for #2801: the `legends` layer returned a bare
+    // `legends.map(...)` array (unlike the `features`/`graticule` layers which
+    // return keyed elements), triggering a React "unique key" warning under
+    // React 19. It is now wrapped in a keyed `<Fragment>`.
+    it('renders legends without a React "key" warning (#2801)', () => {
+        const originalError = console.error
+        const calls = []
+        console.error = (...args) => {
+            calls.push(args)
+        }
+
+        const wrapper = mount(
+            <Choropleth
+                width={600}
+                height={400}
+                features={features}
+                data={data}
+                domain={[0, 100]}
+                legends={legends}
+            />
+        )
+        console.error = originalError
+
+        // the legend is still rendered after wrapping the layer in a Fragment
+        expect(wrapper.find('BoxLegendSvg').length).toBe(1)
+
+        const keyWarning = calls.find(args => /unique "?key"?/i.test(String(args[0])))
+        expect(keyWarning).toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Closes #2801

### Problem
`<ResponsiveChoropleth>` / `<Choropleth>` with a `legends` prop logs a React "Each child in a list should have a unique key prop" warning (reported under React 19). The stack trace points at the nested `Array.map` calls in `Choropleth`.

### Root cause
In `Choropleth`, `layers.map(...)` renders each layer. The `features` and `graticule` layers return keyed elements (`<Fragment key="features">`, `<GeoGraticule key="graticule">`), but the `legends` layer returned a bare `legends.map(...)` array with no keyed wrapper — so it's the odd one out.

### Fix
Wrap the `legends` layer in a keyed `<Fragment key="legends">`, exactly like the `features` layer. Rendered output is unchanged; the key warning is resolved.

### Testing
Added `packages/geo/tests/Choropleth.test.js`, which renders a Choropleth with a legend and asserts the legend renders and no React key warning is logged.